### PR TITLE
FW-2052 Access files signed URL in web plugin [Security, Important]

### DIFF
--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -190,6 +190,8 @@ KommunicateConstants = {
         RIGHT: 'right',
     },
     KOMMUNICATE_DOMAINS: ['kommunicate.io'],
+    AWS_IMAGE_URL_EXPIRY_TIME: 15*60*1000,
+    IMAGE_PLACEHOLDER_URL: 'https://via.placeholder.com/350x265',
 };
 
 /**

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -191,7 +191,7 @@ KommunicateConstants = {
     },
     KOMMUNICATE_DOMAINS: ['kommunicate.io'],
     AWS_IMAGE_URL_EXPIRY_TIME: 15*60*1000,
-    IMAGE_PLACEHOLDER_URL: 'https://via.placeholder.com/350x265',
+    IMAGE_PLACEHOLDER_URL: 'https://cdn.kommunicate.io/kommunicate/image-placeholder.png',
 };
 
 /**

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1402,15 +1402,16 @@ KommunicateUI = {
             rect.right <= targetRect.right
         );
     },
-    processLazyImage: function(img){
-        img.classList.remove('lazy_image');
-        var thumbnailBlobKey = img.getAttribute('data-thumbnailBlobKey');
-        KommunicateUI.getUrlFromBlobKey(thumbnailBlobKey, function(err, thumbnailUrl){
-            if (err) throw err;
-            thumbnailUrl && (img.src = thumbnailUrl);
-            setTimeout(function(){
-                img.classList.add('lazy_image');
-            },15*60*1000);
+    processLazyImage: function (imageElement, thumbnailBlobKey) {
+        imageElement.classList.remove('lazy-image');
+        KommunicateUI.getUrlFromBlobKey(thumbnailBlobKey, function (err, thumbnailUrl) {
+            if (err) {
+                throw err
+            };
+            thumbnailUrl && (imageElement.src = thumbnailUrl);
+            setTimeout(function () {
+                imageElement.classList.add('lazy-image');
+            }, KommunicateConstants.AWS_IMAGE_URL_EXPIRY_TIME);
         });
     }
 };

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1394,11 +1394,12 @@ KommunicateUI = {
     },
     isInView: function (element, targetElement) {
         const rect = element.getBoundingClientRect();
+        const targetRect = targetElement.getBoundingClientRect();
         return (
-            rect.top >= 0 &&
-            rect.left >= 0 &&
-            rect.bottom <= (targetElement.innerHeight || targetElement.clientHeight) &&
-            rect.right <= (targetElement.innerWidth || targetElement.clientWidth)
+            rect.top >= targetRect.top &&
+            rect.left >= targetRect.left &&
+            rect.bottom <= targetRect.bottom &&
+            rect.right <= targetRect.right
         );
     },
     processLazyImage: function(img){

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1378,4 +1378,38 @@ KommunicateUI = {
             },
         });
     },
+    getUrlFromBlobKey: function(blobKey, callback) {
+        var params= '?key='+blobKey;
+        window.Applozic.ALApiService.ajax({
+            type: 'GET',
+            global: false,
+            url: MCK_BASE_URL + '/rest/ws/file/url' + params,
+            success: function (res) {
+                callback(null, res);
+            },
+            error: function (err) {
+                callback(err);
+            },
+        })
+    },
+    isInView: function (element, targetElement) {
+        const rect = element.getBoundingClientRect();
+        return (
+            rect.top >= 0 &&
+            rect.left >= 0 &&
+            rect.bottom <= (targetElement.innerHeight || targetElement.clientHeight) &&
+            rect.right <= (targetElement.innerWidth || targetElement.clientWidth)
+        );
+    },
+    processLazyImage: function(img){
+        img.classList.remove('lazy_image');
+        var thumbnailBlobKey = img.getAttribute('data-thumbnailBlobKey');
+        KommunicateUI.getUrlFromBlobKey(thumbnailBlobKey, function(err, thumbnailUrl){
+            if (err) throw err;
+            thumbnailUrl && (img.src = thumbnailUrl);
+            setTimeout(function(){
+                img.classList.add('lazy_image');
+            },15*60*1000);
+        });
+    }
 };

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3175,15 +3175,7 @@ var userOverride = {
                     $this.data('name')
                 );
                 var blobKey = $this.find('img').attr('data-blobKey');
-                var modal = parent.document.getElementById(
-                    'km-fullscreen-image-modal'
-                );
-                var modalImg = parent.document.getElementById(
-                    'km-fullscreen-image-modal-content'
-                );
-                var captionText = parent.document.getElementById(
-                    'km-fullscreen-image-modal-caption'
-                );
+                
                 if(blobKey && href == ''){
                     KommunicateUI.getUrlFromBlobKey(blobKey, function(err, url){
                         if(err) throw err;
@@ -3195,9 +3187,24 @@ var userOverride = {
                             $this.data('url', '');
                         }, 15*60*1000)    
                     })
+                }else if(href === ''){
+                    var key;
+                    key = $this.data('blobkey');
+                    alFileService.generateCloudUrl(key, function (result) {
+                        href = result;
+                    });
                 }else{
                     modalImg.src = href;
                 }
+                var modal = parent.document.getElementById(
+                    'km-fullscreen-image-modal'
+                );
+                var modalImg = parent.document.getElementById(
+                    'km-fullscreen-image-modal-content'
+                );
+                var captionText = parent.document.getElementById(
+                    'km-fullscreen-image-modal-caption'
+                );
                 modal.style.display = 'block';
                 captionText.innerHTML = title ? title : '';       
             });

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4529,7 +4529,7 @@ var userOverride = {
                         }
                     }else{
                         var lazy_images = document.querySelectorAll('img.lazy_image');
-                        lazy_images.forEach(img => {
+                        lazy_images.forEach(function (img){
                             if(KommunicateUI.isInView(img, document.querySelector('#mck-message-cell .mck-message-inner'))){
                                 KommunicateUI.processLazyImage(img)
                             }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3175,27 +3175,6 @@ var userOverride = {
                     $this.data('name')
                 );
                 var blobKey = $this.find('img').attr('data-blobKey');
-                
-                if(blobKey && href == ''){
-                    KommunicateUI.getUrlFromBlobKey(blobKey, function(err, url){
-                        if(err) throw err;
-                        if(url){
-                            modalImg.src = url;
-                            $this.data('url', url)
-                        }
-                        setTimeout(function(){
-                            $this.data('url', '');
-                        }, 15*60*1000)    
-                    })
-                }else if(href === ''){
-                    var key;
-                    key = $this.data('blobkey');
-                    alFileService.generateCloudUrl(key, function (result) {
-                        href = result;
-                    });
-                }else{
-                    modalImg.src = href;
-                }
                 var modal = parent.document.getElementById(
                     'km-fullscreen-image-modal'
                 );
@@ -3205,6 +3184,19 @@ var userOverride = {
                 var captionText = parent.document.getElementById(
                     'km-fullscreen-image-modal-caption'
                 );
+                if(blobKey && href == ''){
+                    modalImg.src = KommunicateConstants.IMAGE_PLACEHOLDER_URL;
+                    KommunicateUI.processLazyImage(modalImg, blobKey);
+                }else if(href === ''){
+                    var key;
+                    key = $this.data('blobkey');
+                    alFileService.generateCloudUrl(key, function (result) {
+                        href = result;
+                    });
+                }else{
+                    modalImg.src = href;
+                }
+                
                 modal.style.display = 'block';
                 captionText.innerHTML = title ? title : '';       
             });
@@ -4528,10 +4520,10 @@ var userOverride = {
                             });
                         }
                     }else{
-                        var lazy_images = document.querySelectorAll('img.lazy_image');
-                        lazy_images.forEach(function (img){
+                        var lazyImages = document.querySelectorAll('img.lazy-image');
+                        lazyImages.forEach(function (img){
                             if(KommunicateUI.isInView(img, document.querySelector('#mck-message-cell .mck-message-inner'))){
-                                KommunicateUI.processLazyImage(img)
+                                KommunicateUI.processLazyImage(img, img.getAttribute('data-thumbnailBlobKey'))
                             }
                         })
                     }
@@ -7945,7 +7937,7 @@ var userOverride = {
                                         : '');
                             if(message && message.fileMeta && message.fileMeta.contentType.includes('image')){
                                 message.fileMeta.url = '';
-                                message.fileMeta.thumbnailUrl = 'https://via.placeholder.com/350x265'
+                                message.fileMeta.thumbnailUrl = KommunicateConstants.IMAGE_PLACEHOLDER_URL;
                             }
 
                             _this.addMessage(
@@ -7981,9 +7973,10 @@ var userOverride = {
                         },
                         'slow',
                         function (){
-                            var lazyImages = document.querySelectorAll('img.lazy_image')
+                            var lazyImages = document.querySelectorAll('img.lazy-image')
                             lazyImages.forEach(function(img){
-                                KommunicateUI.isInView(img, document.querySelector('#mck-message-cell .mck-message-inner')) && KommunicateUI.processLazyImage(img)
+                                KommunicateUI.isInView(img, document.querySelector('#mck-message-cell .mck-message-inner')) && 
+                                KommunicateUI.processLazyImage(img, img.getAttribute('data-thumbnailBlobKey'))
                             })
                         }
                     );
@@ -9037,7 +9030,7 @@ var userOverride = {
                                         kommunicateCommons.formatHtmlTag(
                                             msg.fileMeta.name
                                         ) +
-                                        '"><img class="lazy_image" src="' +
+                                        '"><img class="lazy-image" src="' +
                                         msg.fileMeta.thumbnailUrl +
                                         '" area-hidden="true" data-blobKey="'+ msg.fileMeta.blobKey +
                                         '" data-thumbnailBlobKey="'+msg.fileMeta.thumbnailBlobKey +'" ></img></a>'


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- To add security for image files.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- add attachment: true in kommunicate settings
- start new conversation and upload an image
- the image should upload
- go back and reopen conversation
- the image should load and upon clicking the image the modal containing image should open

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch

INTRODUCTION TO THE ISSUE:
As of now all the images uploaded to aws server can directly be accessed using the url provided by them. 
To avoid this, aclsPrivate parameter is passed as true. 
Now in order to access image, we need to pass blobkey which will gives us the link for the particular image. The provided link is only accessible for 15 mins. 


