### PR TITLE
FW-174 Fix bug where attachment icon is coming even if it is disabled using attachment "false"

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2365,7 +2365,7 @@ var MCK_BOT_MESSAGE_QUEUE = [];
 
             _this.hideSendButton = function(){
                 kommunicateCommons.modifyClassList({id:["send-button-wrapper"]}, "n-vis","vis");
-                kommunicateCommons.modifyClassList({id:["mck-file-up"]}, "vis" , "n-vis");
+                MCK_ATTACHMENT && kommunicateCommons.modifyClassList({id:["mck-file-up"]}, "vis" , "n-vis");
                 !IS_MCK_LOCSHARE ? kommunicateCommons.modifyClassList({id: ["mck-file-up2"]}, "vis" , "n-vis") : kommunicateCommons.modifyClassList({id:["mck-btn-loc"]}, "vis" , "n-vis");
                 !EMOJI_LIBRARY ? "" : kommunicateCommons.modifyClassList({id:["mck-btn-smiley-box"]}, "vis" , "n-vis");
             }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix bug where attachment icon is coming even if it is disabled using attachment "false"

### How was the code tested?
<!-- Be as specific as possible. -->
- Bypassing locShare: true and attachment: false in Kommunicate script.

### In case you fixed a bug then please describe the root cause of it? 
- The attachment icon was getting enabled without even checking the attachment parameter value. Which when false should not be shown.

NOTE: Make sure you're comparing your branch with the correct base branch