### PR TITLE
FW-633 Add support for custom welcome intent in settings

### DIFF
--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -74,7 +74,9 @@ Kommunicate.client={
         conversationDetail.skipBotEvent && (groupMetadata.SKIP_BOT_EVENT = conversationDetail.skipBotEvent);
 
         // Add welcome message in group metadata only if some value for it is coming in conversationDetails parameter.
-        conversationDetail.metadata && conversationDetail.metadata.WELCOME_MESSAGE && (groupMetadata.WELCOME_MESSAGE = conversationDetail.metadata.WELCOME_MESSAGE)
+        conversationDetail.metadata && conversationDetail.metadata.WELCOME_MESSAGE && (groupMetadata.WELCOME_MESSAGE = conversationDetail.metadata.WELCOME_MESSAGE);
+
+        conversationDetail.metadata && conversationDetail.metadata.CUSTOM_WELCOME_INTENT && (groupMetadata.CUSTOM_WELCOME_INTENT = conversationDetail.metadata.CUSTOM_WELCOME_INTENT);
 
         $applozic.fn.applozic("createGroup", {
             //createUrl:Kommunicate.getBaseUrl()+"/conversations/create",

--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -72,11 +72,10 @@ Kommunicate.client={
 
         conversationDetail.metadata.KM_ORIGINAL_TITLE && (groupMetadata.KM_ORIGINAL_TITLE = true);
         conversationDetail.skipBotEvent && (groupMetadata.SKIP_BOT_EVENT = conversationDetail.skipBotEvent);
+        conversationDetail.customWelcomeEvent && (groupMetadata.CUSTOM_WELCOME_EVENT = conversationDetail.customWelcomeEvent);
 
         // Add welcome message in group metadata only if some value for it is coming in conversationDetails parameter.
         conversationDetail.metadata && conversationDetail.metadata.WELCOME_MESSAGE && (groupMetadata.WELCOME_MESSAGE = conversationDetail.metadata.WELCOME_MESSAGE);
-
-        conversationDetail.metadata && conversationDetail.metadata.CUSTOM_WELCOME_INTENT && (groupMetadata.CUSTOM_WELCOME_INTENT = conversationDetail.metadata.CUSTOM_WELCOME_INTENT);
 
         $applozic.fn.applozic("createGroup", {
             //createUrl:Kommunicate.getBaseUrl()+"/conversations/create",

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -105,7 +105,7 @@ $applozic.extend(true,Kommunicate,{
         conversationDetail.botIds = conversationDetail.botIds || kommunicateSettings.defaultBotIds;
         conversationDetail.skipRouting = conversationDetail.skipRouting || kommunicateSettings.skipRouting;
         conversationDetail.skipBotEvent = conversationDetail.skipBotEvent || kommunicateSettings.skipBotEvent;
-        conversationDetail.customWelcomeIntent = conversationDetail.customWelcomeIntent;
+        conversationDetail.customWelcomeEvent = conversationDetail.customWelcomeEvent;
 
         return conversationDetail;
     },
@@ -439,7 +439,7 @@ $applozic.extend(true,Kommunicate,{
        5. skipBotEvent [multiple values]
        6. KM_CHAT_CONTEXT
        7. WELCOME_MESSAGE
-       8. customWelcomeIntent [single value]
+       8. customWelcomeEvent [single value]
    */
     updateSettings:function(options){
         var type = typeof options;

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -70,6 +70,7 @@ $applozic.extend(true,Kommunicate,{
             "isInternal": params.isInternal,
             "skipRouting": params.skipRouting,
             "skipBotEvent": params.skipBotEvent,
+            "customWelcomeEvent": params.customWelcomeEvent,
             "metadata": groupMetadata
         };
         if (IS_SOCKET_CONNECTED) {
@@ -104,6 +105,7 @@ $applozic.extend(true,Kommunicate,{
         conversationDetail.botIds = conversationDetail.botIds || kommunicateSettings.defaultBotIds;
         conversationDetail.skipRouting = conversationDetail.skipRouting || kommunicateSettings.skipRouting;
         conversationDetail.skipBotEvent = conversationDetail.skipBotEvent || kommunicateSettings.skipBotEvent;
+        conversationDetail.customWelcomeIntent = conversationDetail.customWelcomeIntent;
 
         return conversationDetail;
     },
@@ -437,6 +439,7 @@ $applozic.extend(true,Kommunicate,{
        5. skipBotEvent [multiple values]
        6. KM_CHAT_CONTEXT
        7. WELCOME_MESSAGE
+       8. customWelcomeIntent [single value]
    */
     updateSettings:function(options){
         var type = typeof options;

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -452,7 +452,6 @@ $applozic.extend(true,Kommunicate,{
         for (var key in options){
             settings[key]= options[key];
         }
-        console.log("#storing settings: " + settings);
         KommunicateUtils.storeDataIntoKmSession("settings",settings);
     },
     getSettings:function(setting){

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -105,6 +105,7 @@ $applozic.extend(true,Kommunicate,{
         conversationDetail.botIds = conversationDetail.botIds || kommunicateSettings.defaultBotIds;
         conversationDetail.skipRouting = conversationDetail.skipRouting || kommunicateSettings.skipRouting;
         conversationDetail.skipBotEvent = conversationDetail.skipBotEvent || kommunicateSettings.skipBotEvent;
+        conversationDetail.customWelcomeEvent = conversationDetail.customWelcomeEvent || kommunicateSettings.customWelcomeEvent;
 
         return conversationDetail;
     },
@@ -451,6 +452,7 @@ $applozic.extend(true,Kommunicate,{
         for (var key in options){
             settings[key]= options[key];
         }
+        console.log("#storing settings: " + settings);
         KommunicateUtils.storeDataIntoKmSession("settings",settings);
     },
     getSettings:function(setting){

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -105,7 +105,6 @@ $applozic.extend(true,Kommunicate,{
         conversationDetail.botIds = conversationDetail.botIds || kommunicateSettings.defaultBotIds;
         conversationDetail.skipRouting = conversationDetail.skipRouting || kommunicateSettings.skipRouting;
         conversationDetail.skipBotEvent = conversationDetail.skipBotEvent || kommunicateSettings.skipBotEvent;
-        conversationDetail.customWelcomeEvent = conversationDetail.customWelcomeEvent;
 
         return conversationDetail;
     },


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Add customWelcomeEvent in settings, this will be used by bot service to trigger a custom event for the welcome message

### How was the code tested?
<!-- Be as specific as possible. -->
Pass  "customWelcomeEvent": "welcome-post-signup" in update settings and verify the group metadata to contain the metadata: CUSTOM_WELCOME_EVENT


->    (function(d, m){
        var kommunicateSettings = {"appId":"kommunicate-support","popupWidget":true,"automaticChatOpenOnNavigation":true, onInit: function() {
var defaultSettings = {
  
    "skipBotEvent": '["WELCOME_EVENT"]', // Replace <EVENT_NAME> with the bot platform event names which you want to skip
    "skipRouting": true,
    "customWelcomeEvent": "welcome-post-signup"
};
Kommunicate.updateSettings(defaultSettings);  

} };
        var s = document.createElement("script"); s.type = "text/javascript"; s.async = true;
        s.src = "http://localhost:3030/v2/kommunicate.app";
        var h = document.getElementsByTagName("head")[0]; h.appendChild(s);
        window.kommunicate = m; m._globals = kommunicateSettings;
      })(document, window.kommunicate || {});

<img width="1390" alt="Screenshot 2020-01-16 at 8 44 54 PM" src="https://user-images.githubusercontent.com/159686/72537143-9b066880-38a1-11ea-98a9-f91cb53ee2ca.png">


### What new thing you came across while writing this code? 
->

### Incase you fixed a bug then please describe the root cause of it? 
->

NOTE: Make sure you're comparing your branch with the correct base branch