### PR TITLE
Add voice output in chat widget

### DIFF
--- a/webplugin/js/app/events/applozic-event-handler.js
+++ b/webplugin/js/app/events/applozic-event-handler.js
@@ -27,6 +27,9 @@ Kommunicate.KmEventHandler = {
         if (!message.metadata || (validMessageMetadata)) {
             // hiding away message when new message received from agents.
             KommunicateUI.hideAwayMessage();
+            // Send the message for voice output
+            Kommunicate.mediaService.voiceOutputIncomingMessage(message);
+
         }
     },
     'onMessageSent': function(message){

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -152,5 +152,14 @@ Kommunicate.defaultLabels = {
         'mins.ago': 'mins ago',
         'hr.ago': 'hr ago',
         'hrs.ago': 'hrs ago'
+    },
+    'voice.output': {
+        'location': {
+            'init': 'A location has been shared with you.',
+            'lat': 'Latitude is ',
+            'lon': 'and Longitude is '
+
+        },
+        'attachment': 'You have an attachment.'
     }
 }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9841,7 +9841,6 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                             };
                         };
                         if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
-                        Kommunicate.mediaService.voiceOutputIncomingMessage(resp);
                             var messageFeed = mckMessageLayout.getMessageFeed(message);
                             Kommunicate.KmEventHandler.onMessageReceived(message);
                             // events.onMessageReceived({

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9846,8 +9846,23 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                                 console.log(JSON.stringify(resp));
                                 if (appOptions.voiceOutput && "speechSynthesis" in window){
                                     console.log(appOptions.voiceOutput);
-                                    if (resp.message.message) {
-                                    var utterance = new SpeechSynthesisUtterance(resp.message.message);
+                                    if (resp.message) {
+                                        var textToSpeak = "";
+                                        if(resp.message.hasOwnProperty("fileMeta")){
+                                            console.log("file");
+                                            textToSpeak += "you have an attachment ";
+                                            textToSpeak += resp.message.fileMeta.name;
+                                        }
+                                        else if (resp.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
+                                            textToSpeak += "a location has been shared with you ";
+                                            textToSpeak += resp.message.message;
+
+                                        }
+                                        else {
+                                            textToSpeak += resp.message.message;
+
+                                        }
+                                    var utterance = new SpeechSynthesisUtterance(textToSpeak);
                                     utterance.onerror = ev =>{
                     console.log(ev.error);
                                     };

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -63,7 +63,8 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             'disableChatForNonGroupMember': false,
             'defaultChatDisabledMessage': 'Chat Disabled!'
         },
-        voiceInput:false
+        voiceInput:false,
+        voiceOutput:false
     };
     var message_default_options = {
         'messageType': 5,
@@ -525,6 +526,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             mckMessageService.openChat(params)
         };
 
+
         var EVENTS = {
             'onConnectFailed': function (resp) {
                 console.log('onConnectFailed' + resp)
@@ -560,6 +562,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             'onConversationRead': function (resp) {
             },
             'onMessageReceived': function (resp) {
+                
             },
             'onMessageSentUpdate': function (resp) {
             },
@@ -9577,6 +9580,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             };
 
             _this.onMessage = function (resp) {
+
                 // In case of encryption enabled, response is comming after getting decrypted from the parent function.
                 typeof resp.message == "object" && $mck_msg_inner.data('last-message-received-time', resp.message.createdAtTime);
                 var messageType = resp.type;
@@ -9837,6 +9841,22 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                             };
                         };
                         if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
+                            
+                            
+                                console.log(JSON.stringify(resp));
+                                if (appOptions.voiceOutput && "speechSynthesis" in window){
+                                    console.log(appOptions.voiceOutput);
+                                    if (resp.message.message) {
+                                    var utterance = new SpeechSynthesisUtterance(resp.message.message);
+                                    utterance.onerror = ev =>{
+                    console.log(ev.error);
+                                    };
+                                    speechSynthesis.speak(utterance);
+                                    }
+                                }
+                    
+                            
+
                             var messageFeed = mckMessageLayout.getMessageFeed(message);
                             Kommunicate.KmEventHandler.onMessageReceived(message);
                             // events.onMessageReceived({

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9841,37 +9841,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                             };
                         };
                         if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
