### PR TITLE
Fix bug where multiple socket connection getting initialized when launchConversation method is called.

### DIFF
--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -106,10 +106,9 @@ function KommunicateCommons() {
         if (KommunicateCommons.IS_WIDGET_OPEN === isWidgetOpen) return; // return if same value is already assigned to IS_WIDGET_OPEN.
         KommunicateCommons.IS_WIDGET_OPEN = isWidgetOpen;
         if (IS_SOCKET_CONNECTED) {
-            window.$applozic.fn.applozic('setSocketDisconnectProcedure', false);
+            window.Applozic.SOCKET_DISCONNECT_PROCEDURE.stop();
         } else {
-            IS_SOCKET_CONNECTED = true;
-            window.Applozic.ALSocket.checkConnected(true);
+            window.Applozic.SOCKET_DISCONNECT_PROCEDURE.disConnected && window.Applozic.ALSocket.checkConnected(true);
         };
     };
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix bug where multiple socket connection getting initialized when launchConversation method is called.
- Socket disconnect time changed from 4min -> 2min.

### How was the code tested?
<!-- Be as specific as possible. -->
- By calling launchConversation method in "onInit" callback function.
- Checking the overall socket disconnect feature again.

### In case you fixed a bug then please describe the root cause of it? 
- Multiple socket connections were getting initialized because of calling the checkConnected method when socket initialization is in progress.

NOTE: Make sure you're comparing your branch with the correct base branch