### PR TITLE
CO-852 Added close button in pre-chat popup template

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -994,7 +994,7 @@
     background-color: #fff;
     border-radius: 5px 5px 0px 0px;
 }
-.mck-msg-preview-visual-indicator-container .mck-close-btn {
+.mck-msg-preview-visual-indicator-container .mck-close-btn, .chat-popup-widget-container .chat-popup-widget-close-btn {
     border-radius: 100px;
     background-color: #a19e9e;
     width: 20px;

--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -4766,7 +4766,7 @@ box-shadow: 0 0 4px rgba(0,0,0,.22), 0 4px 8px rgba(0,0,0,.31);
     align-items: center;
 	justify-content: flex-start;
 }
-.mck-msg-preview-visual-indicator-container .mck-close-btn-container {
+.mck-msg-preview-visual-indicator-container .mck-close-btn-container, .chat-popup-widget-container .chat-popup-widget-close-btn-container {
 	position: absolute;
     top: 50%;
     left: -26px;
@@ -4794,7 +4794,7 @@ box-shadow: 0 0 4px rgba(0,0,0,.22), 0 4px 8px rgba(0,0,0,.31);
 .mck-msg-preview-visual-indicator-container:hover .mck-close-btn-container {
 	display: block;
 }
-.mck-msg-preview-visual-indicator-container .mck-close-btn .mck-close-icon-svg svg {
+.mck-msg-preview-visual-indicator-container .mck-close-btn .mck-close-icon-svg svg, .chat-popup-widget-container .chat-popup-widget-close-btn .hat-popup-widget-close-icon-svg svg {
 	vertical-align: middle;
 }
 .mck-msg-preview-visual-indicator-container .mck-close-btn .mck-close-text {
@@ -5592,6 +5592,10 @@ body.accesibility :focus {
 	box-shadow: none;
 }
 
+.chat-popup-widget-container:hover .chat-popup-widget-close-btn-container {
+	display: block;
+}
+
 .chat-popup-widget-container--vertical.km-animate {
 	-webkit-clip-path: circle(55px at 355px 50px);
 	clip-path: circle(55px at 355px 50px);
@@ -5627,29 +5631,6 @@ body.accesibility :focus {
 	-o-animation: km-slide-in-animation .5s ease .5s 1 forwards;
 	animation: km-slide-in-animation .5s ease .5s 1 forwards;
 }
-.mck-conversation-resolved{
-	display: none !important;
-}
-.mck-conversation-resolved.mck-show-resolved-conversation {
-    opacity: 0.5;
-    display: block ! important;
-}
-
-#mck-conversation-filter {
-    padding: 10px 20px;
-    font-size: 14px;
-    background: #f9f9f9;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-#mck-conversation-filter span:last-child{
-	cursor: pointer;
-	color: #4a39ff;	
-}
-#mck-conversation-filter span:last-child:hover{
-	text-decoration: underline;
-}
 
 @-webkit-keyframes km-reveal-animation-horizontal {
 	from {
@@ -5657,8 +5638,8 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		-webkit-clip-path: circle(345px at 335px 35px);
-		clip-path: circle(345px at 335px 35px);
+		-webkit-clip-path: circle(345px at 315px 35px);
+		clip-path: circle(345px at 315px 35px);
 	}
 }
 @-moz-keyframes km-reveal-animation-horizontal {
@@ -5667,7 +5648,7 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		clip-path: circle(345px at 335px 35px);
+		clip-path: circle(345px at 315px 35px);
 	}
 }
 @-o-keyframes km-reveal-animation-horizontal {
@@ -5676,7 +5657,7 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		clip-path: circle(345px at 335px 35px);
+		clip-path: circle(345px at 315px 35px);
 	}
 }
 @keyframes km-reveal-animation-horizontal {
@@ -5685,8 +5666,8 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		-webkit-clip-path: circle(345px at 335px 35px);
-		clip-path: circle(345px at 335px 35px);
+		-webkit-clip-path: circle(345px at 315px 35px);
+		clip-path: circle(345px at 315px 35px);
 	}
 }
 @-webkit-keyframes km-scale-animation {
@@ -5798,8 +5779,8 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		-webkit-clip-path: circle(365px at 345px 50px);
-		clip-path: circle(365px at 345px 50px);
+		-webkit-clip-path: circle(365px at 335px 50px);
+		clip-path: circle(365px at 335px 50px);
 	}
 }
 @-moz-keyframes km-reveal-animation-vertical {
@@ -5808,7 +5789,7 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		clip-path: circle(365px at 345px 50px);	
+		clip-path: circle(365px at 335px 50px);	
 	}
 }
 @-o-keyframes km-reveal-animation-vertical {
@@ -5817,7 +5798,7 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		clip-path: circle(365px at 345px 50px);
+		clip-path: circle(365px at 335px 50px);
 	}
 }
 @keyframes km-reveal-animation-vertical {
@@ -5826,8 +5807,8 @@ body.accesibility :focus {
 	}
 	to {
 		opacity: 1;
-		-webkit-clip-path: circle(365px at 345px 50px);
-		clip-path: circle(365px at 345px 50px);
+		-webkit-clip-path: circle(365px at 335px 50px);
+		clip-path: circle(365px at 335px 50px);
 	}
 }
 
