### PR TITLE
Disable chat widget if Allowed Domains is set

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -320,13 +320,11 @@ function ApplozicSidebox() {
             }
 
             // Remove scripts if chatwidget is restricted by domains
-            if (Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.some(isSubDomain)){
-                parent.window && parent.window.removeKommunicateScripts();
-                return false;
-            }
+            var isCurrentDomainAllowed = Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.some(isSubDomain);
 
             // Remove scripts if disableChatWidget property is enabled
-            if (disableChatWidget) {
+            // or domain restrictions are enabled
+            if (disableChatWidget || isCurrentDomainAllowed) {
                 parent.window && parent.window.removeKommunicateScripts();
                 return false;
             }

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -311,10 +311,12 @@ function ApplozicSidebox() {
             var disableChatWidget = options.disableChatWidget != null ? options.disableChatWidget : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
             
             var allowedDomains = widgetSettings.allowedDomains;
-            var host = parent.window.location.host;
+            var hostname = parent.window.location.hostname;
+
+            const isSubDomain = (domain) => hostname.endsWith(domain);
 
             // Remove scripts if chatwidget is restricted by domains
-            if (Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.includes(host)){
+            if (Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.some(isSubDomain)){
                 parent.window && parent.window.removeKommunicateScripts();
                 return false;
             }

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -309,7 +309,15 @@ function ApplozicSidebox() {
             var options = applozic._globals;
             var widgetSettings = data.chatWidget;
             var disableChatWidget = options.disableChatWidget != null ? options.disableChatWidget : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
-            
+            var allowedDomains = widgetSettings.allowedDomains;
+            var host = parent.window.location.host;
+            console.log(host);
+            if (Array.isArray(allowedDomains) && allowedDomains.length){
+              if(!allowedDomains.includes(host)){
+                parent.window && parent.window.removeKommunicateScripts();
+                return false;
+              }
+            }
             // Remove scripts if disableChatWidget property is enabled
             if (disableChatWidget) {
                 parent.window && parent.window.removeKommunicateScripts();

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -309,15 +309,16 @@ function ApplozicSidebox() {
             var options = applozic._globals;
             var widgetSettings = data.chatWidget;
             var disableChatWidget = options.disableChatWidget != null ? options.disableChatWidget : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
+            
             var allowedDomains = widgetSettings.allowedDomains;
             var host = parent.window.location.host;
-            console.log(host);
-            if (Array.isArray(allowedDomains) && allowedDomains.length){
-              if(!allowedDomains.includes(host)){
+
+            // Remove scripts if chatwidget is restricted by domains
+            if (Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.includes(host)){
                 parent.window && parent.window.removeKommunicateScripts();
                 return false;
-              }
             }
+
             // Remove scripts if disableChatWidget property is enabled
             if (disableChatWidget) {
                 parent.window && parent.window.removeKommunicateScripts();

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -313,7 +313,11 @@ function ApplozicSidebox() {
             var allowedDomains = widgetSettings.allowedDomains;
             var hostname = parent.window.location.hostname;
 
-            const isSubDomain = (domain) => hostname.endsWith(domain);
+            // check if the current hostname is equal to or a subdomain
+            // e.g. www.google.com is a subdomain of google.com
+            const isSubDomain = (domain) => {
+                return ((hostname == domain) || ((hostname.length > domain.length) && (hostname.substr(hostname.length-domain.length-1) == "." + domain)));
+            }
 
             // Remove scripts if chatwidget is restricted by domains
             if (Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.some(isSubDomain)){

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -311,7 +311,7 @@ function ApplozicSidebox() {
             var disableChatWidget = options.disableChatWidget != null ? options.disableChatWidget : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
             
             var allowedDomains = widgetSettings.allowedDomains;
-            var hostname = parent.window.location.hostname;
+            var hostname = parent.window.location.hostname.toLowerCase();
 
             // check if the current hostname is equal to or a subdomain
             // e.g. www.google.com is a subdomain of google.com
@@ -320,11 +320,11 @@ function ApplozicSidebox() {
             }
 
             // Remove scripts if chatwidget is restricted by domains
-            var isCurrentDomainAllowed = Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.some(isSubDomain);
+            var isCurrentDomainDisabled = Array.isArray(allowedDomains) && allowedDomains.length && !allowedDomains.some(isSubDomain);
 
             // Remove scripts if disableChatWidget property is enabled
             // or domain restrictions are enabled
-            if (disableChatWidget || isCurrentDomainAllowed) {
+            if (disableChatWidget || isCurrentDomainDisabled) {
                 parent.window && parent.window.removeKommunicateScripts();
                 return false;
             }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- We want to be able to restrict the chat widget from running on domains that are not inside the list of allowed domains specified by the customer. This PR will check the current host from which the chat widget is running and block if it's not in the specified list.

(if running from localhost then the port number must match too)

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Ran the modified changes locally and tested the results.

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch