### PR TITLE
Add a title label for the heading of Pre-Chat Lead collection.

### DIFF
--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -110,6 +110,7 @@ Kommunicate.defaultLabels = {
         'email':'Email',
         'name':'Name',
         'phone':'Contact Number',
+        'title':'Conversations',
         'heading':'Before starting, we just need a few details so that we may serve you better',
         'submit':'Start Conversation',
     },

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1587,7 +1587,6 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                             });
                         }
             
-                        document.getElementById("km-tab-title").innerHTML = optns.conversationTitle;
                         if ($applozic("#km-form-chat-login .km-form-group input").hasClass("n-vis")){
                             $applozic("#km-form-chat-login .km-form-group .km-form-control.n-vis").prop('required',null);
                         }
@@ -1971,7 +1970,6 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 });
 
             };
-
             _this.configureRatingElements = function(){
                 var ratingSmilies = document.getElementsByClassName("mck-rating-box");
                 var sendFeedbackComment = document.getElementById('mck-submit-comment');
@@ -2074,7 +2072,8 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             _this.setLeadCollectionLabels = function () {
                 var LEAD_COLLECTION_LABEL = MCK_LABELS['lead.collection'];
                 document.getElementById('km-submit-chat-login').innerHTML= LEAD_COLLECTION_LABEL.submit;
-                document.getElementById('km-lead-collection-heading').innerHTML= LEAD_COLLECTION_LABEL.heading;           
+                document.getElementById('km-lead-collection-heading').innerHTML= LEAD_COLLECTION_LABEL.heading;   
+                document.getElementById('km-tab-title').innerHTML = LEAD_COLLECTION_LABEL.title;
             };
             _this.setEmojiHoverText = function () {
                 var ratingList = document.getElementsByClassName("mck-rating-box");


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> There was no label defined for the heading on the chat-box for pre-chat-lead-collection. It was still showing 'Conversations' so added a label for that.

> related docs issue: https://github.com/AppLozic/Kommunicate/pull/6327