### PR TITLE
TD-977 Add labels for "hrs ago" || "minutes ago" || "sec ago" in conversation list view in Kommunicate Widget.

### DIFF
--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -92,17 +92,18 @@ function KommunicateCommons() {
     };
 
     _this.getTimeOrDate = function (createdAtTime) {
+        var timeStampLabels = MCK_LABELS['time.stamp'];
         var timeStamp = new Date(createdAtTime);
         var currentTime = new Date(),
             secondsPast = Math.max(0, (currentTime.getTime() - timeStamp.getTime()) / 1000);
         if (secondsPast < 60) {
-            return (parseInt(secondsPast) <= 1) ? parseInt(secondsPast) + ' sec ago' : parseInt(secondsPast) + ' secs ago';
+            return parseInt(secondsPast) + ' ' + ((parseInt(secondsPast) <= 1) ? timeStampLabels['sec.ago'] : timeStampLabels['secs.ago']);
         }
         if (secondsPast < 3600) {
-            return (parseInt(secondsPast / 60) <= 1) ? parseInt(secondsPast / 60) + ' min ago' : parseInt(secondsPast / 60) + ' mins ago';
+            return parseInt(secondsPast / 60) + ' ' + ((parseInt(secondsPast / 60) <= 1) ? timeStampLabels['min.ago'] : timeStampLabels['mins.ago']);
         }
         if (secondsPast <= 172800) {
-            return (parseInt(secondsPast / 3600) <= 1) ? parseInt(secondsPast / 3600) + ' hr ago' : parseInt(secondsPast / 3600) + ' hrs ago';
+            return parseInt(secondsPast / 3600) + ' ' + ((parseInt(secondsPast / 3600) <= 1) ? timeStampLabels['hr.ago'] : timeStampLabels['hrs.ago']);
         }
         if (secondsPast > 172800) {
             day = timeStamp.getDate();

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -144,5 +144,13 @@ Kommunicate.defaultLabels = {
     'faq.query.message': {
         'QUERY_REGARDING': 'Hi, I have a query regarding',
         'HELP_YOU': 'Can you help me out?'
+    },
+    'time.stamp': {
+        'sec.ago': 'sec ago',
+        'secs.ago': 'secs ago',
+        'min.ago': 'min ago',
+        'mins.ago': 'mins ago',
+        'hr.ago': 'hr ago',
+        'hrs.ago': 'hrs ago'
     }
 }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add labels for "hrs ago" || "minutes ago" || "sec ago" in conversation list view in Kommuniate Widget.
- Improve some checks.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- By checking that labels are changing or not.
`
"labels": {
    'time.stamp': {
        'sec.ago': 'sec ago',
        'secs.ago': 'secs ago',
        'min.ago': 'min ago',
        'mins.ago': 'mins ago',
        'hr.ago': 'hr ago',
        'hrs.ago': 'hrs ago'
    }
}
`

NOTE: Make sure you're comparing your branch with the correct base branch