### PR TITLE
prevent group create call from going multiple times

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2335,6 +2335,7 @@ var MCK_CHAT_POPUP_TEMPLATE_TIMER;
                 Kommunicate.startConversation(params,callback);
             }
             _this.openChatbox = function (params, callback) {
+                kommunicateCommons.setWidgetStateOpen(true);
                 if ($mck_sidebox.css('display') === 'none') {
                     $applozic('.mckModal').mckModal('hide');
                     $mck_sidebox.mckModal();
@@ -2343,7 +2344,6 @@ var MCK_CHAT_POPUP_TEMPLATE_TIMER;
                 $mck_msg_to.focus(); 
             }
             _this.loadConversationWithAgents = function (params, callback) {
-                
                 _this.openChatbox();
                 if (window.applozic.PRODUCT_ID == "kommunicate") {
                     $mck_btn_leave_group
@@ -4554,7 +4554,7 @@ var MCK_CHAT_POPUP_TEMPLATE_TIMER;
                     var kommunicateIframe = parent.document.getElementById("kommunicate-widget-iframe");
                     var kommunicateIframeDocument = kommunicateIframe.contentDocument;
                     var chatbox = kommunicateIframeDocument.getElementById("mck-sidebox-launcher");
-                    chatbox.click();
+                    !kommunicateCommons.isWidgetOpen() && chatbox.click();
                 };
 
                 if ($mck_sidebox.css('display') === 'none') {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- prevent the group create call to go multiple times incase user enters 

```
KommunicateGlobal.document.getElementById('mck-sidebox-launcher').addEventListener('click',function(e){
    Kommunicate.startConversation();
});

```
- also stopped the click event on sidebox launcher being called twice

### How was the code tested?
<!-- Be as specific as possible. -->
- code was tested in my local environment for cases mentioned above.
