### PR TITLE
FW-1957 Bot image is half cut if team handover is taking place [BUGFIX]

### DIFF
--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -691,8 +691,8 @@ $applozic.extend(true, Kommunicate, {
     // check if the message needs to be processed by addMessage
     visibleMessage: function (msg) {
         if (!msg) return false;
-        if (!msg.message && msg.metadata.hasOwnProperty('KM_ASSIGN_TO')) {
-            // KM_ASSIGN_TO parameter comes when we change assignee by bot message.
+        if (!msg.message && (msg.metadata.hasOwnProperty('KM_ASSIGN_TO') || msg.metadata.hasOwnProperty('KM_ASSIGN_TEAM'))) {
+            // KM_ASSIGN_TO and KM_ASSIGN_TEAM parameter comes when we change assignee by bot message.
             return false;
         }
         if (

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -11235,9 +11235,11 @@ var userOverride = {
                                                     'true' &&
                                                 contact.type !== 7) ||
                                             (!message.message &&
-                                                message.metadata.hasOwnProperty(
+                                                (message.metadata.hasOwnProperty(
                                                     'KM_ASSIGN_TO'
-                                                ))
+                                                ) || message.metadata.hasOwnProperty(
+                                                    'KM_ASSIGN_TEAM'
+                                                )))
                                         ) {
                                             if (
                                                 MCK_BOT_MESSAGE_DELAY !== 0 &&


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- To fix the bug where the UI was breaking for the case of team handoff if the message was empty.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Create a team handoff intent without the message property in the payload.
- trigger the intent from the chat widget 
- the conversation should get assigned as per the set payload and the bot image should not be cut as shown in the example figure. 
- If no message is their then the user will not see any thing. Only the conversation gets assigned.
![Screenshot 2021-03-03 at 3 08 05 PM](https://user-images.githubusercontent.com/19753380/110574525-44ce4600-8183-11eb-9a12-d590698e5ced.png)


### What new thing you came across while writing this code? 
- 

### In case you fixed a bug then please describe the root cause of it? 
- 

NOTE: Make sure you're comparing your branch with the correct base branch