### PR TITLE
CO-775 Bot message delay timer value will now be fetched from appSettings API

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -455,7 +455,7 @@ var MCK_CHAT_POPUP_TEMPLATE_TIMER;
             10 : MCK_LABELS['emoji.hover.text'].great
         }; 
         var MCK_BOT_MESSAGE_QUEUE = [];
-        var MCK_BOT_MESSAGE_DELAY = (typeof appOptions.botMessageDelay === "number") ? appOptions.botMessageDelay : 0;
+        var MCK_BOT_MESSAGE_DELAY = WIDGET_SETTINGS && WIDGET_SETTINGS.botMessageDelayInterval ? WIDGET_SETTINGS.botMessageDelayInterval : 0;
 
         _this.toggleMediaOptions = function(){
             var mckTypingBox = document.getElementById("mck-text-box");


### PR DESCRIPTION
### What do you want to achieve?
-> Removed check to get `botMessageDelayInterval` value from appOption in the install script, instead it will now be fetched from the appSettings API with same parameter name inside `chatWidget` object.

### How was the code tested?
<!-- Be as specific as possible. -->
-> By setting `"botMessageDelayInterval": 2000` in the `chatWidget` object in App Settings API.

NOTE: Make sure you're comparing your branch with the correct base branch