### PR TITLE
FW 1376 support for teamId

### DIFF
--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -42,6 +42,7 @@ Kommunicate.client={
      */
      createConversation : function(conversationDetail,callback){
         var chatContext =  $applozic.extend(Kommunicate.getSettings("KM_CHAT_CONTEXT"),conversationDetail.metadata ?conversationDetail.metadata["KM_CHAT_CONTEXT"]:{});
+        var appOptions = KommunicateUtils.getDataFromKmSession('appOptions');
 
         var userLocale = kommunicate._globals.userLocale;
         var currentLanguage = {
@@ -69,7 +70,7 @@ Kommunicate.client={
             KM_CHAT_CONTEXT: JSON.stringify(chatContext),
             GROUP_CREATION_URL: parent.location.href
         };
-
+        appOptions.teamId && (groupMetadata.KM_TEAM_ID = appOptions.teamId);
         conversationDetail.metadata.KM_ORIGINAL_TITLE && (groupMetadata.KM_ORIGINAL_TITLE = true);
         conversationDetail.skipBotEvent && (groupMetadata.SKIP_BOT_EVENT = conversationDetail.skipBotEvent);
         conversationDetail.customWelcomeEvent && (groupMetadata.CUSTOM_WELCOME_EVENT = conversationDetail.customWelcomeEvent);

--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -42,7 +42,6 @@ Kommunicate.client={
      */
      createConversation : function(conversationDetail,callback){
         var chatContext =  $applozic.extend(Kommunicate.getSettings("KM_CHAT_CONTEXT"),conversationDetail.metadata ?conversationDetail.metadata["KM_CHAT_CONTEXT"]:{});
-        var appOptions = KommunicateUtils.getDataFromKmSession('appOptions');
 
         var userLocale = kommunicate._globals.userLocale;
         var currentLanguage = {
@@ -70,7 +69,7 @@ Kommunicate.client={
             KM_CHAT_CONTEXT: JSON.stringify(chatContext),
             GROUP_CREATION_URL: parent.location.href
         };
-        appOptions.teamId && (groupMetadata.KM_TEAM_ID = appOptions.teamId);
+        typeof conversationDetail.teamId != "undefined"  && (groupMetadata.KM_TEAM_ID = conversationDetail.teamId);
         conversationDetail.metadata.KM_ORIGINAL_TITLE && (groupMetadata.KM_ORIGINAL_TITLE = true);
         conversationDetail.skipBotEvent && (groupMetadata.SKIP_BOT_EVENT = conversationDetail.skipBotEvent);
         conversationDetail.customWelcomeEvent && (groupMetadata.CUSTOM_WELCOME_EVENT = conversationDetail.customWelcomeEvent);

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -69,7 +69,8 @@ $applozic.extend(true,Kommunicate,{
             "skipRouting": params.skipRouting,
             "skipBotEvent": params.skipBotEvent,
             "customWelcomeEvent": params.customWelcomeEvent,
-            "metadata": groupMetadata
+            "metadata": groupMetadata,
+            "teamId": params.teamId 
         };
         if (IS_SOCKET_CONNECTED) {
             Kommunicate.client.createConversation(conversationDetail, callback);
@@ -104,7 +105,7 @@ $applozic.extend(true,Kommunicate,{
         conversationDetail.skipRouting = conversationDetail.skipRouting || kommunicateSettings.skipRouting;
         conversationDetail.skipBotEvent = conversationDetail.skipBotEvent || kommunicateSettings.skipBotEvent;
         conversationDetail.customWelcomeEvent = conversationDetail.customWelcomeEvent || kommunicateSettings.customWelcomeEvent;
-
+        conversationDetail.teamId = conversationDetail.teamId || kommunicateSettings.teamId;
         return conversationDetail;
     },
     openConversationList: function () {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- assign the conversation to a particular team by adding parameter teamId .

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- KM_TEAM_ID is added into group metadata in below mentioned test cases
- script:

`(function(d, m){
        var defaultSettings={"teamId": 7}
        var kommunicateSettings = {"appId":"102797803a1e00dccfa83eaf700f2b28a","popupWidget":true,"automaticChatOpenOnNavigation":true, "onInit": function() {Kommunicate.updateSettings(defaultSettings);}};
        var s = document.createElement("script"); s.type = "text/javascript"; s.async = true;
        s.src = "http://localhost:3030/v2/kommunicate.app";
        var h = document.getElementsByTagName("head")[0]; h.appendChild(s);
        window.kommunicate = m; m._globals = kommunicateSettings;
      })(document, window.kommunicate || {});`

- tested with `Kommunicate.updateSettings(defaultSettings);` and `Kommunicate.startConversation();` functions 

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch