### PR TITLE
Add support for link in card carousel on the top of cards

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -1016,6 +1016,7 @@
     max-width: 240px;
     width:240px !important;
     margin:8px 4px 0 10px;
+    position: relative;
 }
 .tns-slider .km-carousel-card-template {
     margin:8px 4px 0 6px;
@@ -1066,6 +1067,14 @@
     padding-bottom: 6px;
     border: 1px solid #e7e4e4;
     border-top: 0;
+}
+.km-carousel-url-container {
+        position:absolute; 
+        width:100%;
+        height:100%;
+        top:0;
+        left: 0;
+        z-index: 1; 
 }
 .km-carousel-card-title-wrapper {
     display: flex;

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -258,8 +258,11 @@ getCarouselTemplate: function() {
 return `<div class="mck-msg-box-rich-text-container km-card-message-container  km-div-slider">
             {{#payload}}
             <div class="km-carousel-card-template">
+            <div class="km-carousel-card-header-container">
+            {{#url}}<a href = {{url}} target="_blank"><span class="km-carousel-url-container"></span></a>{{/url}}
             <div class="km-carousel-card-header {{carouselHeaderClass}}">{{{header}}}</div>
             <div class="km-carousel-card-content-wrapper {{carouselInfoWrapperClass}}">{{{info}}}</div>
+            </div>
             <div class="km-carousel-card-footer">{{{footer}}}</div>
             </div>
             {{/payload}}
@@ -591,6 +594,7 @@ Kommunicate.markup.getCarouselMarkup = function(options) {
             cardHtml.info = Kommunicate.markup.cardInfo(item);
             item.buttons && (cardHtml.footer = createCardFooter(item.buttons));
             cardList[i] = $applozic.extend([], cardHtml);
+            cardList[i].url = item.url;
         }
     }
     var cardCarousel = {payload:cardList};


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix the issue where URL coming in carousel type rich-messages coming in the google-assistant based payloads was not mapped in the rich-message displayed in chat widget.

### How was the code tested?
<!-- Be as specific as possible. -->
- Set a payload in Dialogflow fulfillment with carousel cards.
- Received the message in chat-widget in the form of a card carousel.
- All the items in the carousel are clickable and redirect to the URL in the payload.

![Screenshot 2020-05-12 at 1 32 06 PM](https://user-images.githubusercontent.com/16364023/81657884-e565b380-9455-11ea-9b58-5c3c1d170caf.png)
