### PR TITLE
Add language option in TTS and don't print error for not-allowed

### DIFF
--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -68,6 +68,7 @@ Kommunicate.mediaService = {
             }
             if (textToSpeak) {
                 var utterance = new SpeechSynthesisUtterance(textToSpeak);
+                utterance.lang = appOptions.language || "en-US";
                 utterance.onerror = function (error) {
                     throw new Error("Error while converting the message to voice.", error);
                 };

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -69,8 +69,10 @@ Kommunicate.mediaService = {
             if (textToSpeak) {
                 var utterance = new SpeechSynthesisUtterance(textToSpeak);
                 utterance.lang = appOptions.language || "en-US";
-                utterance.onerror = function (error) {
-                    throw new Error("Error while converting the message to voice.", error);
+                utterance.onerror = function (event) {
+                    if (event.error !== "not-allowed") {
+                    throw new Error("Error while converting the message to voice.", event.error);
+                    }
                 };
                 speechSynthesis.speak(utterance);
             }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Use the same language option for STT in TTS also. Also don't throw error when it occurs because of user activation.
https://stackoverflow.com/questions/54265423/javascript-speechsynthesis-speak-without-user-activation-is-no-longer-allowed

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- { "voiceOutput" : "true", "language": "de-DE"} 
- Incoming message `Auf welche Branchen ist Protection One spezialisiert?` will be spoken in german.

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch