### PR TITLE
FW-2210-Chat widget position is wrong when "Pre chat lead collection" is enabled.

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2110,11 +2110,18 @@ var userOverride = {
                         );
 
                         if (KOMMUNICATE_VERSION === 'v2') {
-                            WIDGET_POSITION ===
-                            KommunicateConstants.POSITION.LEFT
-                                ? (kmAnonymousChatLauncher.style.left = '10px')
-                                : (kmAnonymousChatLauncher.style.right =
-                                      '10px');
+                            if (
+                                WIDGET_POSITION ===
+                                KommunicateConstants.POSITION.LEFT
+                            ) {
+                                kmAnonymousChatLauncher.style.left = '10px';
+                                var kommunicateIframe = parent.document.getElementById(
+                                    'kommunicate-widget-iframe'
+                                );
+                                kommunicateIframe.classList.add('align-left');
+                            } else {
+                                kmAnonymousChatLauncher.style.right = '10px';
+                            }
                             kmAnonymousChatLauncher.style.bottom = '10px';
                         }
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Set chat widget position on left when pre-chat is enabled and widget position is set to left.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Set pre-chat enable from dashboard and widget position is set to left under customization option.
---
![image](https://user-images.githubusercontent.com/22856546/117533463-9de31a80-b00a-11eb-963f-a7bbd6507171.png)
---
![image](https://user-images.githubusercontent.com/22856546/117533395-35943900-b00a-11eb-989a-30d709030736.png)
---
![image](https://user-images.githubusercontent.com/22856546/117533439-7724e400-b00a-11eb-9d1b-1443c3d99dc9.png)
---
![image](https://user-images.githubusercontent.com/22856546/117533445-7ee48880-b00a-11eb-989d-14520dc57ea8.png)


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch