### PR TITLE
remove default agent id from create conversation payload

### DIFF
--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -34,7 +34,7 @@ $applozic.extend(true,Kommunicate,{
         kommunicateCommons.setWidgetStateOpen(true);
         params = typeof params == 'object' ? params : {};
         params = Kommunicate.updateConversationDetail(params);
-        if (!params.agentId && !params.agentIds) {
+        if (!params.agentId && !params.agentIds && !params.teamId) {
             params.agentId = KommunicateUtils.getDataFromKmSession('appOptions').agentId;
         }
         var user = [];

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7825,7 +7825,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 var defaultSettings = KommunicateUtils.getDataFromKmSession("settings");
                 var conversationDetail = {
                     groupName: (defaultSettings && defaultSettings.groupName) || DEFAULT_GROUP_NAME,
-                    agentId: (defaultSettings && defaultSettings.agentId) || DEFAULT_AGENT_ID,
+                    agentId: (defaultSettings && defaultSettings.agentId), // || DEFAULT_AGENT_ID,
                     botIds: (defaultSettings && defaultSettings.botIds) || DEFAULT_BOT_IDS
                 };
                 return conversationDetail;


### PR DESCRIPTION
### What do you want to achieve?
- Remove default agent from adding as admin or assignee to a conversation. The conversation will be routed through routing rules and the admin and assignee will be added accordingly.
- By default, super admin is getting added into all conversation, by these changes, it will be prevented. 

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- tested locally by seeing the presence of super admin. It should not be present in conversation until the super admin is not select into routing rules. 
- or until a super admin is not getting added directly from the installation script

NOTE: Make sure you're comparing your branch with the correct base branch