### PR TITLE
FW-768 Fix bug where conversation closed banner is not getting removed real-time.

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9685,14 +9685,16 @@ var MCK_BOT_MESSAGE_QUEUE = [];
                         }
                         if (kommunicateCommons.isObject(resp.message) && resp.message.groupId && resp.message.groupId == tabId && resp.message.metadata) {
                             CURRENT_GROUP_DATA.tabId = resp.message.groupId;
-                            if(resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS) {
-                                if(MCK_BOT_MESSAGE_DELAY !== 0 && mckMessageLayout.isMessageSentByBot(resp.message, contact)) {
-                                    setTimeout(function() {
+                            if (resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_CLOSED_STATUS) {
+                                if (MCK_BOT_MESSAGE_DELAY !== 0 && mckMessageLayout.isMessageSentByBot(resp.message, contact)) {
+                                    setTimeout(function () {
                                         KommunicateUI.showClosedConversationBanner(true);
                                     }, MCK_BOT_MESSAGE_DELAY);
                                 } else {
                                     KommunicateUI.showClosedConversationBanner(true);
                                 }
+                            } else if (resp.message.metadata.KM_STATUS === KommunicateConstants.CONVERSATION_OPEN_STATUS) {
+                                KommunicateUI.showClosedConversationBanner(false);
                             }
                             if (message && message.metadata && message.metadata.KM_ASSIGN && !(contact && contact.metadata && contact.metadata.KM_ORIGINAL_TITLE)) {
                                 var getUsersDetailparams = {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix bug, where conversation closed-banner, is not getting removed in real-time when a conversation is reopened from the Dashboard.

### How was the code tested?
<!-- Be as specific as possible. -->
- By closing the conversation from Kommunicate dashboard and checking that the conversation closed-banner is getting removed from the chat in real-time.

### In case you fixed a bug then please describe the root cause of it? 
- This use case was not handled when it was created.

NOTE: Make sure you're comparing your branch with the correct base branch