### PR TITLE
CO-708 fix launcher with no custom image not visible

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -423,16 +423,22 @@ function ApplozicSidebox() {
         if(widgetTheme && widgetTheme.widgetImageLink) {
             var img = new Image();
             img.onload = function () {
-                var launcherInterval = setInterval(function(){
-                    if(document.getElementById("mck-sidebox-launcher")){
-                        document.getElementById("mck-sidebox-launcher").classList.remove("n-vis");
-                        document.getElementById("mck-sidebox-launcher").classList.add("km-launcher-animation");
-                        clearInterval(launcherInterval);
-                    }
-                }, 100);   
+                preLoadLauncherIconInterval();
             }
             img.src = widgetTheme.widgetImageLink;
+        } else { // This condition is to check if there is no custom launcher icon image.
+            preLoadLauncherIconInterval();
         }
+    }
+
+    function preLoadLauncherIconInterval() {
+        var launcherInterval = setInterval(function() {
+            if(document.getElementById("mck-sidebox-launcher")){
+                document.getElementById("mck-sidebox-launcher").classList.remove("n-vis");
+                document.getElementById("mck-sidebox-launcher").classList.add("km-launcher-animation");
+                clearInterval(launcherInterval);
+            }
+        }, 100);
     }
     
     // function seekReplaceDestroyCookies (mapCookies){


### PR DESCRIPTION
### In case you fixed a bug then please describe the root cause of it? 
-> Fixed a bug where if the chat widget is loaded without any custom launcher icon then the chat widget launcher icon was visible.

The reason to add an `else` condition is to check if there is a custom launcher icon present or not. If it is not present then go through the `setInterval` and remove the `n-vis` class and add the animation class to show the smooth transition of the chat widget is visible in the webpage.

NOTE: Make sure you're comparing your branch with the correct base branch