### PR TITLE
Do not call getDomainFromUrl method multiple times

### DIFF
--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -342,21 +342,17 @@ KommunicateUtils = {
         document.cookie = value + "=;expires=Thu, 01 Jan 1970 00:00:01 GMT;domain=" + domain + ";";
         return domain
     },
-    getDomainFromUrl: function () {
-        return KommunicateUtils.findCookieDomain(document.domain);
-    },
     getSubDomain : function(){
          var hostName = parent.window.location.hostname;
-         var domainLength= this.getDomainFromUrl(hostName).length;
+         var domainLength= MCK_COOKIE_DOMAIN.length;
          var subDomain =hostName.substr(0,hostName.length - domainLength);
          return subDomain;
     },
     deleteUserCookiesOnLogout : function(){
-        var cookieDomain  = KommunicateUtils.getDomainFromUrl();
-        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,domain: KommunicateUtils.getDomainFromUrl()});
-        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_USERNAME, domain: KommunicateUtils.getDomainFromUrl()});
-        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,  domain: KommunicateUtils.getDomainFromUrl()});
-        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.ACCESS_TOKEN, domain: KommunicateUtils.getDomainFromUrl()});
+        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,domain: MCK_COOKIE_DOMAIN});
+        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_USERNAME, domain:MCK_COOKIE_DOMAIN });
+        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,  domain: MCK_COOKIE_DOMAIN});
+        KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.ACCESS_TOKEN, domain: MCK_COOKIE_DOMAIN});
     },
     isValidTimeZone : function(tzId) {
         if (!Intl || !Intl.DateTimeFormat().resolvedOptions().timeZone) {

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -303,7 +303,7 @@ $applozic.extend(true,Kommunicate,{
     updateUserIdentity: function (newUserId) {
         window.$applozic.fn.applozic('updateUserIdentity', {
             newUserId: newUserId, callback: function (response) {
-                KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,"value": newUserId,expiresInDays:30,domain:KommunicateUtils.getDomainFromUrl()});
+                KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,"value": newUserId,expiresInDays:30,domain: MCK_COOKIE_DOMAIN});
                 if (response == 'success') {
                     window.$applozic.fn.applozic('reInitialize', { userId: newUserId });
                 }

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -1,6 +1,7 @@
 var $original;
 var oModal = "";
 var sentryConfig = MCK_THIRD_PARTY_INTEGRATION.sentry;
+var MCK_COOKIE_DOMAIN;
 if (typeof jQuery !== 'undefined') {
     $original = jQuery.noConflict(true);
     $ = $original;
@@ -235,6 +236,7 @@ function ApplozicSidebox() {
     function mckInitPluginScript() {
         try {
             var options = applozic._globals;
+            MCK_COOKIE_DOMAIN = KommunicateUtils.findCookieDomain(document.domain);
             for (var index in mck_third_party_scripts) {
                 var data = mck_third_party_scripts[index];
                 if (data.name === "locationPicker") {
@@ -445,15 +447,14 @@ function ApplozicSidebox() {
         });
     };
     function saveUserCookies(kommunicateSettings){
-        var cookieDomain  = KommunicateUtils.getDomainFromUrl();
-        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,"value": kommunicateSettings.userId, "expiresInDays":30, domain: cookieDomain});
-        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_USERNAME,"value": kommunicateSettings.userName ||"", "expiresInDays":30,domain: cookieDomain});
+        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,"value": kommunicateSettings.userId, "expiresInDays":30, domain: MCK_COOKIE_DOMAIN});
+        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_USERNAME,"value": kommunicateSettings.userName ||"", "expiresInDays":30,domain: MCK_COOKIE_DOMAIN});
         if (!(kommunicateSettings.preLeadCollection || kommunicateSettings.askUserDetails)) {
-            KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,"value": false, "expiresInDays":30, domain: cookieDomain});
+            KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,"value": false, "expiresInDays":30, domain: MCK_COOKIE_DOMAIN});
         }
         if(kommunicateSettings.accessToken){
             var encodedToken = window.btoa(kommunicateSettings.accessToken);
-            KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.ACCESS_TOKEN,"value": encodedToken || "", "expiresInDays":30,domain: cookieDomain});
+            KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.ACCESS_TOKEN,"value": encodedToken || "", "expiresInDays":30,domain: MCK_COOKIE_DOMAIN});
         }
     };
     

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -954,8 +954,8 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 // Below function will clearMckMessageArray, clearAppHeaders, clearMckContactNameArray, removeEncryptionKey
                 ALStorage.clearSessionStorageElements();
                 $applozic.fn.applozic("reset", appOptions);
-                KommunicateUtils.deleteCookie({name :KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_USERNAME, domain: KommunicateUtils.getDomainFromUrl()});
-                KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID, domain: KommunicateUtils.getDomainFromUrl()});
+                KommunicateUtils.deleteCookie({name :KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_USERNAME, domain: MCK_COOKIE_DOMAIN});
+                KommunicateUtils.deleteCookie({name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID, domain: MCK_COOKIE_DOMAIN});
                 $applozic("#mck-sidebox").hide();
                 $applozic("#mck-sidebox-launcher").hide();
                 parent.document.getElementById("kommunicate-widget-iframe") && (parent.document.getElementById("kommunicate-widget-iframe").style.display = "none");
@@ -2986,8 +2986,8 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     }
                     if(email){
                         userId = email;
-                        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,"value": email, "expiresInDays":30, domain: KommunicateUtils.getDomainFromUrl()});
-                        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,"value": true, "expiresInDays":30, domain: KommunicateUtils.getDomainFromUrl()});
+                        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,"value": email, "expiresInDays":30, domain: MCK_COOKIE_DOMAIN});
+                        KommunicateUtils.setCookie({"name":KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,"value": true, "expiresInDays":30, domain: MCK_COOKIE_DOMAIN});
                     }
                     var metadata = mckMessageService.getUserMetadata();
                     $error_chat_login.removeClass('show').addClass('hide');


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- do not call getDomainFromUrl method multiple times

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- findCookieDomain method is getting called only once. useful screenshots are attached below.

### In case you fixed a bug then please describe the root cause of it? 
- getDomainFromUrl method is called multiple places, along with that findCookieDomain method also called. 
- findCookieDomain method tries to find domain by adding "km_{timestamp}" on the cookie and once it is a success, km_{timestamp} be removed from the cookie but chrome always shows deleted cookie in "cookie in use".

**BEFORE** FIX: 
- on screenshot check the "cookie in use" and  browser bottom panel cookies under storage

![Screen Shot 2020-08-12 at 3 45 18 PM](https://user-images.githubusercontent.com/34020392/90004234-ed322f80-dcb2-11ea-8e66-a299b87632b5.png)


- **AFTER** FIX:

![Screen Shot 2020-08-12 at 5 05 34 PM](https://user-images.githubusercontent.com/34020392/90010776-1ad0a600-dcbe-11ea-9f11-a1b845bf0ffb.png)

-  findCookieDomain method should be executed only once when the user loads the script.

NOTE: Make sure you're comparing your branch with the correct base branch