### PR TITLE
Fix Rich Message Icon visual bug in popup message notification [RELEASE]

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -5794,6 +5794,13 @@ div[name="message"]:last-child {
 	text-overflow: ellipsis;
 	margin: 0;
 }
+.mck-msg-preview-visual-indicator-text.applozic-launcher .mck-icon--rich-message{
+	min-width: 25px;
+}
+.mck-msg-preview-visual-indicator-text.applozic-launcher .mck-icon--rich-message + span{
+	white-space: nowrap;
+}
+
 
 @media only screen and (width: 442px) {
 	.mck-sidebox.fade.in.popup-enabled, #km-chat-login-modal.km-sidemodal {


### PR DESCRIPTION
### How was the code tested?
<!-- Be as specific as possible. -->
-> By sending bot's rich message in the chat with the widget is closed.

### Incase you fixed a bug then please describe the root cause of it? 
-> Fixed a bug where the Rich Message icon in the popup message notification was being cut in half when a rich message arrives from bot in chat as seen in the screenshot below.

![image](https://user-images.githubusercontent.com/12482554/64703958-1490e300-d4cb-11e9-948c-ddf3c37810f5.png)

NOTE: Make sure you're comparing your branch with the correct base branch