### PR TITLE
TD-1564 BUGFIX For the reverse message order issue. [DEVELOPMENT]

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7866,7 +7866,10 @@ var userOverride = {
                         'last-message-received-time',
                         data.message[0].createdAtTime
                     );
-                allowReload && (scroll = false);
+                if (allowReload){
+                    scroll = false;
+                    data && data.message && (data.message = data.message.reverse());
+                }
                 if (typeof data.message.length === 'undefined') {
                     var messageArray = [];
                     messageArray.push(data.message);
@@ -7895,7 +7898,9 @@ var userOverride = {
                                 append,
                                 false,
                                 isValidated,
-                                enableAttachment
+                                enableAttachment,
+                                null,
+                                allowReload
                             );
                             Kommunicate.appendEmailToIframe(message);
                             showMoreDateTime = message.createdAtTime;
@@ -8061,7 +8066,8 @@ var userOverride = {
                 scroll,
                 appendContextMenu,
                 enableAttachment,
-                callback
+                callback,
+                allowReload
             ) {
                 var metadatarepiledto = '';
                 var replymessage = '';
@@ -8319,7 +8325,7 @@ var userOverride = {
                 if (
                     append &&
                     MCK_BOT_MESSAGE_DELAY !== 0 &&
-                    mckMessageLayout.isMessageSentByBot(msg, contact)
+                    (!allowReload && mckMessageLayout.isMessageSentByBot(msg, contact))
                 ) {
                     botMessageDelayClass = 'n-vis';
                 }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7607,6 +7607,7 @@ var userOverride = {
                     document
                         .getElementById('mck-char-warning')
                         .classList.add('n-vis');
+                kommunicateCommons.modifyClassList( {class : ["mck-rating-box"]}, "","selected");
                 if (params.tabId) {
                     $mck_msg_to.val(params.tabId);
                     $mck_msg_inner.data('mck-id', params.tabId);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- fix the issue were the messages were rendering in reverse order and bot messages were not showing
- fix for the vogo's query regarding the csat rating emoji issue.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Create and intent having multiple messages.
![Screenshot 2021-02-19 at 12 56 08 PM](https://user-images.githubusercontent.com/19753380/108471738-d861d480-72b1-11eb-8306-7a7976861fcb.png)
( have minimum 5 - 6 messages so that it takes around 2, 3 seconds to render )

- open the widget
- type the training phrase as configured for the intent made above.
- press enter and immediately switch the internet connection off. ( response should not have been loaded completely)
-  wait for 30s and reconnect the internet.
- the messages should appear in order. (not in reverse, or hidden in case for bots' response)

If bug exists then messages will render as show in the video
https://user-images.githubusercontent.com/19753380/108473109-9df93700-72b3-11eb-9fc7-538a2331e645.mov
Note: Video contains responses sent by human agent


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- upon socket reconnection, the allowReload variable was set to true but was not configured in the processMessageList() and addMessage() in the mck-sidebox-1.0.js in the chat widget.

NOTE: Make sure you're comparing your branch with the correct base branch