### PR TITLE
TD-1514 Hide List and button in a rich message on click

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -830,7 +830,7 @@
         border-bottom-right-radius: 18px;
     }
     .km-faq-list--footer_button-container button {
-        width: 99%;
+        width: 100%;
         outline: none;
         border: none;
         background: transparent;
@@ -852,8 +852,7 @@
     }
     
     .km-faq-list--footer_button-container button:not(:last-child){
-        border-bottom: 1px solid #e5e5e5;
-    
+        border-bottom: 1px solid #e5e5e5!important;
     }
     .km-dialog-box{
         /*width:96%;*/

--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -6180,3 +6180,12 @@ body.accesibility :focus {
 	border: 0;
 	text-align: center;
 }
+
+/* -----------------Support for hiding list and buttons post call to action------------- */
+.mck-msg-left [data-hidepostcta="true"] {
+	display:none;
+}
+.mck-msg-left:last-child [data-hidepostcta="true"] {
+	display:block!important;
+	visibility: visible;
+}

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -509,9 +509,8 @@ Kommunicate.richMsgEventHandler = {
         Kommunicate.sendMessage(messagePxy);
 
         if(kommunicate._globals.hidePostCTA){
-            e.target.classList.add("n-vis");
             var siblingsArray = Kommunicate.getAllSiblings(e.target);
-            var siblingContainsLink = siblingsArray.some(sibling => sibling.classList.contains("km-link-button"));      
+            var siblingContainsLink = siblingsArray.some(sibling => sibling.classList.contains("km-link-button"));     
             !siblingContainsLink && Kommunicate.hideMessage(e.target);
         }
         
@@ -540,13 +539,6 @@ Kommunicate.richMsgEventHandler = {
             Kommunicate.sendMessage(messagePxy);
         }else if(type && type =='submit'){
             //TODO : support for post request with data.
-        }
-
-        if(kommunicate._globals.hidePostCTA){
-            e.currentTarget.classList.add("n-vis");
-            var siblingsArray = Kommunicate.getAllSiblings(e.currentTarget);
-            var siblingContainsLink = siblingsArray.some(sibling => sibling.getAttribute("data-type") == "link");      
-            !siblingContainsLink && Kommunicate.hideMessage(e.target);
         }
 
     },

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -507,6 +507,14 @@ Kommunicate.richMsgEventHandler = {
         };
         document.getElementById('mck-text-box').setAttribute('data-quick-reply',true);
         Kommunicate.sendMessage(messagePxy);
+
+        if(kommunicate._globals.hidePostCTA){
+            e.target.classList.add("n-vis");
+            var siblingsArray = Kommunicate.getAllSiblings(e.target);
+            var siblingContainsLink = siblingsArray.some(sibling => sibling.classList.contains("km-link-button"));      
+            !siblingContainsLink && Kommunicate.hideMessage(e.target);
+        }
+        
     },
     processClickOnListItem: function(e){
         var target = e.currentTarget;

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -542,6 +542,13 @@ Kommunicate.richMsgEventHandler = {
             //TODO : support for post request with data.
         }
 
+        if(kommunicate._globals.hidePostCTA){
+            e.currentTarget.classList.add("n-vis");
+            var siblingsArray = Kommunicate.getAllSiblings(e.currentTarget);
+            var siblingContainsLink = siblingsArray.some(sibling => sibling.getAttribute("data-type") == "link");      
+            !siblingContainsLink && Kommunicate.hideMessage(e.target);
+        }
+
     },
     processClickOnButtonItem: function(e){
         e.preventDefault();
@@ -549,12 +556,7 @@ Kommunicate.richMsgEventHandler = {
         var reply = target.dataset.reply;
         var type = target.dataset.type;
         var languageCode = target.dataset.languagecode;
-        var metadata = {};
-        try{
-            metadata=  JSON.parse(target.dataset.metadata);
-        }catch(e){
-            console.log(e);
-        }
+        var metadata = (target.dataset && target.dataset.metadata) || {};
         metadata.KM_BUTTON_CLICKED =true;
         if(type && type =="quick_reply"){
             languageCode && Kommunicate.updateUserLanguage(languageCode);

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -148,7 +148,7 @@ getQuickRepliesTemplate:function(){
             </div>`;
 },
 getGenericSuggestedReplyButton : function(){
-    return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-buttonType="quick_reply">{{name}}</button>`
+    return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-buttonType="quick_reply" data-hidepostcta="{{hidePostCTA}}">{{name}}</button>`
 },
 getPassangerDetail : function(options){
     if(!options.sessionId){
@@ -191,7 +191,7 @@ getListMarkup:function(){
              <div class="km-faq-list--body_list-container">
                  <ul class="km-faq-list--body_list {{elementClass}}">
                      {{#elements}}
-                     <li class ={{handlerClass}} data-type="{{dataType}}" data-buttontype="{{dataType}}" data-metadata = "{{replyMetadata}}" data-reply = "{{dataReply}}" data-languageCode = "{{updateLanguage}}" data-articleid= "{{dataArticleId}}" data-source="{{source}}"> <a href={{href}} {{{target}}} class="km-undecorated-link km-custom-widget-text-color" >
+                     <li class ={{handlerClass}} data-type="{{dataType}}" data-hidepostcta="{{hidePostCTA}}" data-metadata = "{{replyMetadata}}" data-reply = "{{dataReply}}" data-languageCode = "{{updateLanguage}}" data-articleid= "{{dataArticleId}}" data-source="{{source}}"> <a href={{href}} {{{target}}} class="km-undecorated-link km-custom-widget-text-color" >
                              <div class="km-faq-list--body_img">
                                      {{{imgSrc}}}
                              </div>
@@ -215,7 +215,7 @@ getListMarkup:function(){
          <div class="km-faq-list--footer">
                  <div class="km-faq-list--footer_button-container">
                     {{#buttons}}
-                        <button aria-label="{{name}}" class="{{buttonClass}} km-cta-button km-custom-widget-border-color km-custom-widget-text-color km-add-more-rooms {{handlerClass}} km-faq-list-link-button" data-type ="{{dataType}}" data-buttontype ="{{dataType}}" data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-url={{href}} type="button" data-target={{target}} data-reply="{{dataReply}}">{{name}}</button>
+                        <button aria-label="{{name}}" class="{{buttonClass}} km-cta-button km-custom-widget-border-color km-custom-widget-text-color km-add-more-rooms {{handlerClass}} km-faq-list-link-button" data-type ="{{dataType}}" data-hidepostcta="{{hidePostCTA}}" data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-url={{href}} type="button" data-target={{target}} data-reply="{{dataReply}}">{{name}}</button>
                     {{/buttons}}  
              </div>
          </div>
@@ -505,10 +505,12 @@ Kommunicate.markup.getListContainerMarkup = function (metadata) {
                 if (item.action && item.action.type == "link") {
                     item.href = item.action.url;
                     item.action.openLinkInNewTab == false ? item.target = 'target="_parent"' : item.target = 'target="_blank"';
+                    item.hidePostCTA = false;
                 } else {
                     item.href = "javascript:void(0)";
                     item.target = '';
                     item.action && (item.updateLanguage = item.action.updateLanguage);
+                    item.hidePostCTA = kommunicate._globals.hidePostCTA;
                 }
                 item.handlerClass = "km-list-item-handler";
                 if (item.action) {
@@ -538,12 +540,20 @@ Kommunicate.markup.getListContainerMarkup = function (metadata) {
                     button.href = encodeURI(button.action.url);
                 }
 
+                if(button.action.type == "quick_reply"){
+                    button.hidePostCTA = kommunicate._globals.hidePostCTA;
+                }else{
+                    button.hidePostCTA = false;
+                }
+
                 button.dataType = button.action ? button.action.type : "";
+
                 button.dataReply = (button.action && button.action.text) ? button.action.text : (button.name || "");
                 // TODO : add post url in data.
                 return button;
             })
         }
+        
 
         return Mustache.to_html(Kommunicate.markup.getListMarkup(), json);
     } else {
@@ -701,6 +711,7 @@ Kommunicate.markup.getGenericButtonMarkup = function (metadata) {
         typeof (singlePayload.replyMetadata == "object") && (singlePayload.replyMetadata = JSON.stringify(singlePayload.replyMetadata));
         !singlePayload.type && singlePayload.action && (singlePayload.type = singlePayload.action.type);
         !singlePayload.replyMetadata && singlePayload.action && singlePayload.action.replyMetadata && kommunicateCommons.isObject(singlePayload.action.replyMetadata) && (singlePayload.replyMetadata = JSON.stringify(singlePayload.action.replyMetadata));
+        singlePayload.hidePostCTA = false;
         if (singlePayload.type == "link" || singlePayload.type == "submit") {
             singlePayload.url = buttonPayloadList[i].action.url || buttonPayloadList[i].action.formAction;
             singlePayload.openLinkInNewTab = buttonPayloadList[i].action.openLinkInNewTab;
@@ -713,6 +724,7 @@ Kommunicate.markup.getGenericButtonMarkup = function (metadata) {
         } else if (singlePayload.type == "quickReply" || singlePayload.type == "suggestedReply") {
             singlePayload.buttonClass = "km-quick-rpy-btn " + buttonClass;
             singlePayload.message = singlePayload.action.message || singlePayload.name;
+            singlePayload.type == "quickReply" && (singlePayload.hidePostCTA = kommunicate._globals.hidePostCTA);
             buttonContainerHtml += Mustache.to_html(Kommunicate.markup.getGenericSuggestedReplyButton(), singlePayload);
         } else if (singlePayload.action && singlePayload.action.type == "submit") {
 

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -143,12 +143,12 @@ getButtonTemplate:function(options,requestType, buttonClass){
 getQuickRepliesTemplate:function(){
     return`<div class="km-cta-multi-button-container">
             {{#payload}}
-                 <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-buttonType="quick_reply">{{title}}</button>
+                 <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}">{{title}}</button>
             {{/payload}}
             </div>`;
 },
 getGenericSuggestedReplyButton : function(){
-    return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-buttonType="quick_reply" data-hidepostcta="{{hidePostCTA}}">{{name}}</button>`
+    return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-hidePostCTA="{{hidePostCTA}}">{{name}}</button>`
 },
 getPassangerDetail : function(options){
     if(!options.sessionId){
@@ -191,7 +191,7 @@ getListMarkup:function(){
              <div class="km-faq-list--body_list-container">
                  <ul class="km-faq-list--body_list {{elementClass}}">
                      {{#elements}}
-                     <li class ={{handlerClass}} data-type="{{dataType}}" data-hidepostcta="{{hidePostCTA}}" data-metadata = "{{replyMetadata}}" data-reply = "{{dataReply}}" data-languageCode = "{{updateLanguage}}" data-articleid= "{{dataArticleId}}" data-source="{{source}}"> <a href={{href}} {{{target}}} class="km-undecorated-link km-custom-widget-text-color" >
+                     <li class ={{handlerClass}} data-type="{{dataType}}" data-hidePostCTA="{{hidePostCTA}}" data-metadata = "{{replyMetadata}}" data-reply = "{{dataReply}}" data-languageCode = "{{updateLanguage}}" data-articleid= "{{dataArticleId}}" data-source="{{source}}"> <a href={{href}} {{{target}}} class="km-undecorated-link km-custom-widget-text-color" >
                              <div class="km-faq-list--body_img">
                                      {{{imgSrc}}}
                              </div>
@@ -215,7 +215,7 @@ getListMarkup:function(){
          <div class="km-faq-list--footer">
                  <div class="km-faq-list--footer_button-container">
                     {{#buttons}}
-                        <button aria-label="{{name}}" class="{{buttonClass}} km-cta-button km-custom-widget-border-color km-custom-widget-text-color km-add-more-rooms {{handlerClass}} km-faq-list-link-button" data-type ="{{dataType}}" data-hidepostcta="{{hidePostCTA}}" data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-url={{href}} type="button" data-target={{target}} data-reply="{{dataReply}}">{{name}}</button>
+                        <button aria-label="{{name}}" class="{{buttonClass}} km-cta-button km-custom-widget-border-color km-custom-widget-text-color km-add-more-rooms {{handlerClass}} km-faq-list-link-button" data-type ="{{dataType}}" data-hidePostCTA="{{hidePostCTA}}" data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-url={{href}} type="button" data-target={{target}} data-reply="{{dataReply}}">{{name}}</button>
                     {{/buttons}}  
              </div>
          </div>

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -481,73 +481,72 @@ Kommunicate.markup.getRoomDetailsContainerTemplate = function (roomList, session
     }
     return `<div class="km-card-room-detail-container  km-div-slider">` + roomListMarkup + `</div>`
 }
-Kommunicate.markup.getListContainerMarkup = function(metadata){
-    const buttonClass = {link:"km-link-button", submit:""}
-    if(metadata && metadata.payload){
-       var json = JSON.parse(metadata.payload);
-        if(json.headerImgSrc){
-            json.headerImgSrc = '<div class="km-faq-list--header_text-img"><img src= "'+json.headerImgSrc+'"  alt = "image" /></div>';
-        }if(json.headerText){
-            json.headerText ='<p class="km-faq-list--header_text">'+json.headerText+"</p>"
+Kommunicate.markup.getListContainerMarkup = function (metadata) {
+    const buttonClass = { link: "km-link-button", submit: "" }
+    if (metadata && metadata.payload) {
+        var json = JSON.parse(metadata.payload);
+        if (json.headerImgSrc) {
+            json.headerImgSrc = '<div class="km-faq-list--header_text-img"><img src= "' + json.headerImgSrc + '"  alt = "image" /></div>';
+        } if (json.headerText) {
+            json.headerText = '<p class="km-faq-list--header_text">' + json.headerText + "</p>"
         }
-        if(json.elements&&json.elements.length){
-            json.elementClass ="vis";
-            json.elements =   json.elements.map(function(item){
-               // checking for image
-                if(item.imgSrc){
-                item.imgSrc =  '<img src ="'+item.imgSrc +'" />';
-               }
-               item.description && (item.description = kommunicateCommons.removeHtmlTag(item.description));
-               if(item.action && item.action.replyMetadata){
-                 item.replyMetadata = typeof  item.action.replyMetadata =="object"? JSON.stringify(item.action.replyMetadata):item.action.replyMetadata;
-               }
-               //checking for type
-               if(item.action && item.action.type=="link"){
-                item.href = item.action.url;
-                item.action.openLinkInNewTab == false ? item.target = 'target="_parent"' : item.target = 'target="_blank"';
-               }else{
-                item.href = "javascript:void(0)";
-                item.target = '';
-                item.handlerClass= "km-list-item-handler";
-                item.action && (item.updateLanguage = item.action.updateLanguage);
-                
-               }
-               if(item.action){
-                item.dataType=item.action.type||"";
-                item.dataReply = item.action.text||item.title||"";
-               }
-               item.dataArticleId = item.articleId||"";
-               item.dataSource = item.source||"";
-               // TODO : add post url in data.
+        if (json.elements && json.elements.length) {
+            json.elementClass = "vis";
+            json.elements = json.elements.map(function (item) {
+                // checking for image
+                if (item.imgSrc) {
+                    item.imgSrc = '<img src ="' + item.imgSrc + '" />';
+                }
+                item.description && (item.description = kommunicateCommons.removeHtmlTag(item.description));
+                if (item.action && item.action.replyMetadata) {
+                    item.replyMetadata = typeof item.action.replyMetadata == "object" ? JSON.stringify(item.action.replyMetadata) : item.action.replyMetadata;
+                }
+                //checking for type
+                if (item.action && item.action.type == "link") {
+                    item.href = item.action.url;
+                    item.action.openLinkInNewTab == false ? item.target = 'target="_parent"' : item.target = 'target="_blank"';
+                } else {
+                    item.href = "javascript:void(0)";
+                    item.target = '';
+                    item.action && (item.updateLanguage = item.action.updateLanguage);
+                }
+                item.handlerClass = "km-list-item-handler";
+                if (item.action) {
+                    item.dataType = item.action.type || "";
+                    item.dataReply = item.action.text || item.title || "";
+                }
+                item.dataArticleId = item.articleId || "";
+                item.dataSource = item.source || "";
+                // TODO : add post url in data.
                 return item;
             })
-        }else{
-            json.elementClass ="n-vis"
+        } else {
+            json.elementClass = "n-vis"
         }
-        if(json.buttons&&json.buttons.length){
-        json.buttons=  json.buttons.map(function (button){
-            button.target = Kommunicate.markup.getLinkTarget(button.action);
-            button.buttonClass = buttonClass[button.action.type];
-            if(button.action && button.action.replyMetadata){
-                button.replyMetadata = typeof  button.action.replyMetadata =="object"? JSON.stringify(button.action.replyMetadata):button.action.replyMetadata;
-              }
-              button.action && (button.updateLanguage = button.action.updateLanguage);
-            if(!button.action || button.action.type =="quick_reply" || button.action.type =="submit"){
-                button.href = "javascript:void(0)";
-                button.handlerClass= "km-list-button-item-handler";
-               }else{
-                button.href = encodeURI(button.action.url);
-               }
-               
-               button.dataType=button.action? button.action.type:"";
-               button.dataReply = (button.action && button.action.text)? button.action.text: (button.name||"");
-               // TODO : add post url in data.
-                return button;
-        })
-    }
+        if (json.buttons && json.buttons.length) {
+            json.buttons = json.buttons.map(function (button) {
+                button.target = Kommunicate.markup.getLinkTarget(button.action);
+                button.buttonClass = buttonClass[button.action.type];
+                if (button.action && button.action.replyMetadata) {
+                    button.replyMetadata = typeof button.action.replyMetadata == "object" ? JSON.stringify(button.action.replyMetadata) : button.action.replyMetadata;
+                }
+                button.action && (button.updateLanguage = button.action.updateLanguage);
+                if (!button.action || button.action.type == "quick_reply" || button.action.type == "submit") {
+                    button.href = "javascript:void(0)";
+                    button.handlerClass = "km-list-button-item-handler";
+                } else {
+                    button.href = encodeURI(button.action.url);
+                }
 
-       return Mustache.to_html(Kommunicate.markup.getListMarkup(), json);
-    }else{
+                button.dataType = button.action ? button.action.type : "";
+                button.dataReply = (button.action && button.action.text) ? button.action.text : (button.name || "");
+                // TODO : add post url in data.
+                return button;
+            })
+        }
+
+        return Mustache.to_html(Kommunicate.markup.getListMarkup(), json);
+    } else {
         return "";
     }
 

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -143,12 +143,12 @@ getButtonTemplate:function(options,requestType, buttonClass){
 getQuickRepliesTemplate:function(){
     return`<div class="km-cta-multi-button-container">
             {{#payload}}
-                 <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}">{{title}}</button>
+                 <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-buttonType="quick_reply">{{title}}</button>
             {{/payload}}
             </div>`;
 },
 getGenericSuggestedReplyButton : function(){
-    return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}">{{name}}</button>`
+    return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-buttonType="quick_reply">{{name}}</button>`
 },
 getPassangerDetail : function(options){
     if(!options.sessionId){
@@ -191,7 +191,7 @@ getListMarkup:function(){
              <div class="km-faq-list--body_list-container">
                  <ul class="km-faq-list--body_list {{elementClass}}">
                      {{#elements}}
-                     <li class ={{handlerClass}} data-type="{{dataType}}" data-metadata = "{{replyMetadata}}" data-reply = "{{dataReply}}" data-languageCode = "{{updateLanguage}}" data-articleid= "{{dataArticleId}}" data-source="{{source}}"> <a href={{href}} {{{target}}} class="km-undecorated-link km-custom-widget-text-color" >
+                     <li class ={{handlerClass}} data-type="{{dataType}}" data-buttontype="{{dataType}}" data-metadata = "{{replyMetadata}}" data-reply = "{{dataReply}}" data-languageCode = "{{updateLanguage}}" data-articleid= "{{dataArticleId}}" data-source="{{source}}"> <a href={{href}} {{{target}}} class="km-undecorated-link km-custom-widget-text-color" >
                              <div class="km-faq-list--body_img">
                                      {{{imgSrc}}}
                              </div>
@@ -215,7 +215,7 @@ getListMarkup:function(){
          <div class="km-faq-list--footer">
                  <div class="km-faq-list--footer_button-container">
                     {{#buttons}}
-                        <button aria-label="{{name}}" class="{{buttonClass}} km-cta-button km-custom-widget-border-color km-custom-widget-text-color km-add-more-rooms {{handlerClass}} km-faq-list-link-button" data-type ="{{dataType}}" data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-url={{href}} type="button" data-target={{target}} data-reply="{{dataReply}}">{{name}}</button>
+                        <button aria-label="{{name}}" class="{{buttonClass}} km-cta-button km-custom-widget-border-color km-custom-widget-text-color km-add-more-rooms {{handlerClass}} km-faq-list-link-button" data-type ="{{dataType}}" data-buttontype ="{{dataType}}" data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-url={{href}} type="button" data-target={{target}} data-reply="{{dataReply}}">{{name}}</button>
                     {{/buttons}}  
              </div>
          </div>

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -545,7 +545,7 @@ $applozic.extend(true,Kommunicate,{
     },
     getAllSiblings: function (element) {
         var siblings = []; 
-        if (!element.parentNode) {
+        if (!element || !element.parentNode) {
             return siblings;
         }
         var sibling  = element.parentNode.firstChild;

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -535,5 +535,26 @@ $applozic.extend(true,Kommunicate,{
             return false;
         }
         return true;
-    }
+    },
+    hideMessage: function(element){
+            var parentEle =  element.parentElement;
+            while (!parentEle.classList.contains("mck-msg-left")){
+                parentEle = parentEle.parentElement;
+            }
+            parentEle.classList.add("n-vis");
+    },
+    getAllSiblings: function (element) {
+        var siblings = []; 
+        if (!element.parentNode) {
+            return siblings;
+        }
+        var sibling  = element.parentNode.firstChild;
+        while (sibling) {
+            if (sibling.nodeType === 1 && sibling !== element) {
+                siblings.push(sibling);
+            }
+            sibling = sibling.nextSibling;
+        }
+        return siblings;
+    },
 });

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -536,12 +536,15 @@ $applozic.extend(true,Kommunicate,{
         }
         return true;
     },
-    hideMessage: function(element){
-            var parentEle =  element.parentElement;
-            while (!parentEle.classList.contains("mck-msg-left")){
-                parentEle = parentEle.parentElement;
-            }
-            parentEle.classList.add("n-vis");
+    hideMessage: function (element) {
+        if (!element) {
+            return;
+        }
+        var parentEle = element.parentElement;
+        while (!parentEle.classList.contains("mck-msg-left")) {
+            parentEle = parentEle.parentElement;
+        }
+        parentEle.classList.add("n-vis");
     },
     getAllSiblings: function (element) {
         var siblings = []; 

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -341,7 +341,7 @@ function ApplozicSidebox() {
             options["customerCreatedAt"]=options.appSettings.customerCreatedAt;
             options["collectFeedback"]=options.appSettings.collectFeedback;
             options['chatPopupMessage'] = options.appSettings.chatPopupMessage;
-            
+        
             var pseudoNameEnabled = (widgetSettings && (typeof widgetSettings.pseudonymsEnabled !== 'undefined')) ? widgetSettings.pseudonymsEnabled : KM_PLUGIN_SETTINGS.pseudoNameEnabled;
             options.metadata = typeof options.metadata == 'object' ? options.metadata : {};
             options.fileUpload = options.fileUpload || (widgetSettings && widgetSettings.fileUpload);
@@ -349,6 +349,8 @@ function ApplozicSidebox() {
             options.voiceInput = options.voiceInput != null ? options.voiceInput : (widgetSettings && widgetSettings.voiceInput);
             options.voiceOutput = options.voiceOutput != null ? options.voiceOutput : (widgetSettings && widgetSettings.voiceOutput);
             options.attachment = options.attachment != null ? options.attachment : (widgetSettings && widgetSettings.attachment);
+            options.activeRichMessages = options.activeRichMessages != null ? options.activeRichMessages : (widgetSettings && widgetSettings.activeRichMessages);
+
             KommunicateUtils.deleteDataFromKmSession("settings");
 
             if (sessionTimeout != null && !(options.preLeadCollection || options.askUserDetails)) {

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -349,7 +349,7 @@ function ApplozicSidebox() {
             options.voiceInput = options.voiceInput != null ? options.voiceInput : (widgetSettings && widgetSettings.voiceInput);
             options.voiceOutput = options.voiceOutput != null ? options.voiceOutput : (widgetSettings && widgetSettings.voiceOutput);
             options.attachment = options.attachment != null ? options.attachment : (widgetSettings && widgetSettings.attachment);
-            options.activeRichMessages = options.activeRichMessages != null ? options.activeRichMessages : (widgetSettings && widgetSettings.activeRichMessages);
+            options.hidePostCTA = options.hidePostCTA != null ? options.hidePostCTA : (widgetSettings && widgetSettings.hidePostCTA);
 
             KommunicateUtils.deleteDataFromKmSession("settings");
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5430,6 +5430,15 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     botMessageDelayClass = 'n-vis';
                 }
 
+                if (HIDE_POST_CTA && 
+                    richText && 
+                    kmRichTextMarkup.includes("km-cta-multi-button-container") && 
+                    !kmRichTextMarkup.includes("km-link-button") && 
+                    !append) {
+                    // if type of message is richmessage having CTA buttons and it does not include links then it should not be visible
+                        botMessageDelayClass = 'n-vis';
+                };
+
                 // if (!richText && !attachment && messageClass == "n-vis"){
                 //     // if it is not a rich msg and neither contains any text then dont precess it because in UI it is shown as empty text box which does not look good.
                 //     return ;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4865,29 +4865,18 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 $applozic.template("csatModule", csatModule);
             };
 
-            var activeRichMsgCSS = `
-                .mck-msg-left .km-cta-multi-button-container .km-quick-replies {
-                    display:none;
-                } 
-                .mck-msg-left:last-child .km-cta-multi-button-container .km-quick-replies {
-                    display:block!important;
-                    visibility: visible;
-                }
-                .mck-msg-left .km-chat-faq-list.km-list-container li.km-list-item-handler[data-type="quick_reply"] {
-                    display: none;
-                }
-                .mck-msg-left:last-child .km-chat-faq-list.km-list-container li.km-list-item-handler[data-type="quick_reply"] {
-                    display: block;
-                }
-                .mck-msg-left .km-faq-list--footer_button-container button.km-cta-button[data-type="quick_reply"]{
-                    display: none;
-                }
-                .mck-msg-left:last-child .km-faq-list--footer_button-container button.km-cta-button[data-type="quick_reply"]{
-                    display: block;
-                }
+            
+            if (HIDE_POST_CTA) {
+                var requiredCSS = `
+                    .mck-msg-left [data-buttontype="quick_reply"] {
+                        display:none;
+                    }
+                    .mck-msg-left:last-child [data-buttontype="quick_reply"] {
+                        display:block!important;
+                        visibility: visible;
+                    }
                 `;
-            if(HIDE_POST_CTA){
-                Kommunicate.customizeWidgetCss(activeRichMsgCSS);
+                Kommunicate.customizeWidgetCss(requiredCSS);
             };
 
             _this.loadDropdownOptions = function () {
@@ -5441,10 +5430,10 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     botMessageDelayClass = 'n-vis';
                 }
 
-                if (HIDE_POST_CTA && richText && kmRichTextMarkup.includes("km-cta-multi-button-container") && !kmRichTextMarkup.includes("km-link-button") && !append) {
-                    // if type of message is richmessage having CTA buttons and it does not include links then it should not be visible
-                    botMessageDelayClass = 'n-vis';
-                };
+                // if (HIDE_POST_CTA && richText && kmRichTextMarkup.includes("km-cta-multi-button-container") && !kmRichTextMarkup.includes("km-link-button") && !append) {
+                //     // if type of message is richmessage having CTA buttons and it does not include links then it should not be visible
+                //     botMessageDelayClass = 'n-vis';
+                // };
 
                 // if (!richText && !attachment && messageClass == "n-vis"){
                 //     // if it is not a rich msg and neither contains any text then dont precess it because in UI it is shown as empty text box which does not look good.

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4879,6 +4879,12 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 .mck-msg-left:last-child .km-chat-faq-list.km-list-container li.km-list-item-handler[data-type="quick_reply"] {
                     display: block;
                 }
+                .mck-msg-left .km-faq-list--footer_button-container button.km-cta-button[data-type="quick_reply"]{
+                    display: none;
+                }
+                .mck-msg-left:last-child .km-faq-list--footer_button-container button.km-cta-button[data-type="quick_reply"]{
+                    display: block;
+                }
                 `;
             if(HIDE_POST_CTA){
                 Kommunicate.customizeWidgetCss(activeRichMsgCSS);

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4863,6 +4863,24 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 $applozic.template("searchContactbox", searchContactbox);
                 $applozic.template("csatModule", csatModule);
             };
+
+            var activeRichMsgCSS = `
+                .mck-msg-left .km-cta-multi-button-container .km-quick-replies {
+                    display:none;
+                } 
+                .mck-msg-left:last-child .km-cta-multi-button-container .km-quick-replies {
+                    display:block;
+                    visibility: visible;
+                }
+                .mck-msg-left .km-chat-faq-list.km-list-container li.km-list-item-handler[data-type="quick_reply"] {
+                    display: none;
+                }
+                .mck-msg-left:last-child .km-chat-faq-list.km-list-container li.km-list-item-handler[data-type="quick_reply"] {
+                    display: block;
+                }
+                `;
+            kommunicate._globals.activeRichMessages && Kommunicate.customizeWidgetCss(activeRichMsgCSS);
+
             _this.loadDropdownOptions = function () {
                 var enableDropdown = false;
                 /*

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4866,18 +4866,6 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
             };
 
             
-            if (HIDE_POST_CTA) {
-                var requiredCSS = `
-                    .mck-msg-left [data-buttontype="quick_reply"] {
-                        display:none;
-                    }
-                    .mck-msg-left:last-child [data-buttontype="quick_reply"] {
-                        display:block!important;
-                        visibility: visible;
-                    }
-                `;
-                Kommunicate.customizeWidgetCss(requiredCSS);
-            };
 
             _this.loadDropdownOptions = function () {
                 var enableDropdown = false;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5430,11 +5430,6 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     botMessageDelayClass = 'n-vis';
                 }
 
-                // if (HIDE_POST_CTA && richText && kmRichTextMarkup.includes("km-cta-multi-button-container") && !kmRichTextMarkup.includes("km-link-button") && !append) {
-                //     // if type of message is richmessage having CTA buttons and it does not include links then it should not be visible
-                //     botMessageDelayClass = 'n-vis';
-                // };
-
                 // if (!richText && !attachment && messageClass == "n-vis"){
                 //     // if it is not a rich msg and neither contains any text then dont precess it because in UI it is shown as empty text box which does not look good.
                 //     return ;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -336,6 +336,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
         var WIDGET_SETTINGS = appOptions.widgetSettings;
         var EMOJI_LIBRARY = appOptions.emojilibrary;
         var CSAT_ENABLED = appOptions.collectFeedback;
+        var HIDE_POST_CTA = appOptions.hidePostCTA;
         var MCK_MODE = appOptions.mode;
         MCK_LABELS = appOptions.labels;
         MCK_BASE_URL = appOptions.baseUrl;
@@ -4869,7 +4870,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     display:none;
                 } 
                 .mck-msg-left:last-child .km-cta-multi-button-container .km-quick-replies {
-                    display:block;
+                    display:block!important;
                     visibility: visible;
                 }
                 .mck-msg-left .km-chat-faq-list.km-list-container li.km-list-item-handler[data-type="quick_reply"] {
@@ -4879,7 +4880,9 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     display: block;
                 }
                 `;
-            kommunicate._globals.activeRichMessages && Kommunicate.customizeWidgetCss(activeRichMsgCSS);
+            if(HIDE_POST_CTA){
+                Kommunicate.customizeWidgetCss(activeRichMsgCSS);
+            };
 
             _this.loadDropdownOptions = function () {
                 var enableDropdown = false;
@@ -5417,6 +5420,7 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 var richText = Kommunicate.isRichTextMessage(msg.metadata) || msg.contentType == 3;
                 var kmRichTextMarkupVisibility=richText ? 'vis' : 'n-vis';
                 var kmRichTextMarkup = richText ? Kommunicate.getRichTextMessageTemplate(msg) : "";
+                
                 var containerType = Kommunicate.getContainerTypeForRichMessage(msg);
                 var attachment = Kommunicate.isAttachment(msg);
                 msg.fileMeta && msg.fileMeta.size && (msg.fileMeta.previewSize = alFileService.getFilePreviewSize(msg.fileMeta.size));
@@ -5430,6 +5434,12 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                 if(append && MCK_BOT_MESSAGE_DELAY !== 0 && mckMessageLayout.isMessageSentByBot(msg, contact)) {
                     botMessageDelayClass = 'n-vis';
                 }
+
+                if (HIDE_POST_CTA && richText && kmRichTextMarkup.includes("km-cta-multi-button-container") && !kmRichTextMarkup.includes("km-link-button") && !append) {
+                    // if type of message is richmessage having CTA buttons and it does not include links then it should not be visible
+                    botMessageDelayClass = 'n-vis';
+                };
+
                 // if (!richText && !attachment && messageClass == "n-vis"){
                 //     // if it is not a rich msg and neither contains any text then dont precess it because in UI it is shown as empty text box which does not look good.
                 //     return ;
@@ -5491,7 +5501,10 @@ var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ["application","text","image"];
                     botMsgDelayExpr: botMessageDelayClass
                 }];
 
-                append ? $applozic.tmpl("messageTemplate", msgList).appendTo("#mck-message-cell .mck-message-inner") : $applozic.tmpl("messageTemplate", msgList).prependTo("#mck-message-cell .mck-message-inner");
+                append ? 
+                    $applozic.tmpl("messageTemplate", msgList).appendTo("#mck-message-cell .mck-message-inner") : 
+                    $applozic.tmpl("messageTemplate", msgList).prependTo("#mck-message-cell .mck-message-inner");
+
                 if (msg.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.NOTIFY_MESSAGE) {
                     if (msg.metadata && msg.metadata.feedback) {
                         var userFeedback = JSON.parse(msg.metadata.feedback);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Support functionality for hiding the buttons once the user has clicked on it. (quick reply buttons only)
- Create a global settings for enabling hiding list / quick reply btn.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- The end user is prompted with following options
![Screenshot 2021-02-08 at 3 34 13 PM](https://user-images.githubusercontent.com/19753380/107204905-3e816880-6a23-11eb-95e2-644a2ffb2dbf.png)
- He click on any option, then the all other option expect link should hide (for this example clicked on btn2)
![Screenshot 2021-02-08 at 3 34 26 PM](https://user-images.githubusercontent.com/19753380/107205416-d8e1ac00-6a23-11eb-97fe-6b17fb804a5c.png)
- If no link btn is present then whole msg should hide
![Screenshot 2021-02-08 at 3 34 37 PM](https://user-images.githubusercontent.com/19753380/107205477-ed25a900-6a23-11eb-95dc-709ed01f6483.png)




### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- 

NOTE: Make sure you're comparing your branch with the correct base branch