### PR TITLE
Add support to convert urls in away message to anchor tag

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -29,12 +29,15 @@ KommunicateUI={
             KommunicateUI.displayLeadCollectionTemplate(data);
         } 
     },
-    populateAwayMessage:function(err,message){
+    populateAwayMessage:function(err,message){  
         var conversationWindowNotActive = $applozic("#mck-tab-individual").hasClass('n-vis');
         var closedConversation = $applozic("#mck-conversation-status-box").hasClass('vis');
         if(!err && message.code =="SUCCESS" &&message.data.messageList.length>0 &&!conversationWindowNotActive && !closedConversation){ 
             awayMessage =message.data.messageList[0].message;
             $applozic("#mck-away-msg").html(awayMessage);
+            $applozic("#mck-away-msg").linkify({
+                target: '_blank'
+            });
             $applozic("#mck-away-msg-box").removeClass("n-vis").addClass("vis");     
         } else {
             $applozic("#mck-away-msg-box").removeClass("vis").addClass("n-vis");


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-> Add support to automatically render all urls mentioned in away message as actual anchor tag links.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.

### How was the code tested?
<!-- Be as specific as possible. -->
-> Set away message from dashboard with text containing a link and it was displayed as a link while in the chat-widget.
![Screenshot 2020-06-18 at 4 37 28 AM](https://user-images.githubusercontent.com/16364023/84959792-afcf7c80-b11d-11ea-96e5-ddf2ce53e604.png)

NOTE: Make sure you're comparing your branch with the correct base branch