### PR TITLE
CO-457 added appOption in install script to set user locale 

### DIFF
--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -42,6 +42,11 @@ Kommunicate.client={
      */
      createConversation : function(conversationDetail,callback){
         var chatContext =  $applozic.extend(Kommunicate.getSettings("KM_CHAT_CONTEXT"),conversationDetail.metadata ?conversationDetail.metadata["KM_CHAT_CONTEXT"]:{});
+        var userLocale = kommunicate._globals.userLocale;
+        var currentLanguage = {
+            'kmUserLocale': userLocale ? userLocale.split("-")[0] : (window.navigator.language || window.navigator.userLanguage).split('-')[0]
+        };
+        chatContext = $applozic.extend(chatContext, currentLanguage);
 
         var groupMetadata = {
             CREATE_GROUP_MESSAGE: "",


### PR DESCRIPTION
### What do you want to achieve?
-> Added `userLocale` option in appOption to set the language of the welcome messages. If this option is not available in appOption then the browser language will be set as the language of the welcome messages.
-> Sending `"{"kmUserLocale":"en"}"` in `KM_CHAT_CONTEXT` of the group metadata to set the welcome language of the user.

### How was the code tested?
<!-- Be as specific as possible. -->
-> By adding `userLocale: "en-US` in appOption. 

### What new thing you came across while writing this code? 
->

### Incase you fixed a bug then please describe the root cause of it? 
->

NOTE: Make sure you're comparing your branch with the correct base branch