### PR TITLE
Updated image url for bot whose default image is not present

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5507,7 +5507,7 @@ var MCK_CHAT_POPUP_TEMPLATE_TIMER;
                       } else if (contact.photoLink) {
                           imgsrctag = '<img src="' + MCK_BASE_URL + '/contact.image?photoLink=' + contact.photoLink + '" alt="' + profileDisplayName + '"/>';
                       } else if (contact.contactId == "bot") { //Todo: replace this with role once its build at Applozic side.
-                          imgsrctag = '<img src="' + 'https://api.kommunicate.io/img/logo02.svg' + '" alt="' + profileDisplayName + '"/>';
+                          imgsrctag = '<img src="' + 'https://cdn.kommunicate.io/kommunicate/bot_default_image.png' + '" alt="' + profileDisplayName + '"/>';
                       } else {
                           if (!displayName) {
                               displayName = contact.displayName;


### PR DESCRIPTION
### Incase you fixed a bug then please describe the root cause of it? 
-> Fixed a bug where `https://api.kommunicate.io/img/logo02.svg` this url was giving 404 error so replaced it with `https://cdn.kommunicate.io/kommunicate/bot_default_image.png` this one.

NOTE: Make sure you're comparing your branch with the correct base branch