### PR TITLE
Add class kommunicate-hide-custom-iframe for Kommunicate.displayKommunicateWidget() function.

### DIFF
--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -82,7 +82,10 @@ var kmCustomIframe =
       '.kommunicate-custom-iframe.chat-popup-widget-container--horizontal { ' + 
         'width: 100%;' + 
       '} \n' + 
-    '} \n ';
+    '} \n' +
+    '.kommunicate-hide-custom-iframe { ' +
+    '   display: none!important' +
+    '} \n';
 
 isV1Script() ? addKommunicatePluginToIframe() : appendIframe();
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
> Add class kommunicate-hide-custom-iframe for Kommunicate.displayKommunicateWidget() function.

### How was the code tested?
<!-- Be as specific as possible. -->
> By calling function below function to hide the widget.
Kommunicate.displayKommunicateWidget(false);

### In case you fixed a bug then please describe the root cause of it? 
-> Class was getting added to the Iframe element but CSS class was not there in the DOM.

NOTE: Make sure you're comparing your branch with the correct base branch