### PR TITLE
Remove session data incase of session expiry.

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -461,8 +461,10 @@ function ApplozicSidebox() {
         if (widgetSettings && sessionTimeout != null && timeStampDifference > sessionTimeout) {
             KommunicateUtils.deleteUserCookiesOnLogout();
             sessionStorage.removeItem("kommunicate");
+            KommunicateUtils.removeItemFromLocalStorage(applozic._globals.appId);
             ALStorage.clearSessionStorageElements();
         };
+        // TODO: Handle case where internet disconnects and sessionEndTime is not updated.
         window.addEventListener('beforeunload', function (event) {
             // Cancel the event as stated by the standard.
             var details = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId) || {};


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
> - Remove session data incase of session expire.

### How was the code tested?
<!-- Be as specific as possible. -->
> - By setting session timeout for 2min and checking that new thread is getting created or not.
> - If a new thread is being created in that case session should not expire till 2min unlike previously.

### In case you fixed a bug then please describe the root cause of it? 
> - Previous session data was not getting cleared so in case of session expiry the new use was getting created but after every refresh new user was getting created because of older session data present.

NOTE: Make sure you're comparing your branch with the correct base branch