### PR TITLE
Fix the issue where chat widget will not load after failing password check

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1623,6 +1623,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                             ALStorage.clearMckMessageArray();
                             ALStorage.clearMckContactNameArray();
                             if (result === "INVALID_PASSWORD") {
+                                KommunicateUtils.deleteUserCookiesOnLogout();
                                 Kommunicate.displayKommunicateWidget(false);
                                 if (typeof MCK_ON_PLUGIN_INIT === 'function') {
                                     MCK_ON_PLUGIN_INIT({


### PR DESCRIPTION

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> This PR will fix the issue where the chat widget will not load at all even after refreshing the page after the user was entering the wrong password either in pre-chat lead collection or by passing a variable in KommunicateSettings object.

### How was the code tested?
<!-- Be as specific as possible. -->

- Tried logging in through pre-chat lead collection with wrong credentials -> Got the invalid password error -> Refreshed the page -> Was able to load the widget and login again

- Tried logging in by passing credentials from KommunicateSettings object -> Got the invalid password error -> Refreshed the page -> Was able to load the widget and login again