### PR TITLE
Add SameSite param to sidebox cookies for future chrome release

### DIFF
--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -207,9 +207,10 @@ KommunicateUtils = {
         setCookie: function (cookie) {
         var cookiePrefix =this.getCookiePrefix();
         var name = (cookie && cookie.skipPrefix )?cookie.name: cookiePrefix+cookie.name;
+        var sameSite = cookie.sameSite ? cookie.sameSite : (this.isHttpsEnabledConnection() ? "None" : "Lax"); 
         var value =cookie.value;
         var path = "/";
-        var secure = typeof cookie.secure == "undefined"?this.isHttpsEnabledConnection():cookie.secure;
+        var secure = typeof cookie.secure == "undefined"?(sameSite == "None"):cookie.secure;
         var cookieExpiry= new Date("2038-01-19 04:14:07").toUTCString();
         var domain = cookie.domain;
         if(cookie.path){
@@ -220,7 +221,7 @@ KommunicateUtils = {
             cookieExpiry = new Date(today.setDate(today.getDate()+cookie.expiresInDays)).toUTCString();
         }
 
-        document.cookie = name + "=" + value + ";" + "expires="+cookieExpiry+ ";path="+path+(secure?";secure":"") +(domain?";domain="+domain:"");
+        document.cookie = name + "=" + value + ";" + "expires="+cookieExpiry+ ";path="+path+(secure?";secure":"") +(domain?";domain="+domain:"")+";SameSite="+sameSite;
     },
     getCookiePrefix : function(){
         var appOptions = KommunicateUtils.getDataFromKmSession("appOptions") || applozic._globals;

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -207,10 +207,10 @@ KommunicateUtils = {
         setCookie: function (cookie) {
         var cookiePrefix =this.getCookiePrefix();
         var name = (cookie && cookie.skipPrefix )?cookie.name: cookiePrefix+cookie.name;
-        var sameSite = cookie.sameSite ? cookie.sameSite : (this.isHttpsEnabledConnection() ? "None" : "Lax"); 
+        var sameSite = cookie.sameSite ? cookie.sameSite  : "Lax"; 
         var value =cookie.value;
         var path = "/";
-        var secure = typeof cookie.secure == "undefined"?(sameSite == "None"):cookie.secure;
+        var secure = typeof cookie.secure == "undefined"?this.isHttpsEnabledConnection():cookie.secure;
         var cookieExpiry= new Date("2038-01-19 04:14:07").toUTCString();
         var domain = cookie.domain;
         if(cookie.path){


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Add SameSite param to sidebox cookies for future chrome release.
SameSite param decides how cookies are stored and treated in cross-origin requests.
This will remove the warnings related to the same - currently displayed in the browser console.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-> Simulated a future release of chrome by setting some flags and checked the if the cookies were being stored.


> Need for this change: https://www.troyhunt.com/promiscuous-cookies-and-their-impending-death-via-the-samesite-policy/
