### PR TITLE
FW-2159 Bot messages should auto-scroll when waiting queue message is shown [Chat-Widget]

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -16,6 +16,9 @@ KommunicateUI = {
     faqSVGImage:
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><circle class="km-custom-widget-fill" cx="12" cy="12" r="12" fill="#5553B7" fill-rule="nonzero" opacity=".654"/><g transform="translate(6.545 5.818)"><polygon fill="#FFF" points=".033 2.236 .033 12.057 10.732 12.057 10.732 .02 3.324 .02"/><rect class="km-custom-widget-fill" width="6.433" height="1" x="2.144" y="5.468" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><rect class="km-custom-widget-fill" width="4.289" height="1" x="2.144" y="8.095" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><polygon class="km-custom-widget-fill" fill="#5553B7" points="2.656 .563 3.384 2.487 1.162 3.439" opacity=".65" transform="rotate(26 2.273 2.001)"/></g></g></svg>',
     CONSTS: {},
+    updateScroll: function (element) {
+        element.scrollTop = element.scrollHeight;
+    },
     updateLeadCollectionStatus: function (err, message, data) {
         KommunicateUI.awayMessageInfo = {};
         if (
@@ -68,7 +71,7 @@ KommunicateUI = {
             '.mck-message-inner.mck-group-inner'
         )[0];
         if (KommunicateUI.awayMessageScroll && messageBody) {
-            messageBody.scrollTop = messageBody.scrollHeight;
+            KommunicateUI.updateScroll(messageBody);
             KommunicateUI.awayMessageScroll = false;
         }
     },
@@ -1353,7 +1356,14 @@ KommunicateUI = {
                             'vis'
                         );
                         headerTabTitle.innerHTML = MCK_LABELS['waiting.queue.message']['header.text'];
-                    
+                        var messageBody = document.querySelector(
+                            '.mck-message-inner.mck-group-inner'
+                        );
+                        if (messageBody) {
+                            KommunicateUI.updateScroll(messageBody);
+                            messageBody.scrollTop =
+                            messageBody.scrollHeight;
+                        }
                     } else {
                         kommunicateCommons.modifyClassList(
                             {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1361,8 +1361,6 @@ KommunicateUI = {
                         );
                         if (messageBody) {
                             KommunicateUI.updateScroll(messageBody);
-                            messageBody.scrollTop =
-                            messageBody.scrollHeight;
                         }
                     } else {
                         kommunicateCommons.modifyClassList(


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Bot message auto-scroll when waiting queue message is shown.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Enable waiting queue then start a conversation put a conversation in the waiting queue.
- Check for message body is has to scroll down for multiple bot messages.
---
![image](https://user-images.githubusercontent.com/22856546/117546603-d73a7b00-b048-11eb-9390-c4f033a87262.png)


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- Auto scrolling was not managed while showing the waiting queue message.


NOTE: Make sure you're comparing your branch with the correct base branch