### PR TITLE
CO-791 fixed images with ratio other than 1:1 getting cut in launcher icon

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -5532,7 +5532,8 @@ box-shadow: 0 0 4px rgba(0,0,0,.22), 0 4px 8px rgba(0,0,0,.31);
 }
 #launcher-agent-img-container img {
 	width: 60px;
-	height: auto;
+	height: 60px;
+	object-fit: cover;
 }
 #launcher-agent-img-container .mck-videocall-image {
 	width: 60px;


### PR DESCRIPTION
### How was the code tested?
<!-- Be as specific as possible. -->
-> By sending a message from the dashboard to the chat widget while the chat widget is closed.

### In case you fixed a bug then please describe the root cause of it? 
-> Screenshots:
#### Before:
![image](https://user-images.githubusercontent.com/12482554/64952703-9e132d00-d89e-11e9-90bc-477d6ba78a9d.png)

#### After:
![image](https://user-images.githubusercontent.com/12482554/64952721-a9feef00-d89e-11e9-8650-7fce873b2223.png)


NOTE: Make sure you're comparing your branch with the correct base branch