### PR TITLE
CO-567 Session timeout for chat widget.

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -341,12 +341,12 @@ function ApplozicSidebox() {
             options.metadata = typeof options.metadata=='object'?options.metadata: {};
             KommunicateUtils.deleteDataFromKmSession("settings");
 
-            if(widgetSettings && widgetSettings.sessionTimeout){
+            if(widgetSettings && widgetSettings.sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)){
                 logoutAfterSessionExpiry(widgetSettings);
                 var details = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId) || {};
                 !details.sessionStartTime && (details.sessionStartTime = new Date().getTime());
                 details.sessionTimeout = data.widgetTheme.sessionTimeout;
-                data.widgetTheme && data.widgetTheme.sessionTimeout && KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);
+                data.widgetTheme && data.widgetTheme.sessionTimeout != null && KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);
             }
 
             if (applozic.PRODUCT_ID == 'kommunicate') {
@@ -446,7 +446,7 @@ function ApplozicSidebox() {
         var widgetSettings, timeStampDifference;
         applozic._globals.appId && (widgetSettings = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId));
         var timeStampDifference = widgetSettings && (widgetSettings.sessionEndTime - widgetSettings.sessionStartTime);
-        if (widgetSettings && settings && settings.sessionTimeout && timeStampDifference > settings.sessionTimeout) {
+        if (widgetSettings && settings && settings.sessionTimeout != null && timeStampDifference > settings.sessionTimeout) {
             KommunicateUtils.deleteUserCookiesOnLogout();
         };
         window.addEventListener('beforeunload', (event) => {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Chat widget should start using new userId after a certain amount of session timeout.

### How was the code tested?
<!-- Be as specific as possible. -->
Step-1 Performed fresh login using Kommunicate install script.
Step-2 Refresh the page it will open same chat thread until the session timeout limit reaches.
Step-3 Once the session timeout limit reaches it will start the widget using new userId.

NOTE: Make sure you're comparing your branch with the correct base branch