### PR TITLE
TD-1260 Add support for voiceInput/voiceOutput parameters from chatWidget object in our Kommunicate Widget.

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -346,9 +346,11 @@ function ApplozicSidebox() {
             options.metadata = typeof options.metadata == 'object' ? options.metadata : {};
             options.fileUpload = options.fileUpload || (widgetSettings && widgetSettings.fileUpload);
             options.connectSocketOnWidgetClick = options.connectSocketOnWidgetClick != null ? options.connectSocketOnWidgetClick : (widgetSettings && widgetSettings.connectSocketOnWidgetClick);
+            options.voiceInput = options.voiceInput != null ? options.voiceInput : (widgetSettings && widgetSettings.voiceInput);
+            options.voiceOutput = options.voiceOutput != null ? options.voiceOutput : (widgetSettings && widgetSettings.voiceOutput);
             KommunicateUtils.deleteDataFromKmSession("settings");
 
-            if(sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)){
+            if (sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)) {
                 logoutAfterSessionExpiry(sessionTimeout);
                 var details = KommunicateUtils.getItemFromLocalStorage(applozic._globals.appId) || {};
                 !details.sessionStartTime && (details.sessionStartTime = new Date().getTime());


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add support for voice input/Output parameters from chatWidget object in our Kommunicate Widget.
- First priority is given to appOptions as 'voiceInput" property is live since more than a year and some customer might be using it.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- By updating the "voiceInput" and "voiceOuput" property from the settings update API and check whether both features are working fine or not.

NOTE: Make sure you're comparing your branch with the correct base branch