### PR TITLE
[Master] fix: hyperlink is showing in white color in rich text message

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -2085,7 +2085,6 @@
 .mck-msg-left .mck-msg-box a {
 	color: #333;
 	text-decoration: underline;
-	color: #fff
 }
 
 .mck-msg-left .mck-msg-box a:hover {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> fix: hyperlink is showing in white colour in the rich text message

### How was the code tested?
<!-- Be as specific as possible. -->
-> 
1. Send attachment from the dashboard to plugin, attachment name is showing in white color (plugin)
2. Send attachment from the plugin to dashboard, attachment name is showing in white color (plugin)
3. render HTML template with the hyperlink, hyperlink text is showing in black color.
4. send a link from the dashboard

![Screen Shot 2020-04-02 at 12 20 37 PM](https://user-images.githubusercontent.com/34020392/78219053-7010d580-74dc-11ea-933b-6c47105d480f.png)
![Screen Shot 2020-04-02 at 12 23 03 PM](https://user-images.githubusercontent.com/34020392/78219245-c8e06e00-74dc-11ea-9b3a-c48a295ec7f8.png)

NOTE: Make sure you're comparing your branch with the correct base branch

