### PR TITLE
[WIP] CO-513 Cookies and SessionStorage Error Fix [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 .DS_Store
 webplugin/build/*.*
 webplugin/css/app/bin/
+webplugin/build/test.txt

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -209,21 +209,27 @@ KommunicateUtils = {
         return text;
     },
     getDataFromKmSession: function (key) {
-        var session = sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
-        return session ? JSON.parse(session)[key] : "";
+        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+            var session = sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
+            return session ? JSON.parse(session)[key] : "";  
+        }
     },
     storeDataIntoKmSession: function (key, data) {
-        var session = sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
-        session = session ? JSON.parse(session) : {};
-        session[key] = data;
-        sessionStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+            var session = (typeof sessionStorage !== 'undefined') && sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
+            session = session ? JSON.parse(session) : {};
+            session[key] = data;
+            (typeof sessionStorage !== 'undefined') && sessionStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        }
 
     },
     deleteDataFromKmSession : function (key) {
-        var session = sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
-        session = session ? JSON.parse(session) : {};
-        delete session[key];
-        sessionStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+            var session = (typeof sessionStorage !== 'undefined') && sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
+            session = session ? JSON.parse(session) : {};
+            delete session[key];
+            (typeof sessionStorage !== 'undefined') && sessionStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        }
     },
     triggerCustomEvent: function(eventName, options, kmPluginVersion) {
 
@@ -254,20 +260,26 @@ KommunicateUtils = {
         return key&&settings?settings[key]:(settings?settings:"");
     },
     getItemFromLocalStorage: function(key) {
-        var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
-        return session ? JSON.parse(session)[key] : "";
+        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+            var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
+            return session ? JSON.parse(session)[key] : "";
+        } 
     },
     removeItemFromLocalStorage: function(key) {
-        var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
-        session = session ? JSON.parse(session) : {};
-        delete session[key];
-        localStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+            var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
+            session = session ? JSON.parse(session) : {};
+            delete session[key];
+            localStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        }
     },
     setItemToLocalStorage: function(key,data) {
-        var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
-        session = session ? JSON.parse(session) : {};
-        session[key] = data;
-        localStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+            var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
+            session = session ? JSON.parse(session) : {};
+            session[key] = data;
+            localStorage.setItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY, JSON.stringify(session));
+        }
     },
     getDomainFromUrl: function (hostName) {
         hostName = hostName || parent.window.location.hostname;
@@ -321,5 +333,12 @@ KommunicateUtils = {
     isActiveConversationNeedsToBeOpened : function(activeConversationInfo, data) {
         var userId = KommunicateUtils.getCookie(KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID);
         return (activeConversationInfo && typeof data != "undefined" && (data.appId == activeConversationInfo.appId && userId == activeConversationInfo.userId ));
+    },
+    checkIsSessionStorageAvailable: function() {
+        try {
+            return typeof (w.sessionStorage) !== "undefined"
+        } catch (e) {
+            return false
+        }
     }
 }

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -209,13 +209,13 @@ KommunicateUtils = {
         return text;
     },
     getDataFromKmSession: function (key) {
-        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+        if(KommunicateUtils.isSessionStorageAvailable()) {
             var session = sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
             return session ? JSON.parse(session)[key] : "";  
         }
     },
     storeDataIntoKmSession: function (key, data) {
-        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+        if(KommunicateUtils.isSessionStorageAvailable()) {
             var session = (typeof sessionStorage !== 'undefined') && sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
             session = session ? JSON.parse(session) : {};
             session[key] = data;
@@ -224,7 +224,7 @@ KommunicateUtils = {
 
     },
     deleteDataFromKmSession : function (key) {
-        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+        if(KommunicateUtils.isSessionStorageAvailable()) {
             var session = (typeof sessionStorage !== 'undefined') && sessionStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
             session = session ? JSON.parse(session) : {};
             delete session[key];
@@ -260,13 +260,13 @@ KommunicateUtils = {
         return key&&settings?settings[key]:(settings?settings:"");
     },
     getItemFromLocalStorage: function(key) {
-        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+        if(KommunicateUtils.isSessionStorageAvailable()) {
             var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
             return session ? JSON.parse(session)[key] : "";
         } 
     },
     removeItemFromLocalStorage: function(key) {
-        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+        if(KommunicateUtils.isSessionStorageAvailable()) {
             var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
             session = session ? JSON.parse(session) : {};
             delete session[key];
@@ -274,7 +274,7 @@ KommunicateUtils = {
         }
     },
     setItemToLocalStorage: function(key,data) {
-        if(KommunicateUtils.checkIsSessionStorageAvailable()) {
+        if(KommunicateUtils.isSessionStorageAvailable()) {
             var session = localStorage.getItem(KommunicateConstants.KOMMUNICATE_SESSION_KEY);
             session = session ? JSON.parse(session) : {};
             session[key] = data;
@@ -334,7 +334,7 @@ KommunicateUtils = {
         var userId = KommunicateUtils.getCookie(KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID);
         return (activeConversationInfo && typeof data != "undefined" && (data.appId == activeConversationInfo.appId && userId == activeConversationInfo.userId ));
     },
-    checkIsSessionStorageAvailable: function() {
+    isSessionStorageAvailable: function() {
         try {
             return typeof (w.sessionStorage) !== "undefined"
         } catch (e) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3607,7 +3607,7 @@ var CURRENT_GROUP_DATA={};
                             var conversationAssigneeDetails = data.userDetails.filter(function (item) {
                                 return item.userId == conversationAssignee;
                             })[0];
-                            var userSession = JSON.parse(sessionStorage.kommunicate);
+                            var userSession = (KommunicateUtils.checkIsSessionStorageAvailable()) ? JSON.parse(sessionStorage.kommunicate) : {};
                             var languageCode = userSession && userSession.settings && userSession.settings.KM_CHAT_CONTEXT && userSession.settings.KM_CHAT_CONTEXT.kmUserLanguageCode;
                             if(conversationAssigneeDetails && conversationAssigneeDetails.roleType !== KommunicateConstants.APPLOZIC_USER_ROLE_TYPE.BOT){
                                 Kommunicate.getAwayMessage({

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3607,7 +3607,7 @@ var CURRENT_GROUP_DATA={};
                             var conversationAssigneeDetails = data.userDetails.filter(function (item) {
                                 return item.userId == conversationAssignee;
                             })[0];
-                            var userSession = (KommunicateUtils.checkIsSessionStorageAvailable()) ? JSON.parse(sessionStorage.kommunicate) : {};
+                            var userSession = (KommunicateUtils.isSessionStorageAvailable()) ? JSON.parse(sessionStorage.kommunicate) : {};
                             var languageCode = userSession && userSession.settings && userSession.settings.KM_CHAT_CONTEXT && userSession.settings.KM_CHAT_CONTEXT.kmUserLanguageCode;
                             if(conversationAssigneeDetails && conversationAssigneeDetails.roleType !== KommunicateConstants.APPLOZIC_USER_ROLE_TYPE.BOT){
                                 Kommunicate.getAwayMessage({


### PR DESCRIPTION
### What do you want to achieve?
-> Fix `Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.` error when cookies are disabled.

### How was the code tested?
1. Disable Cookies in the browser and load sidebox script.
2. Sidebox will load with no error in console.
3. A conversation will be created automatically on click of chat launcher and messages will be sent and received smoothly.

### What new thing you came across while writing this code? 
-> Type of `undefined` will not work in case of `sessionStorage` and `localStorage` if Cookies are disabled.

### In case you fixed a bug then please describe the root cause of it? 
-> If cookies are blocked in the browser then our sidebox widget will not load as it is dependent on both Session Storage and Local Storage of the browse. And if cookies are disabled then both Session Storage and Local Storage will be inaccessible by the window object. 

## This PR is marked as WIP because it is dependent on `applozic.chat.min.js` file and we are using `sessionStorage` checks in that file as well. So @ab14bhardwaj merge this PR after you release the new version of `applozic.chat.min.js` file with the necessary fixes for `sessionStorage` checks.

NOTE: Make sure you're comparing your branch with the correct base branch