### PR TITLE
allow word break in away message

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -676,6 +676,7 @@
     }  
     #mck-away-msg {
         white-space: pre-line;
+        word-break: break-word;
     }
     .mck-collect-email {
         font-size: 14px;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Allow longer words [URLs] in most cases to break in away message section.

![image](https://user-images.githubusercontent.com/34703178/84002004-57fa7e00-a985-11ea-8dfd-e3e6ecd433cb.png)


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Using the following text 
`We are away right now, drop your query and we'll get back soon.

For technical queries, post question on Stackoverflow https://stackoverflow.com/questions/tagged/kommunicate`
