### PR TITLE
fix google assistant carousel card title and description text overflow issue

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -1052,6 +1052,8 @@
     line-height: normal;
     letter-spacing: 0.6px;
     color: #141313;
+    word-break: break-word;
+    text-overflow: ellipsis;
 }
 .km-carousel-card-sub-title {
     font-size: 14px;
@@ -1124,6 +1126,8 @@
   color: #797474;
   height: auto;
   white-space: pre-line;
+  text-overflow: ellipsis;
+  word-break: break-word;
 }
 .km-carousel-card-description:before {
     content: '...';

--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -1062,6 +1062,11 @@
     color: #565454;
     margin-top: 4px;
     font-weight: 400;
+    overflow:hidden;
+    text-overflow: ellipsis;
+    overflow:hidden;
+    white-space:nowrap;
+    padding-right:20px;
 }
 .km-carousel-card-content-wrapper {
     padding-top: 6px;
@@ -1127,7 +1132,6 @@
   height: auto;
   white-space: pre-line;
   text-overflow: ellipsis;
-  word-break: break-word;
 }
 .km-carousel-card-description:before {
     content: '...';


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> fix google assistant carousel card title and description text overflow issue. **The change is for google assistant based carousel cards.**

### How was the code tested?
<!-- Be as specific as possible. -->
-> The following payload needs to passed from dialogflow fulfillment:
`new BrowseCarousel({
    items: [
      new BrowseCarouselItem({
        title: 'Title of item 1ddsfsafsdfsdfsafasffsdfasdfasdfsafsafasfsfsadasdf',
        url: 'https://example.com',
        description: 'Description of item 1dsfsfsdfasfasdfasdfasdfasdfsadfsadfsafsafsdfsadfsdfadsfasfasdfasdfsadfdasfasdfasdfasdfsafasdfasdfsadfasdfasdfasfasdfadsfasdfsafasdfas',
        image: new Image({
          url: 'https://storage.googleapis.com/actionsresources/logo_assistant_2x_64dp.png',
          alt: 'Image alternate text',
        }),
        footer: 'Item 1 footer',
      }),
      new BrowseCarouselItem({
        title: 'Title of item 2shdfjsahfkshfksjhfaskhfakjshf',
        url: 'https://facebook.com',
        description: 'Description of item 2sdfjshdfjashdljfhdsafhasfkashfklashflkasjhflkajs',
        image: new Image({
          url: 'https://storage.googleapis.com/actionsresources/logo_assistant_2x_64dp.png',
          alt: 'Image alternate text',
        }),
        footer: 'Item 2 footer',
      }),
    ],
  })`

Example: 

![Screenshot 2020-05-12 at 4 10 56 PM](https://user-images.githubusercontent.com/16364023/81674856-7dba6300-946b-11ea-9bea-e7d7452e2d58.png)