@@ -5941,4 +5922,28 @@ body.accesibility :focus {
 }
 .km-faq-and-close-btn-container {
 	justify-content: flex-end;
+}
+
+.mck-conversation-resolved{
+	display: none !important;
+}
+.mck-conversation-resolved.mck-show-resolved-conversation {
+    opacity: 0.5;
+    display: block ! important;
+}
+
+#mck-conversation-filter {
+    padding: 10px 20px;
+    font-size: 14px;
+    background: #f9f9f9;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+#mck-conversation-filter span:last-child{
+	cursor: pointer;
+	color: #4a39ff;	
+}
+#mck-conversation-filter span:last-child:hover{
+	text-decoration: underline;
 }

--- a/webplugin/js/app/km-message-markup-1.0.js
+++ b/webplugin/js/app/km-message-markup-1.0.js
@@ -33,7 +33,7 @@ Kommunicate.popupChatTemplate = {
             var launcherClass = isAnonymousChat ? "km-anonymous-chat-launcher" : "applozic-launcher";
             var index = (popupWidgetContent && popupWidgetContent.length && popupWidgetContent[0].templateKey) || KommunicateConstants.CHAT_POPUP_TEMPLATE.HORIZONTAL;
             var templateCss = index === KommunicateConstants.CHAT_POPUP_TEMPLATE.HORIZONTAL ? 'chat-popup-widget-container--horizontal' : 'chat-popup-widget-container--vertical';
-            chatPopupTemplateMarkup = '<div id="chat-popup-widget-container" class="chat-popup-widget-container ' + templateCss + ' n-vis ' + launcherClass + '"><div class="chat-popup-widget-text-wrapper"><p class="chat-popup-widget-text">' + (popupMessageContent && kommunicateCommons.formatHtmlTag(popupMessageContent)) + '</p></div></div>';
+            chatPopupTemplateMarkup = '<div id="chat-popup-widget-container" class="chat-popup-widget-container ' + templateCss + ' n-vis"><div class="chat-popup-widget-text-wrapper '  + launcherClass + '"><p class="chat-popup-widget-text">' + (popupMessageContent && kommunicateCommons.formatHtmlTag(popupMessageContent)) + '</p></div>' + '<div class="chat-popup-widget-close-btn-container"><div class="chat-popup-widget-close-btn"><span class="chat-popup-widget-close-icon-svg"><svg viewBox="0 0 64 64" width="8" xmlns="http://www.w3.org/2000/svg" height="8"><path fill="#fff" d="M28.941 31.786L.613 60.114a2.014 2.014 0 1 0 2.848 2.849l28.541-28.541 28.541 28.541c.394.394.909.59 1.424.59a2.014 2.014 0 0 0 1.424-3.439L35.064 31.786 63.41 3.438A2.014 2.014 0 1 0 60.562.589L32.003 29.15 3.441.59A2.015 2.015 0 0 0 .593 3.439l28.348 28.347z"></path></svg></span></div></div>' + '</div>';
         };
         
         if(isAnonymousChat) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2200,6 +2200,11 @@ var MCK_BOT_MESSAGE_QUEUE = [];
                 clearTimeout(MCK_CHAT_POPUP_TEMPLATE_TIMER);
                 KommunicateUI.togglePopupChatTemplate();
             }
+
+            $applozic(d).on("click", ".chat-popup-widget-close-btn-container", function(){
+                KommunicateUI.togglePopupChatTemplate();
+            });
+
         }
 
         function MckMessageService() {

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -64,11 +64,11 @@ var kmCustomIframe =
         'width:100vw;'+
     '} \n' + 
     '.kommunicate-custom-iframe.chat-popup-widget-horizontal { ' + 
-    '   width: 421px;' + 
+    '   width: 441px;' + 
     '   height: 80px;' + 
     '} \n' + 
     '.kommunicate-custom-iframe.chat-popup-widget-vertical { ' + 
-    '   width: 390px;' + 
+    '   width: 415px;' + 
     '   height: 153px;' + 
     '} \n' + 
     '@media only screen and (max-width: 420px) { ' + 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Added close button to close the pre-chat popup template as shown in the screenshot.

### How was the code tested?
<!-- Be as specific as possible. -->
> - By enabling the pre-chat popup from the dashboard.
> - By hovering over the pre-chat popup template when it is visible on the widget to see the close button.
> - By clicking the close button of the pre-chat popup template to dismiss it.

### Screenshots:
![image](https://user-images.githubusercontent.com/12482554/67187819-b2e86080-f408-11e9-954e-9440dfb3ec2c.png)

![image](https://user-images.githubusercontent.com/12482554/67187835-c0054f80-f408-11e9-905c-385ac43dc50f.png)


NOTE: Make sure you're comparing your branch with the correct base branch