### PR TITLE
pass allowEmail and elasticUpdate params on user update API call 

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7556,9 +7556,15 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             };
 
             _this.updateUser = function(options) {
+                var param = {
+                    elasticUpdate:true
+                }
+                options.data.email && (param["allowEmail"] = true);
+                var url = MCK_BASE_URL + "/rest/ws/user/update?"+ $applozic.param(param);
+                //.param() using to serialize the properties of an object as a query string
                 window.Applozic.ALApiService.ajax({
                     type: "POST",
-                    url: MCK_BASE_URL + "/rest/ws/user/update",
+                    url: url,
                     data: w.JSON.stringify(options.data),
                     contentType : 'application/json',
                     success: function(response) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
--> 
### What do you want to achieve?
- pass allowEmail and elasticUpdate params on user update API call 

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- allowEmail:true  and elasticUpdate: true params are getting passed on API when the user submits the email on widget.

![Screen Shot 2020-09-11 at 5 42 05 PM](https://user-images.githubusercontent.com/34020392/92924187-27c7ed00-f456-11ea-83b1-c77a399df802.png)
widget

NOTE: Make sure you're comparing your branch with the correct base branch