-                            
-                            
-                                console.log(JSON.stringify(resp));
-                                if (appOptions.voiceOutput && "speechSynthesis" in window){
-                                    console.log(appOptions.voiceOutput);
-                                    if (resp.message) {
-                                        var textToSpeak = "";
-                                        if(resp.message.hasOwnProperty("fileMeta")){
-                                            console.log("file");
-                                            textToSpeak += "you have an attachment ";
-                                            textToSpeak += resp.message.fileMeta.name;
-                                        }
-                                        else if (resp.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
-                                            textToSpeak += "a location has been shared with you ";
-                                            textToSpeak += resp.message.message;
-
-                                        }
-                                        else {
-                                            textToSpeak += resp.message.message;
-
-                                        }
-                                    var utterance = new SpeechSynthesisUtterance(textToSpeak);
-                                    utterance.onerror = ev =>{
-                    console.log(ev.error);
-                                    };
-                                    speechSynthesis.speak(utterance);
-                                    }
-                                }
-                    
-                            
-
+                        Kommunicate.mediaService.voiceOutputIncomingMessage(resp);
                             var messageFeed = mckMessageLayout.getMessageFeed(message);
                             Kommunicate.KmEventHandler.onMessageReceived(message);
                             // events.onMessageReceived({

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -47,22 +47,28 @@ voiceOutputIncomingMessage: function(resp){
 
     if (appOptions.voiceOutput && "speechSynthesis" in window){
         console.log(appOptions.voiceOutput);
-        if (resp.message) {
-            var textToSpeak = "";
+        var textToSpeak = "";
+        if (resp.message) { 
             if(resp.message.hasOwnProperty("fileMeta")){
                 console.log("file");
                 textToSpeak += "you have an attachment ";
                 textToSpeak += resp.message.fileMeta.name;
             }
             else if (resp.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
-                textToSpeak += "a location has been shared with you ";
+                coord = JSON.parse(resp.message.message);
+                console.log(JSON.stringify(coord));
+                textToSpeak += "a location has been shared with you. Latitude is ";
+                textToSpeak += Math.round(coord.lat * 100) / 100;
+                textToSpeak += " longitude is "
+                textToSpeak += Math.round(coord.lon* 100) / 100;
+
+            }
+            else if (resp.message.message) {
                 textToSpeak += resp.message.message;
 
             }
-            else {
-                textToSpeak += resp.message.message;
-
-            }
+        }
+        if (textToSpeak) {
         var utterance = new SpeechSynthesisUtterance(textToSpeak);
         utterance.onerror = ev =>{
 console.log(ev.error);

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -41,38 +41,37 @@ Kommunicate.mediaService = {
 ;            }
         }
     },
-voiceOutputIncomingMessage: function(message){
-    // get appoptions
-    var appOptions = KommunicateUtils.getDataFromKmSession("appOptions");
+    voiceOutputIncomingMessage: function(message){
+        // get appoptions
+        var appOptions = KommunicateUtils.getDataFromKmSession("appOptions");
 
-    // if voiceoutput is enabled and browser supports it
-    if (appOptions.voiceOutput && "speechSynthesis" in window){
-        var textToSpeak = "";
-        if (message) { 
-            if(message.hasOwnProperty("fileMeta")){
-                textToSpeak += MCK_LABELS['voice.output'].attachment;
-                textToSpeak += message.fileMeta.name;
-            }
-            else if (message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
-                coord = JSON.parse(message.message);
-                textToSpeak +=  MCK_LABELS['voice.output'].location.init;
-                textToSpeak += MCK_LABELS['voice.output'].location.lat + Math.round(coord.lat * 100) / 100;
-                textToSpeak += MCK_LABELS['voice.output'].location.lon + Math.round(coord.lon* 100) / 100;
+        // if voiceoutput is enabled and browser supports it
+        if (appOptions.voiceOutput && "speechSynthesis" in window){
+            var textToSpeak = "";
+            if (message) { 
+                if(message.hasOwnProperty("fileMeta")){
+                    textToSpeak += MCK_LABELS['voice.output'].attachment;
+                    textToSpeak += message.fileMeta.name;
+                }
+                else if (message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
+                    coord = JSON.parse(message.message);
+                    textToSpeak +=  MCK_LABELS['voice.output'].location.init;
+                    textToSpeak += MCK_LABELS['voice.output'].location.lat + Math.round(coord.lat * 100) / 100;
+                    textToSpeak += MCK_LABELS['voice.output'].location.lon + Math.round(coord.lon* 100) / 100;
+                }
+                else if (message.message) {
+                    textToSpeak += message.message;
 
+                }
             }
-            else if (message.message) {
-                textToSpeak += message.message;
-
-            }
-        }
-        if (textToSpeak) {
-        var utterance = new SpeechSynthesisUtterance(textToSpeak);
+            if (textToSpeak) {
+                var utterance = new SpeechSynthesisUtterance(textToSpeak);
         
-        utterance.onerror = ev =>{
-            console.log("Error occured in speech synthesis " + ev.error);
-        };
-        speechSynthesis.speak(utterance);
+                utterance.onerror = ev => {
+                    throw new Error("Error in converting message to voice");
+                };
+                speechSynthesis.speak(utterance);
+            }
         }
     }
-}
 }

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -68,7 +68,7 @@ Kommunicate.mediaService = {
                 var utterance = new SpeechSynthesisUtterance(textToSpeak);
         
                 utterance.onerror = ev => {
-                    throw new Error("Error in converting message to voice");
+                    throw new Error("Error while converting the message to voice.");
                 };
                 speechSynthesis.speak(utterance);
             }

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -50,15 +50,14 @@ voiceOutputIncomingMessage: function(message){
         var textToSpeak = "";
         if (message) { 
             if(message.hasOwnProperty("fileMeta")){
-                textToSpeak += "You have an attachment.";
+                textToSpeak += MCK_LABELS['voice.output'].attachment;
                 textToSpeak += message.fileMeta.name;
             }
             else if (message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
                 coord = JSON.parse(message.message);
-                textToSpeak += "A location has been shared with you. Latitude is ";
-                textToSpeak += Math.round(coord.lat * 100) / 100;
-                textToSpeak += " and Longitude is "
-                textToSpeak += Math.round(coord.lon* 100) / 100;
+                textToSpeak +=  MCK_LABELS['voice.output'].location.init;
+                textToSpeak += MCK_LABELS['voice.output'].location.lat + Math.round(coord.lat * 100) / 100;
+                textToSpeak += MCK_LABELS['voice.output'].location.lon + Math.round(coord.lon* 100) / 100;
 
             }
             else if (message.message) {

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -41,5 +41,34 @@ Kommunicate.mediaService = {
 ;            }
         }
     },
+voiceOutputIncomingMessage: function(resp){
+    console.log(JSON.stringify(resp));
+    var appOptions = KommunicateUtils.getDataFromKmSession("appOptions");
 
+    if (appOptions.voiceOutput && "speechSynthesis" in window){
+        console.log(appOptions.voiceOutput);
+        if (resp.message) {
+            var textToSpeak = "";
+            if(resp.message.hasOwnProperty("fileMeta")){
+                console.log("file");
+                textToSpeak += "you have an attachment ";
+                textToSpeak += resp.message.fileMeta.name;
+            }
+            else if (resp.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
+                textToSpeak += "a location has been shared with you ";
+                textToSpeak += resp.message.message;
+
+            }
+            else {
+                textToSpeak += resp.message.message;
+
+            }
+        var utterance = new SpeechSynthesisUtterance(textToSpeak);
+        utterance.onerror = ev =>{
+console.log(ev.error);
+        };
+        speechSynthesis.speak(utterance);
+        }
+    }
+}
 }

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -41,37 +41,36 @@ Kommunicate.mediaService = {
 ;            }
         }
     },
-voiceOutputIncomingMessage: function(resp){
-    console.log(JSON.stringify(resp));
+voiceOutputIncomingMessage: function(message){
+    // get appoptions
     var appOptions = KommunicateUtils.getDataFromKmSession("appOptions");
 
+    // if voiceoutput is enabled and browser supports it
     if (appOptions.voiceOutput && "speechSynthesis" in window){
-        console.log(appOptions.voiceOutput);
         var textToSpeak = "";
-        if (resp.message) { 
-            if(resp.message.hasOwnProperty("fileMeta")){
-                console.log("file");
-                textToSpeak += "you have an attachment ";
-                textToSpeak += resp.message.fileMeta.name;
+        if (message) { 
+            if(message.hasOwnProperty("fileMeta")){
+                textToSpeak += "You have an attachment.";
+                textToSpeak += message.fileMeta.name;
             }
-            else if (resp.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
-                coord = JSON.parse(resp.message.message);
-                console.log(JSON.stringify(coord));
-                textToSpeak += "a location has been shared with you. Latitude is ";
+            else if (message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION){
+                coord = JSON.parse(message.message);
+                textToSpeak += "A location has been shared with you. Latitude is ";
                 textToSpeak += Math.round(coord.lat * 100) / 100;
-                textToSpeak += " longitude is "
+                textToSpeak += " and Longitude is "
                 textToSpeak += Math.round(coord.lon* 100) / 100;
 
             }
-            else if (resp.message.message) {
-                textToSpeak += resp.message.message;
+            else if (message.message) {
+                textToSpeak += message.message;
 
             }
         }
         if (textToSpeak) {
         var utterance = new SpeechSynthesisUtterance(textToSpeak);
+        
         utterance.onerror = ev =>{
-console.log(ev.error);
+            console.log("Error occured in speech synthesis " + ev.error);
         };
         speechSynthesis.speak(utterance);
         }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- We want to add the functionality of enabling a new option voiceOutput in the chatWidget settings. When it is true, the browser will convert incoming messages to voice and speak them to the user.

Currently, only text messages, location and attachment messages will be converted to voice.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- By running the chat widget and testing incoming messages from the dashboard.

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch