### PR TITLE
safari fix : background colour fix on form submit button

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -1270,6 +1270,7 @@
     border-radius: 19px;
     padding: 5px;
     margin-top: 12px;
+    background-color: white;
 }
 .mck-form-error-text {
     display: block;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
->  background colour of form submit button in safari browser is different, make it white.

### How was the code tested?
<!-- Be as specific as possible. -->
-> tested in safari
![Screen Shot 2020-02-06 at 5 04 52 PM](https://user-images.githubusercontent.com/34020392/73933704-07094900-4903-11ea-9d95-b4122c170249.png)


NOTE: Make sure you're comparing your branch with the correct base branch