### PR TITLE
Add language option in chat widget to use to speech recognition

### DIFF
--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -10,10 +10,11 @@ Kommunicate.mediaService = {
             alert("browser do not support speech recogization");
         } else {
             var recognition = new webkitSpeechRecognition();
+            var appOptions = KommunicateUtils.getDataFromKmSession("appOptions");
             recognition.continuous = false; // The default value for continuous is false, meaning that when the user stops talking, speech recognition will end. 
             recognition.interimResults = true; // The default value for interimResults is false, meaning that the only results returned by the recognizer are final and will not change. Set it to true so we get early, interim results that may change. 
             finalTranscript = '';
-            recognition.lang = "en-us";
+            recognition.lang = appOptions.language || "en-us";
             recognition.start();
             recognition.onstart = function () {
                 // when recognition.start() method is called it begins capturing audio and calls the onstart event handler


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add a valid BCP-47 language code inside the kommunicate settings option. This will be used for speech-to-text if supported by the browser.

Ref this issue: https://applozic.atlassian.net/browse/FW-1612

If language is not supported, speech-to-text will not work.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- {"voiceInput": "true", "language": "hi-IN"}
The input speech will now be converted to Hindi text.

<img width="1177" alt="Screenshot 2020-10-07 at 11 18 27 AM" src="https://user-images.githubusercontent.com/9497860/95292323-1b04a200-0826-11eb-857c-1ab5f9bfa5b7.png">


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch