### PR TITLE
catch error from howler

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -515,7 +515,11 @@ var CURRENT_GROUP_DATA={};
             notificationtoneoption.loop = false;
             if(MCK_NOTIFICATION_TONE_LINK){
                 ringToneService = new RingToneService();
-                mckNotificationTone = ringToneService.loadRingTone(MCK_NOTIFICATION_TONE_LINK, notificationtoneoption);
+                try {
+                    mckNotificationTone = ringToneService.loadRingTone(MCK_NOTIFICATION_TONE_LINK, notificationtoneoption);
+                } catch (e) {
+                    console.log(e)
+                }  
             }
             mckMessageService.init();
             mckFileService.init();

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -518,7 +518,7 @@ var CURRENT_GROUP_DATA={};
                 try {
                     mckNotificationTone = ringToneService.loadRingTone(MCK_NOTIFICATION_TONE_LINK, notificationtoneoption);
                 } catch (e) {
-                    console.log(e)
+                    console.log(e, "error while loading ringTone service")
                 }  
             }
             mckMessageService.init();


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> TypeError: null is not an object (evaluating 'o.ctx.createGain') is thorwing on Safari sometimes. due to this error plugin is not loading.
https://github.com/goldfire/howler.js/issues/1021
the plugin should load if any error throw from howler library

### How was the code tested?
<!-- Be as specific as possible. -->
-> created a sample webpage and loaded plugin multiple times on different tabs using the link button 
### What new thing you came across while writing this code? 
->

### Incase you fixed a bug then please describe the root cause of it? 
->

NOTE: Make sure you're comparing your branch with the correct base branch