### PR TITLE
CO-272 New message indicator in document's title

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -1366,7 +1366,8 @@
 	right: 0;
 	bottom: 0px;
 	left: 0;
-	overflow: visible;
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
 }
 #mck-contacts-content{
 	position: absolute;

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -112,5 +112,6 @@ Kommunicate.defaultLabels = {
         'CONVERSATION_REVIEW_PLACEHOLDER' : 'Add a comment…',
         'OTHER_QUERIES' : 'If you have any other queries, just',
         'RESTART_CONVERSATION' : 'restart this conversation',
-    } 
+    },
+    'page.title.on.new.message': 'New message from '
 }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -395,6 +395,8 @@ var CURRENT_GROUP_DATA={};
         var MCK_TRIGGER_MSG_NOTIFICATION_TIMEOUT = (typeof appOptions.msgTriggerTimeout === "number") ? appOptions.msgTriggerTimeout : 0;
         MCK_MAINTAIN_ACTIVE_CONVERSATION_STATE = (typeof appOptions.automaticChatOpenOnNavigation === "boolean") ? appOptions.automaticChatOpenOnNavigation : false;
         var MCK_ATTACHMENT = (typeof appOptions.attachment === "boolean") ? appOptions.attachment : true;
+        var CURRENT_PAGE_TITLE = parent.document.title;
+        var FLASH_PAGE_TITLE;
         var TAB_FILE_DRAFT = new Object();
         var MCK_GROUP_ARRAY = new Array();
         var MCK_CONTACT_ARRAY = new Array();
@@ -2033,6 +2035,8 @@ var CURRENT_GROUP_DATA={};
                             mckInitializeChannel.checkConnected(true);
                         }
                         _this.stopIdleTimeCounter();
+                        clearInterval(FLASH_PAGE_TITLE);
+                        parent.document.title = CURRENT_PAGE_TITLE;
                     } else {
                         if (MCK_TYPING_STATUS === 1) {
                             mckInitializeChannel.sendTypingStatus(0);
@@ -8606,6 +8610,13 @@ var CURRENT_GROUP_DATA={};
                             iconLink = imgsrc;
                         }
                     }
+                    FLASH_PAGE_TITLE = setInterval(function() {
+                        if(parent.document.title === CURRENT_PAGE_TITLE) {
+                            parent.document.title = MCK_LABELS['page.title.on.new.message'] + displayName;
+                        } else {
+                            parent.document.title = CURRENT_PAGE_TITLE;
+                        }
+                    }, 1000);
                     if(notificationsound){
                     	mckNotificationUtils.sendDesktopNotification(displayName, iconLink, msg, notificationsound);
                     }else{

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -121,7 +121,7 @@ function addKommunicatePluginToIframe() {
     addableWindow.MCK_ONINIT = options.onInit;
   }
   addableWindow.addEventListener('error', function (e) {
-    let sentryConfig = MCK_THIRD_PARTY_INTEGRATION.sentry.plugin;
+    var sentryConfig = MCK_THIRD_PARTY_INTEGRATION.sentry.plugin;
     sentryConfig.enable && typeof Sentry != "undefined" && Sentry.withScope(function (scope) {
       scope.setTag("applicationId", options.appId);
       scope.setTag("userId", options.userId);

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -121,7 +121,7 @@ function addKommunicatePluginToIframe() {
     addableWindow.MCK_ONINIT = options.onInit;
   }
   addableWindow.addEventListener('error', function (e) {
-    var sentryConfig = MCK_THIRD_PARTY_INTEGRATION.sentry.plugin;
+    let sentryConfig = MCK_THIRD_PARTY_INTEGRATION.sentry.plugin;
     sentryConfig.enable && typeof Sentry != "undefined" && Sentry.withScope(function (scope) {
       scope.setTag("applicationId", options.appId);
       scope.setTag("userId", options.userId);


### PR DESCRIPTION
### What do you want to achieve?
-> Whenever the current browser tab in which the script is running, is not in focus and a new message arrives then the current browser tab's title will say **`New message from <Sender Name>`**.

### How was the code tested?
-> By setting `messageTriggerTimeout` in `appOptions` and switching to different tab after reloading the tab with the script running.
-> By sending the message from the dashboard when the current tab is not in focus and widget is closed.

### What new thing you came across while writing this code? 
-> https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API

### In case you fixed a bug then please describe the root cause of it? 
-> Fixed an issue where the chats not auto-scrolling when a new message arrives or when the user sends a message. This issue is already fixed and merged in release branch by @akshatdhabi but was not merged in master.

NOTE: Make sure you're comparing your branch with the correct base branch