### PR TITLE
CO-829 Fix title width adjustment and pre-chat popup widget issues in mobile devices

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -5259,10 +5259,10 @@ textarea::placeholder {
 	height: auto;
 	width: 225px;
 }
-.mck-sidebox.fade.in.popup-enabled .mck-name-status-container #mck-tab-title.mck-title-width-wo-faq-with-close-btn {
+.mck-sidebox.fade.in.popup-enabled .mck-name-status-container #mck-tab-title.mck-title-width-wo-faq-with-close-btn, .mck-sidebox.fade.in.popup-enabled .mck-name-status-container #mck-tab-title.mck-title-width-with-faq {
 	width: 205px;
 }
-.mck-sidebox.fade.in.popup-enabled .mck-name-status-container #mck-tab-title.mck-title-width-with-faq, 	.mck-sidebox.fade.in.popup-enabled .mck-name-status-container #mck-tab-title.mck-title-width-with-faq-close-btn {
+.mck-sidebox.fade.in.popup-enabled .mck-name-status-container #mck-tab-title.mck-title-width-with-faq-close-btn {
 	width: 155px;
 }
 
@@ -6081,18 +6081,6 @@ div[name="message"]:last-child {
 		width: 0!important;
 		overflow: hidden;
 	}
-	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-with-faq {
-		width: 205px !important;
-	}
-	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-wo-faq-with-close-btn {
-		width: 205px !important;
-	}
-	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-with-faq-close-btn {
-		width: 155px !important;
-	}
-	.mck-name-status-container #mck-tab-title, .mck-name-status-container .mck-tab-title-w-typing {
-		width: 270px;
-	}
 }
 
 /* Dialogflow HTML Headers Fix */
@@ -6696,6 +6684,39 @@ body.accesibility :focus {
 	}
 	.chat-popup-widget-container--horizontal {
 		padding-right: 70px;
+	}
+}
+
+@media only screen and (max-device-width: 360px) and (min-device-width: 320px) {
+	.chat-popup-widget-container--horizontal {
+		width: 53% !important;
+		padding-right: 70px;
+	}
+	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-wo-faq-with-close-btn {
+		width: 187px !important;
+	}
+	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-with-faq-close-btn {
+		width: 130px !important;
+	}
+}
+
+@media only screen and (min-device-width: 365px) and (max-device-width: 415px) {
+	.chat-popup-widget-container--horizontal {
+		width: 65% !important;
+		padding-right: 70px;
+	}
+
+	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-with-faq {
+		width: 205px !important;
+	}
+	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-wo-faq-with-close-btn {
+		width: 205px !important;
+	}
+	.mck-sidebox.fade.in .mck-name-status-container #mck-tab-title.mck-title-width-with-faq-close-btn {
+		width: 145px !important;
+	}
+	.mck-name-status-container #mck-tab-title, .mck-name-status-container .mck-tab-title-w-typing {
+		width: 270px;
 	}
 }
 /* Chat Popup Template Code Ends */

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -545,6 +545,7 @@ handleAttachmentIconVisibility : function(enableAttachment, msg, groupReloaded) 
     adjustConversationTitleHeadingWidth: function(isPopupWidgetEnabled) {
         var titleClassName = 'mck-title-width-wo-faq-with-close-btn';
         var mckTabTitle = document.getElementById("mck-tab-title");
+        mckTabTitle.classList.remove(titleClassName);
         if(document.querySelector(".km-kb-container").classList.contains("vis")) {
             titleClassName = isPopupWidgetEnabled ? 'mck-title-width-with-faq' : 'mck-title-width-with-faq-close-btn';
         }


### PR DESCRIPTION
### How was the code tested?
<!-- Be as specific as possible. -->
-> By loading sidebox script in the browser in the responsive mode.

### In case you fixed a bug then please describe the root cause of it? 
-> Fixed a bug where the pre-chat popup message was being cut in mobile devices with width of less than 420 px.
-> Fixed issues with the width adjustment of the conversation title on the mobile devices with width of less than 420px.

### Screenshots:
#### Before:
Pre-chat popup
![image](https://user-images.githubusercontent.com/12482554/66745177-f6d4e600-ee9b-11e9-9e3c-1bb2afdfeee1.png)

Conversation Title
![image](https://user-images.githubusercontent.com/12482554/66745474-aca03480-ee9c-11e9-9ec9-53f98228a99a.png)



#### After:
Pre-chat popup
![image](https://user-images.githubusercontent.com/12482554/66745242-18ce6880-ee9c-11e9-947d-f058d2803de5.png)

Conversation Title
![image](https://user-images.githubusercontent.com/12482554/66745495-ba55ba00-ee9c-11e9-9b4f-5ae9189e8b1e.png)


NOTE: Make sure you're comparing your branch with the correct base branch