### PR TITLE
Fixed popup dialog visible in IE11 when closing tab

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -522,7 +522,7 @@ function ApplozicSidebox() {
         };
         window.addEventListener('beforeunload', function (event) {
             // Cancel the event as stated by the standard.
-            event.preventDefault();
+            // event.preventDefault();
             var details = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId) || {};
             details.sessionEndTime = new Date().getTime();
             KommunicateUtils.setItemToLocalStorage(applozic._globals.appId, details);


### PR DESCRIPTION
### How was the code tested?
<!-- Be as specific as possible. -->
-> By running the KM Script in IE and then reloading the page.

### Incase you fixed a bug then please describe the root cause of it? 
-> Fixed a bug where popup confirmation dialog was visible in IE11 whenever the user is reloading the page or navigating to some other section of the page where the KM Script is Installed.

NOTE: Make sure you're comparing your branch with the correct base branch