### PR TITLE
CO-795  Set default group name using startConversation method.

### DIFF
--- a/webplugin/js/app/events/applozic-event-handler.js
+++ b/webplugin/js/app/events/applozic-event-handler.js
@@ -14,7 +14,7 @@ Kommunicate.KmEventHandler = {
         }
     },
     'notificationEvent': function (message) {
-        if (KommunicateUtils.getDataFromKmSession("appOptions").openConversationOnNewMessage) {
+        if (KommunicateUtils.getDataFromKmSession("appOptions") && KommunicateUtils.getDataFromKmSession("appOptions").openConversationOnNewMessage) {
             Kommunicate.KmEventHandler.openChatOnNotification(message);
         } else if(document.getElementById('launcher-agent-img-container').classList.contains('vis')) {
             document.querySelector('#mck-sidebox-launcher #launcher-svg-container').classList.add("n-vis");

--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -69,9 +69,8 @@ Kommunicate.client={
             GROUP_CREATION_URL: parent.location.href
         };
 
-        if (conversationDetail.skipBotEvent) {
-            groupMetadata.SKIP_BOT_EVENT = conversationDetail.skipBotEvent;
-        }
+        conversationDetail.metadata.KM_ORIGINAL_TITLE && (groupMetadata.KM_ORIGINAL_TITLE = true);
+        conversationDetail.skipBotEvent && (groupMetadata.SKIP_BOT_EVENT = conversationDetail.skipBotEvent);
 
         // Add welcome message in group metadata only if some value for it is coming in conversationDetails parameter.
         conversationDetail.metadata && conversationDetail.metadata.WELCOME_MESSAGE && (groupMetadata.WELCOME_MESSAGE = conversationDetail.metadata.WELCOME_MESSAGE)

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -50,11 +50,11 @@ $applozic.extend(true,Kommunicate,{
                 user.push({ "userId": params.botIds[i], "groupRole": 2 });
             }
         }
-        var groupName = params.conversationTitle || params.groupName || kommunicate._globals.conversationTitle || kommunicate._globals.groupName || kommunicate._globals.agentId;
+        var groupName = params.defaultGroupName || params.conversationTitle || params.groupName || kommunicate._globals.conversationTitle || kommunicate._globals.groupName || kommunicate._globals.agentId;
         var assignee = params.defaultAssignee || params.assignee || params.agentId;
 
         var groupMetadata = {};
-
+        params.defaultGroupName && (groupMetadata.KM_ORIGINAL_TITLE = true);
         ((typeof params.metadata == "object"  && typeof params.metadata['KM_CHAT_CONTEXT'] == "object")) && (groupMetadata.KM_CHAT_CONTEXT = params.metadata['KM_CHAT_CONTEXT']);
 
         params.WELCOME_MESSAGE && (groupMetadata.WELCOME_MESSAGE = params.WELCOME_MESSAGE);

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9597,7 +9597,7 @@ var MCK_CHAT_POPUP_TEMPLATE_TIMER;
                                 var tabId = $mck_message_inner.data('mck-id');
                                 if (kommunicateCommons.isObject(resp.message) && resp.message.groupId && resp.message.groupId == tabId && resp.message.metadata) {
                                     resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS && KommunicateUI.showClosedConversationBanner(true);
-                                    if (message && message.metadata && message.metadata.KM_ASSIGN) {
+                                    if (message && message.metadata && message.metadata.KM_ASSIGN && !(contact && contact.metadata && contact.metadata.KM_ORIGINAL_TITLE)) {
                                         var getUsersDetailparams = {
                                             "cached": false
                                         };


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Set the default group name using startConversation method.
- Don't change conversation header on change of assignee in case if KM_ORIGINAL_TITLE is passed while group creation.
- Fix bug openConversationOnNewMessage of undefined.

### How was the code tested?
<!-- Be as specific as possible. -->
- Calling below function in onInit Callback function 
          Kommunicate.startConversation({
            "defaultGroupName": "Github Commit",
         }, function (response) {
             console.log(response);
         });

NOTE: Make sure you're comparing your branch with the correct base branch