### PR TITLE
clear active conversation info from local storage on widget logout and after session expiry

### DIFF
--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -260,6 +260,7 @@ $applozic.extend(true,Kommunicate,{
         if (typeof window.$applozic !== "undefined" && typeof window.$applozic.fn !== "undefined" && typeof window.$applozic.fn.applozic !== "undefined") {
             window.$applozic.fn.applozic('logout');
         };
+        KommunicateUtils.removeItemFromLocalStorage("mckActiveConversationInfo");
         KommunicateUtils.deleteUserCookiesOnLogout();
         parent.window && parent.window.removeKommunicateScripts();
     },

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -457,6 +457,7 @@ function ApplozicSidebox() {
             sessionStorage.removeItem("kommunicate");
             KommunicateUtils.removeItemFromLocalStorage(applozic._globals.appId);
             ALStorage.clearSessionStorageElements();
+            KommunicateUtils.removeItemFromLocalStorage("mckActiveConversationInfo");
         };
         // TODO: Handle case where internet disconnects and sessionEndTime is not updated.
         window.addEventListener('beforeunload', function (event) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> clear active conversation info from local storage on widget logout and after session expiry

### How was the code tested?
<!-- Be as specific as possible. -->
-> 
1. on Kommunicate.logout() call, mckActiveConversation object is cleared 
2. enabled "Remove chat session history on page refresh" on the dashboard,  while initializing the chat widget, mckActiveConversation object is cleared 

NOTE: Make sure you're comparing your branch with the correct base branch