### PR TITLE
Not allow socket to make message list call when it's getting initialized.

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -294,6 +294,7 @@ var IS_SOCKET_CONNECTED = false;
 
     function Applozic(appOptions) {
         var _this = this;
+        var IS_SOCKET_INITIALIZED = false;
         var INIT_APP_DATA = {};
         var IS_PLUGIN_INITIALIZATION_PROCESS_COMPLETED = false;
         var PRE_CHAT_LEAD_COLLECTION_POPUP_ON = true;
@@ -9239,12 +9240,13 @@ var IS_SOCKET_CONNECTED = false;
                                 "allowReload": true
                             })
                         } else {
-                            // do we need this? 
+                            // Below code will update the all conversation list
                             ALStorage.clearMckMessageArray();
-                            mckMessageLayout.loadTab({
+                            IS_SOCKET_INITIALIZED && mckMessageLayout.loadTab({
                                 'tabId': '',
                                 'isGroup': false
                             });
+                            IS_SOCKET_INITIALIZED = true;
                         }
                     }
                 if (!stompClient.connected) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Not allow the socket to make a message list call when it's getting initialized.

### How was the code tested?
<!-- Be as specific as possible. -->
-> By adding the below code in Kommunicate script.
 onInit: function (response, data) {
         Kommunicate.launchConversation();
}

### In case you fixed a bug then please describe the root cause of it? 
-> Whenever the socket was getting connected, we were making a message list call. So now when the socket connection will be initialized for the first time, we will avoid this call.

NOTE: Make sure you're comparing your branch with the correct base branch