### PR TITLE
TD-1370 Mobile browser not showing the full view of chat widgets

### DIFF
--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -34,10 +34,10 @@ var kmCustomIframe =
     '   right: 0px;' +
     '} \n ' +
     '@media only screen and (max-width:600px) { .kommunicate-iframe-enable-media-query {' +
-    '   right: 0px;' +
+    '   right: 0px !important;' +
     '   bottom: 0px;' +
     '   top: 0;' +
-    '   left: 0;' +
+    '   left: 0px !important;' +
     '   border-radius: 0px;' +
     '   height: 100% !important;' +
     '   width: 100% !important;' +


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- To enable the full view of widget in mobile browsers when the widget is aligned left.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-
![Screenshot 2020-12-10 at 1 08 38 PM](https://user-images.githubusercontent.com/19753380/101736088-dd075100-3ae8-11eb-85a3-7ad979c9ba15.png)
![Screenshot 2020-12-10 at 1 08 44 PM](https://user-images.githubusercontent.com/19753380/101736113-e4c6f580-3ae8-11eb-8fc0-98bee4b829e3.png)



### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch