### PR TITLE
Fix bug where message is not rendering when KM_ASSIGN_TO metadata is coming.

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5200,7 +5200,10 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 var messageClass= "vis";
                 var progressMeterClass = "n-vis";
                 var attachmentBox = "n-vis";
-                if((msg && msg.metadata && msg.metadata.feedback) || msg.metadata.KM_ASSIGN_TO){ // KM_ASSIGN_TO parameter comes when we change assignee by bot message.
+                if((msg && msg.metadata && msg.metadata.feedback)){
+                    return;
+                }
+                if (msg && !msg.message && msg.metadata.hasOwnProperty("KM_ASSIGN_TO")) { // KM_ASSIGN_TO parameter comes when we change assignee by bot message.
                     return;
                 }
                 if (typeof msg.metadata === "object" && typeof msg.metadata.AL_REPLY !== "undefined") {
@@ -7001,8 +7004,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                                             mckMessageLayout.addMessage(message, contact, true, true, validated);
                                         }
 
-                                        if (!message.metadata || (message.metadata.category !== 'HIDDEN' && message.metadata.hide !== "true" && contact.type !== 7) || message.metadata.KM_ASSIGN_TO) {
-
+                                        if (!message.metadata || (message.metadata.category !== 'HIDDEN' && message.metadata.hide !== "true" && contact.type !== 7) || (!message.message && message.metadata.hasOwnProperty("KM_ASSIGN_TO"))) {
                                             if(MCK_BOT_MESSAGE_DELAY !== 0 && _this.isMessageSentByBot(message, contact)) {
                                                 mckMessageLayout.addMessage(message, contact, true, true, validated, null, function() {
                                                     _this.processMessageInQueue(message);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix bug where the message is not rendering when KM_ASSIGN_TO metadata is coming.

### How was the code tested?
<!-- Be as specific as possible. -->
- Tested with Dialogflow and Lex bot.
- Case-1 
{
  "platform": "kommunicate",
  "message": "our agents will get back to you",
  "metadata": {
    "KM_ASSIGN_TO": "abhinav+testkm27042020@applozic.com"
  }
}
**Result**: Message should render in UI.

- Case-2 
{
  "platform": "kommunicate",
  "metadata": {
    "KM_ASSIGN_TO": "abhinav+testkm27042020@applozic.com"
  }
}
**Result**: No messge should render in UI.

NOTE: Make sure you're comparing your branch with the correct base branch