### PR TITLE
Fix bug where multiple socket connection getting initialized when launchConversation method is called. [MASTER]

### DIFF
--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -106,10 +106,9 @@ function KommunicateCommons() {
         if (KommunicateCommons.IS_WIDGET_OPEN === isWidgetOpen) return; // return if same value is already assigned to IS_WIDGET_OPEN.
         KommunicateCommons.IS_WIDGET_OPEN = isWidgetOpen;
         if (IS_SOCKET_CONNECTED) {
-            window.$applozic.fn.applozic('setSocketDisconnectProcedure', false);
+            window.Applozic.SOCKET_DISCONNECT_PROCEDURE.stop();
         } else {
-            IS_SOCKET_CONNECTED = true;
-            window.Applozic.ALSocket.checkConnected(true);
+            window.Applozic.SOCKET_DISCONNECT_PROCEDURE.disConnected && window.Applozic.ALSocket.checkConnected(true);
         };
     };
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -466,7 +466,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
         var MCK_BOT_MESSAGE_DELAY = WIDGET_SETTINGS && WIDGET_SETTINGS.botMessageDelayInterval ? WIDGET_SETTINGS.botMessageDelayInterval : 0;
         var WIDGET_POSITION = WIDGET_SETTINGS && kommunicateCommons.isObject(WIDGET_SETTINGS) && WIDGET_SETTINGS.hasOwnProperty('position') ? WIDGET_SETTINGS.position : KommunicateConstants.POSITION.RIGHT;
         window.Applozic.SOCKET_DISCONNECT_PROCEDURE = {
-            SOCKET_DISCONNECT_TIMER_VALUE: 120000, // 2 minutes : 240000 milliSeconds
+            SOCKET_DISCONNECT_TIMER_VALUE: 120000, // 2 minutes : 120000 milliSeconds
             DISCONNECTED: false,
             "start": function () {
                 this.SOCKET_DISCONNECT_TIMEOUT = setTimeout(function () {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
> NOTE: Merge when tested in development.

### What do you want to achieve?
- Fix bug where multiple socket connection getting initialized when launchConversation method is called.
- Socket disconnect time changed from 4min -> 2min.

### How was the code tested?
<!-- Be as specific as possible. -->
- By calling launchConversation method in "onInit" callback function.
- Checking the overall socket disconnect feature again.

### In case you fixed a bug then please describe the root cause of it? 
- Multiple socket connections were getting initialized because of calling the checkConnected method when socket initialization is in progress.

NOTE: Make sure you're comparing your branch with the correct base branch