### PR TITLE
FW-1075 Disable automatic open on navigation for mobile browsers screen on chat widget.

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -493,6 +493,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
         var CONNECT_SOCKET_ON_WIDGET_CLICK = appOptions.connectSocketOnWidgetClick;
         var SUBSCRIBE_TO_EVENTS_BACKUP = {};
         var DEFAULT_ENCRYPTED_APP_VERSION = 112;
+        kommunicateCommons.checkIfDeviceIsHandheld() && (MCK_MAINTAIN_ACTIVE_CONVERSATION_STATE = false);
 
         _this.toggleMediaOptions = function(){
             var mckTypingBox = document.getElementById("mck-text-box");


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Disable automatic open on navigation for mobile browsers screen on chat widget.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- By checking automatic open on navigation is working for mobile browsers screen. It shouldn't.

### What new thing you came across while writing this code? 
- checkIfDeviceIsHandheld function in our code base which is used to identify that browser is on mobile or not.

NOTE: Make sure you're comparing your branch with the correct base branch