### PR TITLE
Bump node-fetch from 2.6.0 to 2.6.1 [security vulnerability]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "4.17.1",
     "form-data": "3.0.0",
     "minimist": "1.2.5",
-    "node-fetch": "2.6.0",
+    "node-fetch": "2.6.1",
     "@node-minify/no-compress": "6.0.0",
     "@node-minify/core": "6.0.0",
     "@node-minify/terser": "6.0.0",


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Bump node-fetch from 2.6.0 to 2.6.1 [security vulnerability]
- https://github.com/node-fetch/node-fetch/releases/tag/v2.6.1

NOTE: Make sure you're comparing your branch with the correct base branch