### PR TITLE
FW-1099 Add property to disable/hide the widget.

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -306,6 +306,14 @@ function ApplozicSidebox() {
         try {
             var options = applozic._globals;
             var widgetSettings = data.chatWidget;
+            var disableChatWidget = options.disableChatWidget != null ? options.disableChatWidget : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
+            
+            // Remove scripts if disableChatWidget property is enabled
+            if ( disableChatWidget ) {
+                parent.window && parent.window.removeKommunicateScripts();
+                return false;
+            }
+
             var sessionTimeout = options.sessionTimeout;
             sessionTimeout == null && (sessionTimeout = widgetSettings && widgetSettings.sessionTimeout);
             options['appSettings'] = $applozic.extend(true, data, options.appSettings);

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -309,7 +309,7 @@ function ApplozicSidebox() {
             var disableChatWidget = options.disableChatWidget != null ? options.disableChatWidget : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
             
             // Remove scripts if disableChatWidget property is enabled
-            if ( disableChatWidget ) {
+            if (disableChatWidget) {
                 parent.window && parent.window.removeKommunicateScripts();
                 return false;
             }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add property to disable/hide the widget.
- Property Name: "disableChatWidget"
- If disableChatWidget is true then Kommunicate widget won't be loaded on the customer website.
- Priority will be given to appOptions if the property is passed in Kommunicate script over appSettings table data.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- By adding the property in chatWidget column in appSettings table and checking that widget is getting loaded or not.

NOTE: Make sure you're comparing your branch with the correct base branch