### PR TITLE
C-SAT bug fix, support for sessionTimeout via appOptions and replaced Jquery with JS.

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -130,7 +130,7 @@ function ApplozicSidebox() {
                 if (this.readyState == 4 && this.status == 200) {
                     var body = document.getElementsByTagName('body')[0];
                     body.innerHTML = this.responseText;
-                    var scriptContent = addScriptInstideHtml();
+                    var scriptContent = addScriptInsideHtml();
                     body.appendChild(scriptContent);
                     mckInitPluginScript();
                 }
@@ -145,7 +145,7 @@ function ApplozicSidebox() {
             return false;
         }
     };
-    function addScriptInstideHtml() {
+    function addScriptInsideHtml() {
         var script =  
         "function showAfterLoad(){"+
             "var mckSidebox = document.getElementById(\"mck-sidebox\");"+

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -143,6 +143,7 @@ function ApplozicSidebox() {
             return false;
         }
     };
+            "var isScriptV2 = !!parent.document.getElementById('kommunicate-widget-iframe');"+
     function mckLoadStyle(url) {
         var head = document.getElementsByTagName('head')[0];
         var style = document.createElement('link');

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -130,6 +130,8 @@ function ApplozicSidebox() {
                 if (this.readyState == 4 && this.status == 200) {
                     var body = document.getElementsByTagName('body')[0];
                     body.innerHTML = this.responseText;
+                    var scriptContent = addScriptInstideHtml();
+                    body.appendChild(scriptContent);
                     mckInitPluginScript();
                 }
             };
@@ -143,7 +145,35 @@ function ApplozicSidebox() {
             return false;
         }
     };
+    function addScriptInstideHtml() {
+        var script =  
+        "function showAfterLoad(){"+
+            "var mckSidebox = document.getElementById(\"mck-sidebox\");"+
+            "mckSidebox.style.visibility='visible';"+
+            "var mckLocBox = document.getElementById(\"mck-loc-box\");"+
+            "mckLocBox.style.visibility='visible';"+
+            "var mckGmSearchBox = document.getElementById(\"mck-gm-search-box\");"+
+            "mckGmSearchBox.style.visibility='visible';"+
+        "};"+
+        "if (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0) {"+
+            "showAfterLoad();"+
+        "} else {"+
             "var isScriptV2 = !!parent.document.getElementById('kommunicate-widget-iframe');"+
+            "if (isScriptV2) {"+
+                "window.parent.document.addEventListener('kmInitilized', function () {"+
+                    "showAfterLoad();"+
+                "}, false);"+
+            "} else {"+
+                "window.addEventListener('kmInitilized', function () {"+
+                    "showAfterLoad();"+
+                "}, false);"+
+            "}"+
+        "}";
+
+        var tag = document.createElement('script');
+        tag.innerHTML = script;
+        return tag;
+    };
     function mckLoadStyle(url) {
         var head = document.getElementsByTagName('head')[0];
         var style = document.createElement('link');

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -146,30 +146,33 @@ function ApplozicSidebox() {
         }
     };
     function addScriptInsideHtml() {
-        var script =  
-        "function showAfterLoad(){"+
-            "var mckSidebox = document.getElementById(\"mck-sidebox\");"+
-            "mckSidebox.style.visibility='visible';"+
-            "var mckLocBox = document.getElementById(\"mck-loc-box\");"+
-            "mckLocBox.style.visibility='visible';"+
-            "var mckGmSearchBox = document.getElementById(\"mck-gm-search-box\");"+
-            "mckGmSearchBox.style.visibility='visible';"+
-        "};"+
-        "if (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0) {"+
-            "showAfterLoad();"+
-        "} else {"+
-            "var isScriptV2 = !!parent.document.getElementById('kommunicate-widget-iframe');"+
-            "if (isScriptV2) {"+
-                "window.parent.document.addEventListener('kmInitilized', function () {"+
-                    "showAfterLoad();"+
-                "}, false);"+
-            "} else {"+
-                "window.addEventListener('kmInitilized', function () {"+
-                    "showAfterLoad();"+
-                "}, false);"+
-            "}"+
-        "}";
+        var scriptData = function detectBrowserAndMakeUiVisible() {
+            function showAfterLoad() {
+                var mckSidebox = document.getElementById("mck-sidebox");
+                mckSidebox.style.visibility = 'visible';
+                var mckLocBox = document.getElementById("mck-loc-box");
+                mckLocBox.style.visibility = 'visible';
+                var mckGmSearchBox = document.getElementById("mck-gm-search-box");
+                mckGmSearchBox.style.visibility = 'visible';
+            };
+            if (navigator.userAgent.indexOf('MSIE') !== -1 ||
+                navigator.appVersion.indexOf('Trident/') > 0) {
+                showAfterLoad;
+            } else {
+                var isScriptV2 = !!parent.document.getElementById('kommunicate-widget-iframe');
+                if (isScriptV2) {
+                    window.parent.document.addEventListener('kmInitilized', function () {
+                        showAfterLoad();
+                    }, false);
+                } else {
+                    window.addEventListener('kmInitilized', function () {
+                        showAfterLoad();
+                    }, false);
+                }
+            };
+        };
 
+        var script = String(scriptData) + "detectBrowserAndMakeUiVisible();"
         var tag = document.createElement('script');
         tag.innerHTML = script;
         return tag;

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -53,9 +53,6 @@ function ApplozicSidebox() {
     var mck_script_loader2 = [ {
             "name": "locationpicker", "url": MCK_STATICPATH + "/lib/js/locationpicker.jquery.min.js"
     } ];
-   var mck_videocall = [ {
-          "name": "video_twilio", "url": MCK_STATICPATH + "/js/app/twilio-video.js"
-    } ];
     this.load = function() {
         try {
             for (var index in mck_external_scripts) {
@@ -124,16 +121,22 @@ function ApplozicSidebox() {
             }
         }
         try {
-            $.each(mck_style_loader, function(i, data) {
-                mckLoadStyle(data.url);
-            });
-            $.ajax({
-                    url: MCK_SIDEBOX_HTML, crossDomain: true, success: function(data) {
-                        data = data.replace(/MCK_STATICPATH/g, MCK_STATICPATH);
-                        $("body").append(data);
-                        mckInitPluginScript();
-                    }
-            });
+            for (var index in mck_style_loader) {
+                mck_style_loader[index] && mckLoadStyle(mck_style_loader[index].url);
+            }
+            var url = MCK_SIDEBOX_HTML;
+            var xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function () {
+                if (this.readyState == 4 && this.status == 200) {
+                    // var data = JSON.parse(this.responseText);
+                    var body = document.getElementsByTagName('body')[0];
+                    body.innerHTML = this.responseText;
+                    mckInitPluginScript();
+                    // mckInitSidebox(data.response, userId);
+                }
+            };
+            xhr.open("GET", url, true);
+            xhr.send(null);
         } catch (e) {
             console.log("Plugin loading error. Refresh page.", e);
             if (typeof MCK_ONINIT === 'function') {
@@ -196,7 +199,8 @@ function ApplozicSidebox() {
                 }
                     applozic._globals.googleApiKey= (applozic._globals.googleApiKey)?applozic._globals.googleApiKey :"AIzaSyCrBIGg8X4OnG4raKqqIC3tpSIPWE-bhwI";
        	    }
-            $.each(mck_script_loader1, function(i, data) {
+            for (var index in mck_script_loader1) {
+                var data = mck_script_loader1[index];
                 if (data.name === "km-utils") {
                     try {
                        var options = applozic._globals;
@@ -230,12 +234,7 @@ function ApplozicSidebox() {
                 else {
                     mckLoadScript(data.url);    
                 }
-            });
-             if (typeof applozic._globals !== 'undefined'&& applozic._globals.video === true) {
-                          $.each(mck_videocall, function(i, data) {
-                          mckLoadScript(data.url);
-                 });
-               }
+            };
         } catch (e) {
             console.log("Plugin loading error. Refresh page.");
             console.log(e);
@@ -247,11 +246,12 @@ function ApplozicSidebox() {
     };
     function mckLoadScript2() {
         try {
-            $.each(mck_script_loader2, function(i, data) {
+            for (var index in mck_script_loader2) {
+                var data = mck_script_loader1[index];
                 if (data.name === "locationpicker") {
                     mckLoadScript(data.url, mckLoadAppScript);
                 }
-            });
+            };
         } catch (e) {
             console.log("Plugin loading error. Refresh page.");
             if (typeof MCK_ONINIT === 'function') {
@@ -332,6 +332,8 @@ function ApplozicSidebox() {
         try {
             var options = applozic._globals;
             var widgetSettings = data.chatWidget || data.widgetTheme;
+            var sessionTimeout = options.sessionTimeout;
+            sessionTimeout == null && (sessionTimeout = widgetSettings && widgetSettings.sessionTimeout);
             options["agentId"]= data.agentId;
             options["agentName"]=data.agentName;
             options["widgetSettings"] = widgetSettings;
@@ -341,12 +343,12 @@ function ApplozicSidebox() {
             options.metadata = typeof options.metadata=='object'?options.metadata: {};
             KommunicateUtils.deleteDataFromKmSession("settings");
 
-            if(widgetSettings && widgetSettings.sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)){
-                logoutAfterSessionExpiry(widgetSettings);
+            if(sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)){
+                logoutAfterSessionExpiry(sessionTimeout);
                 var details = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId) || {};
                 !details.sessionStartTime && (details.sessionStartTime = new Date().getTime());
-                details.sessionTimeout = data.widgetTheme.sessionTimeout;
-                data.widgetTheme && data.widgetTheme.sessionTimeout != null && KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);
+                details.sessionTimeout = sessionTimeout;
+                KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);
             }
 
             if (applozic.PRODUCT_ID == 'kommunicate') {
@@ -402,18 +404,16 @@ function ApplozicSidebox() {
         var data = {};
         data.appId = applozic._globals.appId;
         // NOTE: Don't pass applozic._globals as it is in data field of ajax call, pass only the fields which are required for this API call.
-        $applozic.ajax({
-            url: KM_PLUGIN_SETTINGS.kommunicateApiUrl + "/users/v2/chat/plugin/settings",
-            method: 'GET',
-            data: data,
-            success: function (data) {
+        var url = KM_PLUGIN_SETTINGS.kommunicateApiUrl + "/users/v2/chat/plugin/settings?appId=" + applozic._globals.appId;
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function () {
+            if (this.readyState == 4 && this.status == 200) {
+                var data = JSON.parse(this.responseText);
                 mckInitSidebox(data.response, userId);
-            },
-            error: function (error) {
-                console.log(error);
             }
-
-        })
+        };
+        xhr.open("GET", url, true);
+        xhr.send(data);
     };
     function loadErrorTracking(userId) {
         userId = KommunicateUtils.getCookie(KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID) || userId;
@@ -442,11 +442,11 @@ function ApplozicSidebox() {
         }
     };
     
-    function logoutAfterSessionExpiry(settings) {
+    function logoutAfterSessionExpiry(sessionTimeout) {
         var widgetSettings, timeStampDifference;
         applozic._globals.appId && (widgetSettings = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId));
         var timeStampDifference = widgetSettings && (widgetSettings.sessionEndTime - widgetSettings.sessionStartTime);
-        if (widgetSettings && settings && settings.sessionTimeout != null && timeStampDifference > settings.sessionTimeout) {
+        if (widgetSettings && sessionTimeout != null && timeStampDifference > sessionTimeout) {
             KommunicateUtils.deleteUserCookiesOnLogout();
             sessionStorage.removeItem("kommunicate");
             ALStorage.clearSessionStorageElements();

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -53,9 +53,6 @@ function ApplozicSidebox() {
     var mck_script_loader2 = [ {
             "name": "locationpicker", "url": MCK_STATICPATH + "/lib/js/locationpicker.jquery.min.js"
     } ];
-   var mck_videocall = [ {
-          "name": "video_twilio", "url": MCK_STATICPATH + "/js/app/twilio-video.js"
-    } ];
     this.load = function() {
         try {
             for (var index in mck_external_scripts) {
@@ -124,16 +121,20 @@ function ApplozicSidebox() {
             }
         }
         try {
-            $.each(mck_style_loader, function(i, data) {
-                mckLoadStyle(data.url);
-            });
-            $.ajax({
-                    url: MCK_SIDEBOX_HTML, crossDomain: true, success: function(data) {
-                        data = data.replace(/MCK_STATICPATH/g, MCK_STATICPATH);
-                        $("body").append(data);
-                        mckInitPluginScript();
-                    }
-            });
+            for (var index in mck_style_loader) {
+                mck_style_loader[index] && mckLoadStyle(mck_style_loader[index].url);
+            }
+            var url = MCK_SIDEBOX_HTML;
+            var xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function () {
+                if (this.readyState == 4 && this.status == 200) {
+                    var body = document.getElementsByTagName('body')[0];
+                    body.innerHTML = this.responseText;
+                    mckInitPluginScript();
+                }
+            };
+            xhr.open("GET", url, true);
+            xhr.send(null);
         } catch (e) {
             console.log("Plugin loading error. Refresh page.", e);
             if (typeof MCK_ONINIT === 'function') {
@@ -196,7 +197,8 @@ function ApplozicSidebox() {
                 }
                     applozic._globals.googleApiKey= (applozic._globals.googleApiKey)?applozic._globals.googleApiKey :"AIzaSyCrBIGg8X4OnG4raKqqIC3tpSIPWE-bhwI";
        	    }
-            $.each(mck_script_loader1, function(i, data) {
+            for (var index in mck_script_loader1) {
+                var data = mck_script_loader1[index];
                 if (data.name === "km-utils") {
                     try {
                        var options = applozic._globals;
@@ -230,12 +232,7 @@ function ApplozicSidebox() {
                 else {
                     mckLoadScript(data.url);    
                 }
-            });
-             if (typeof applozic._globals !== 'undefined'&& applozic._globals.video === true) {
-                          $.each(mck_videocall, function(i, data) {
-                          mckLoadScript(data.url);
-                 });
-               }
+            };
         } catch (e) {
             console.log("Plugin loading error. Refresh page.");
             console.log(e);
@@ -247,11 +244,12 @@ function ApplozicSidebox() {
     };
     function mckLoadScript2() {
         try {
-            $.each(mck_script_loader2, function(i, data) {
+            for (var index in mck_script_loader2) {
+                var data = mck_script_loader1[index];
                 if (data.name === "locationpicker") {
                     mckLoadScript(data.url, mckLoadAppScript);
                 }
-            });
+            };
         } catch (e) {
             console.log("Plugin loading error. Refresh page.");
             if (typeof MCK_ONINIT === 'function') {
@@ -332,6 +330,8 @@ function ApplozicSidebox() {
         try {
             var options = applozic._globals;
             var widgetSettings = data.chatWidget || data.widgetTheme;
+            var sessionTimeout = options.sessionTimeout;
+            sessionTimeout == null && (sessionTimeout = widgetSettings && widgetSettings.sessionTimeout);
             options["agentId"]= data.agentId;
             options["agentName"]=data.agentName;
             options["widgetSettings"] = widgetSettings;
@@ -341,12 +341,12 @@ function ApplozicSidebox() {
             options.metadata = typeof options.metadata=='object'?options.metadata: {};
             KommunicateUtils.deleteDataFromKmSession("settings");
 
-            if(widgetSettings && widgetSettings.sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)){
-                logoutAfterSessionExpiry(widgetSettings);
+            if(sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)){
+                logoutAfterSessionExpiry(sessionTimeout);
                 var details = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId) || {};
                 !details.sessionStartTime && (details.sessionStartTime = new Date().getTime());
-                details.sessionTimeout = data.widgetTheme.sessionTimeout;
-                data.widgetTheme && data.widgetTheme.sessionTimeout != null && KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);
+                details.sessionTimeout = sessionTimeout;
+                KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);
             }
 
             if (applozic.PRODUCT_ID == 'kommunicate') {
@@ -402,18 +402,16 @@ function ApplozicSidebox() {
         var data = {};
         data.appId = applozic._globals.appId;
         // NOTE: Don't pass applozic._globals as it is in data field of ajax call, pass only the fields which are required for this API call.
-        $applozic.ajax({
-            url: KM_PLUGIN_SETTINGS.kommunicateApiUrl + "/users/v2/chat/plugin/settings",
-            method: 'GET',
-            data: data,
-            success: function (data) {
+        var url = KM_PLUGIN_SETTINGS.kommunicateApiUrl + "/users/v2/chat/plugin/settings?appId=" + applozic._globals.appId;
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function () {
+            if (this.readyState == 4 && this.status == 200) {
+                var data = JSON.parse(this.responseText);
                 mckInitSidebox(data.response, userId);
-            },
-            error: function (error) {
-                console.log(error);
             }
-
-        })
+        };
+        xhr.open("GET", url, true);
+        xhr.send(data);
     };
     function loadErrorTracking(userId) {
         userId = KommunicateUtils.getCookie(KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID) || userId;
@@ -442,11 +440,11 @@ function ApplozicSidebox() {
         }
     };
     
-    function logoutAfterSessionExpiry(settings) {
+    function logoutAfterSessionExpiry(sessionTimeout) {
         var widgetSettings, timeStampDifference;
         applozic._globals.appId && (widgetSettings = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId));
         var timeStampDifference = widgetSettings && (widgetSettings.sessionEndTime - widgetSettings.sessionStartTime);
-        if (widgetSettings && settings && settings.sessionTimeout != null && timeStampDifference > settings.sessionTimeout) {
+        if (widgetSettings && sessionTimeout != null && timeStampDifference > sessionTimeout) {
             KommunicateUtils.deleteUserCookiesOnLogout();
             sessionStorage.removeItem("kommunicate");
             ALStorage.clearSessionStorageElements();

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -157,7 +157,7 @@ function ApplozicSidebox() {
             };
             if (navigator.userAgent.indexOf('MSIE') !== -1 ||
                 navigator.appVersion.indexOf('Trident/') > 0) {
-                showAfterLoad;
+                showAfterLoad();
             } else {
                 var isScriptV2 = !!parent.document.getElementById('kommunicate-widget-iframe');
                 if (isScriptV2) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -295,7 +295,6 @@ var CURRENT_GROUP_DATA={};
         var PRE_CHAT_LEAD_COLLECTION_POPUP_ON = true;
         var MCK_TOKEN;
         var AUTH_CODE;
-        var ACTIVE_TAB_ID = '';
         MCK_GROUP_MAP = [];
         var FILE_META = [];
         var USER_DEVICE_KEY;
@@ -758,7 +757,6 @@ var CURRENT_GROUP_DATA={};
             ALStorage.clearSessionStorageElements();
             MCK_TOKEN = '';
             AUTH_CODE = '';
-            ACTIVE_TAB_ID = '';
             FILE_META = [];
             MCK_GROUP_MAP = [];
             IS_LOGGED_IN = true;
@@ -4468,7 +4466,6 @@ var CURRENT_GROUP_DATA={};
                 clearTimeout(MCK_TRIGGER_MSG_NOTIFICATION_PARAM);
                 MCK_MAINTAIN_ACTIVE_CONVERSATION_STATE && params.isGroup && params.tabId && KommunicateUtils.setItemToLocalStorage("mckActiveConversationInfo",{groupId:params.tabId, "appId":appOptions.appId, "userId":userId});
                 var currTabId = $mck_msg_inner.data('mck-id');
-                ACTIVE_TAB_ID = params.tabId || currTabId;
                 if (currTabId) {
                     if ($mck_text_box.html().length > 1 || $mck_file_box.hasClass('vis')) {
                         var text = $mck_text_box.html();
@@ -9387,14 +9384,13 @@ var CURRENT_GROUP_DATA={};
                                 'messageKey': message.key
                             });
                         } else if (messageType === "APPLOZIC_01" || messageType === "APPLOZIC_02" || messageType === "MESSAGE_RECEIVED") {
-                            if (kommunicateCommons.isObject(resp.message) && resp.message.groupId && resp.message.groupId == ACTIVE_TAB_ID && resp.message.metadata && resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS) {
-                                console.log(resp.message);                      
-                                KommunicateUI.showClosedConversationBanner(true);
-                            }
                             ALStorage.updateLatestMessage(message);
                             var contact = (message.groupId) ? mckGroupUtils.getGroup(message.groupId) : mckMessageLayout.getContact(message.to);
                                 var $mck_sidebox_content = $applozic("#mck-sidebox-content");
                                 var tabId = $mck_message_inner.data('mck-id');
+                                if (kommunicateCommons.isObject(resp.message) && resp.message.groupId && resp.message.groupId == tabId && resp.message.metadata && resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS) {
+                                    KommunicateUI.showClosedConversationBanner(true);
+                                };
                                 if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
                                     var messageFeed = mckMessageLayout.getMessageFeed(message);
                                     events.onMessageReceived({

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -295,6 +295,7 @@ var CURRENT_GROUP_DATA={};
         var PRE_CHAT_LEAD_COLLECTION_POPUP_ON = true;
         var MCK_TOKEN;
         var AUTH_CODE;
+        var ACTIVE_TAB_ID = '';
         MCK_GROUP_MAP = [];
         var FILE_META = [];
         var USER_DEVICE_KEY;
@@ -757,6 +758,7 @@ var CURRENT_GROUP_DATA={};
             ALStorage.clearSessionStorageElements();
             MCK_TOKEN = '';
             AUTH_CODE = '';
+            ACTIVE_TAB_ID = '';
             FILE_META = [];
             MCK_GROUP_MAP = [];
             IS_LOGGED_IN = true;
@@ -1855,7 +1857,7 @@ var CURRENT_GROUP_DATA={};
                         _this.sendFeedback(feedbackObject);                     
                     })
                 }
-            }
+            };
             _this.sendFeedback = function(feedbackData){
                 mckUtils.ajax({
                     type: 'POST',
@@ -1874,7 +1876,7 @@ var CURRENT_GROUP_DATA={};
                         console.log('Error submitting feedback')
                     }
                 });
-            },
+            };
             _this.getPreLeadDataForAskUserDetail = function(){
                 var LEAD_COLLECTION_LABEL = MCK_LABELS['lead.collection'];
                 var KM_USER_DETAIL_TYPE_MAP = {'email':'email', 'phone':'number'};
@@ -1889,7 +1891,7 @@ var CURRENT_GROUP_DATA={};
                     KM_PRELEAD_COLLECTION.push(obj);
                     }
                 }
-            }
+            };
             _this.addLeadCollectionInputDiv = function() {
                     KM_ASK_USER_DETAILS && _this.getPreLeadDataForAskUserDetail();
                 for(var i=0; i<KM_PRELEAD_COLLECTION.length; i++){
@@ -1908,7 +1910,7 @@ var CURRENT_GROUP_DATA={};
                      $applozic('.km-last-child').append(kmChatInputDiv);
                      $applozic(kmChatInputDiv).append(kmChatInput);
                 }
-            }
+            };
 
             _this.setLeadCollectionLabels = function () {
                 var LEAD_COLLECTION_LABEL = MCK_LABELS['lead.collection'];
@@ -4466,6 +4468,7 @@ var CURRENT_GROUP_DATA={};
                 clearTimeout(MCK_TRIGGER_MSG_NOTIFICATION_PARAM);
                 MCK_MAINTAIN_ACTIVE_CONVERSATION_STATE && params.isGroup && params.tabId && KommunicateUtils.setItemToLocalStorage("mckActiveConversationInfo",{groupId:params.tabId, "appId":appOptions.appId, "userId":userId});
                 var currTabId = $mck_msg_inner.data('mck-id');
+                ACTIVE_TAB_ID = params.tabId || currTabId;
                 if (currTabId) {
                     if ($mck_text_box.html().length > 1 || $mck_file_box.hasClass('vis')) {
                         var text = $mck_text_box.html();
@@ -9384,7 +9387,8 @@ var CURRENT_GROUP_DATA={};
                                 'messageKey': message.key
                             });
                         } else if (messageType === "APPLOZIC_01" || messageType === "APPLOZIC_02" || messageType === "MESSAGE_RECEIVED") {
-                            if (kommunicateCommons.isObject(resp.message) && resp.message.metadata && resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS) {
+                            if (kommunicateCommons.isObject(resp.message) && resp.message.groupId && resp.message.groupId == ACTIVE_TAB_ID && resp.message.metadata && resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS) {
+                                console.log(resp.message);                      
                                 KommunicateUI.showClosedConversationBanner(true);
                             }
                             ALStorage.updateLatestMessage(message);

--- a/webplugin/pluginOptimizer.js
+++ b/webplugin/pluginOptimizer.js
@@ -38,7 +38,7 @@ const compressAndOptimize = () => {
         input: [
             path.resolve(__dirname, 'lib/js/mck-ui-widget.min.js'),
             path.resolve(__dirname, 'lib/js/mck-ui-plugins.min.js'),
-            path.resolve(__dirname, 'lib/js/mck-emojis.min.js'),
+            // path.resolve(__dirname, 'lib/js/mck-emojis.min.js'),
             path.resolve(__dirname, 'lib/js/howler-2.0.2.min.js'),
             path.resolve(__dirname, 'lib/js/tiny-slider-2.4.0.js'),
             path.resolve(__dirname, 'lib/js/mustache.js'),

--- a/webplugin/pluginOptimizer.js
+++ b/webplugin/pluginOptimizer.js
@@ -38,7 +38,7 @@ const compressAndOptimize = () => {
         input: [
             path.resolve(__dirname, 'lib/js/mck-ui-widget.min.js'),
             path.resolve(__dirname, 'lib/js/mck-ui-plugins.min.js'),
-            // path.resolve(__dirname, 'lib/js/mck-emojis.min.js'),
+            path.resolve(__dirname, 'lib/js/mck-emojis.min.js'),
             path.resolve(__dirname, 'lib/js/howler-2.0.2.min.js'),
             path.resolve(__dirname, 'lib/js/tiny-slider-2.4.0.js'),
             path.resolve(__dirname, 'lib/js/mustache.js'),

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -804,29 +804,3 @@
 <div id="km-anonymous-chat-launcher" class="km-hide-logo n-vis">
 </div>
 
-<script>
-function showAfterLoad(){
-	var mckSidebox = document.getElementById("mck-sidebox");
-	mckSidebox.style.visibility='visible';
-	var mckLocBox = document.getElementById("mck-loc-box");
-	mckLocBox.style.visibility='visible';
-	var mckGmSearchBox = document.getElementById("mck-gm-search-box");
-	mckGmSearchBox.style.visibility='visible';
-};
-	if(navigator.userAgent.indexOf('MSIE')!==-1
-|| navigator.appVersion.indexOf('Trident/') > 0){
-
-	showAfterLoad();
-} else {
-	var isScriptV2 = !!parent.document.getElementById('kommunicate-widget-iframe');
-	if (isScriptV2){
-		window.parent.document.addEventListener('kmInitilized', function() {
-			showAfterLoad();
-		}, false);
-	}else{
-		window.addEventListener('kmInitilized', function() {
-			showAfterLoad();
-		}, false);	
-	}
-}
-</script>

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -215,7 +215,6 @@
 							<svg class="mck-circular-spinner"  viewBox="25 25 50 50" width="50" height="50">
 								<circle class="mck-spinner-path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"/>
 							</svg>
-						<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/ring.gif" alt="Loading" /> -->
 					</div>
 					<div id="mck-no-conversations" class="mck-no-data-text mck-text-muted n-vis">
 						<h3>No conversations yet!</h3>
@@ -507,7 +506,6 @@
 							<svg class="mck-circular-spinner"  viewBox="25 25 50 50" width="50" height="50">
 								<circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"/>
 							</svg>
-							<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/ring.gif" alt="Loading" /> -->
 						</div>
 					</div>
 				</div>
@@ -540,7 +538,6 @@
 										<svg class="mck-circular-spinner"  viewBox="25 25 50 50" width="50" height="50">
 											<circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"/>
 										</svg>
-										<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-loading.gif" alt="Loading" /> -->
 									</div>
 									<input id="mck-group-icon-upload" class="mck-group-icon-upload n-vis" type="file" name="files[]">
 								</span>
@@ -603,7 +600,6 @@
 								<svg class="mck-circular-spinner"  viewBox="25 25 50 50" width="50" height="50">
 									<circle class="mck-spinner-path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"/>
 								</svg>
-								<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-loading.gif" alt="Loading" /> -->
 							</div>
 							<input id="mck-group-icon-change" class="mck-group-icon-change n-vis" type="file" name="file[]" />
 						</span>
@@ -614,7 +610,6 @@
 								<path fill="none" d="M0 0h24v24H0z"/>
 								<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
 							</svg>
-							<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-icon-save.png" alt="Save"> -->
 						</a>
 					</div>
 				</div>
@@ -629,14 +624,12 @@
 									<path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
 									<path d="M0 0h24v24H0z" fill="none"/>
 								</svg>
-								<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-icon-write.png" alt="Edit"> -->
 							</a>
 							<a id="mck-group-name-save" href="#" role="link" class="mck-group-name-save n-vis" title="Save">
 								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 									<path fill="none" d="M0 0h24v24H0z"/>
 									<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
 								</svg>
-								<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-icon-save.png" alt="Save"> -->
 							</a>
 						</div>
 					</div>
@@ -652,7 +645,6 @@
 									<path d="M0 0h24v24H0z" fill="none"/>
 									<path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
 								</svg>
-								<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-icon-add-member.png" alt="Add Member"> -->
 							</div>
 							<div class="blk-lg-9">Add Member</div>
 						</a>
@@ -729,7 +721,6 @@
 						<path d="M0 0h24v24H0z" fill="none"/>
 						<path d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
 					</svg>
-					<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/mck-icon-add-member.png" alt="Add Member"> -->
 				</div>
 				<div class="blk-lg-7">
 					<h4 class="mck-box-title">Add Member</h4>
@@ -761,7 +752,6 @@
 						<svg class="mck-circular-spinner"  viewBox="25 25 50 50" width="50" height="50">
 							<circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"/>
 						</svg>
-						<!-- <img src="MCK_STATICPATH/sidebox/css/app/images/ring.gif" alt="Loading" /> -->
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Remove commented links inside HTML file.
-> Replace jquery code inside mck-app.js with JS.
-> Fixed bug where C-SAT rating was showing in the wrong thread.
-> Added sessionTimeout support in appOptions(preference will be given to appOptions if sessionTimeout is coming from application settings API).
-> Removed Twilio related reference from the mck-app.js file.

### How was the code tested?
<!-- Be as specific as possible. -->
-> **sessionTimeout**
 Bypassing sessionTimeout : <integer value in milliseconds> in install script.

-> **C-SAT rating**
 By first opening two threads 1 and 2, then opened thread 2 and resolving thread 1 from the dashboard.

-> **Jquery->JS**
 By creating new build and checking that everything is working fine in our Sidebox.

### In case you fixed a bug then please describe the root cause of it? 
-> For the real-time update of C-SAT rating the check was added inside onMessage function to detect the resolve event but it was not checking that which group is opened currently in sidebox. So if any conversation was getting resolved the C-SAT banner was appearing in the conversation which is currently opened (Other than the resolved one).

NOTE: Make sure you're comparing your branch with the correct base branch