### PR TITLE
TD-258: fix: on click of link button arrow icon, not redirecting to the link

### DIFF
--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -440,8 +440,8 @@ Kommunicate.richMsgEventHandler = {
         Kommunicate.sendMessage(messagePxy);
     },
     handleLinkButtonClick: function(e) {
-        var url  = decodeURI(e.target.dataset.url);
-        window.open(url, e.target.dataset.target);
+        var url  = decodeURI(e.currentTarget.dataset.url);
+        window.open(url, e.currentTarget.dataset.target);
     },
     handleFormSubmit: function(e) {
         e.preventDefault();


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> on click of link button arrow icon, it should redirect to the link

### How was the code tested?
<!-- Be as specific as possible. -->
-> on click of link button arrow icon, it is redirecting to the link

### What new thing you came across while writing this code? 
-> To get the data attribute of parent element even if the child element is clicked, use event. currentTarget instead of event. target

### Incase you fixed a bug then please describe the root cause of it? 
->

NOTE: Make sure you're comparing your branch with the correct base branch