### PR TITLE
Creating build folder in Web Plugin folder to avoid error in Windows

### DIFF
--- a/webplugin/build/test.txt
+++ b/webplugin/build/test.txt
@@ -1,0 +1,1 @@
+Test file please remove it


### PR DESCRIPTION
### Incase you fixed a bug then please describe the root cause of it? 
-> In Windows machine if someone freshly clones the repo and try to run the server using `node app` then node throws the following error **`UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory`**. This error arises because the project is unable to create a `build` folder in the `webplugin` directory. To avoid this error we can create an empty build folder in the `webplugin` directory. And we've already added the `build` folder exception in the `.gitignore` file.

NOTE: Make sure you're comparing your branch with the correct base branch