### PR TITLE
FW-2044 Add group metadata support in start conversation | chat widget

### DIFF
--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -87,6 +87,7 @@ Kommunicate.client = {
                 : false,
             KM_CHAT_CONTEXT: JSON.stringify(chatContext),
             GROUP_CREATION_URL: window.kommunicate.IFRAME_OVERRIDES ? window.kommunicate.IFRAME_OVERRIDES.GROUP_CREATION_URL : parent.location.href,
+            conversationMetadata:JSON.stringify(conversationDetail.metadata),
         };
         typeof conversationDetail.teamId != 'undefined' &&
             (groupMetadata.KM_TEAM_ID = conversationDetail.teamId);
@@ -123,17 +124,6 @@ Kommunicate.client = {
                 ) {
                     if (typeof callback == 'function') {
                         callback(response.data.value);
-                    }
-                    var groupId = response.data.value;
-                    if (groupId && conversationDetail.groupMetadata) {
-                        var conversationMetadata = {
-                            groupId: groupId,
-                            metadata: conversationDetail.groupMetadata,
-                        };
-                        conversationMetadata &&
-                            Kommunicate.updateConversationMetadata(
-                                conversationMetadata
-                            );
                     }
                     KommunicateUI.hideFaq();
                     KommunicateUI.showClosedConversationBanner(false);

--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -125,10 +125,10 @@ Kommunicate.client = {
                         callback(response.data.value);
                     }
                     var groupId = response.data.value;
-                    if (groupId && conversationDetail.conversationMetadata) {
+                    if (groupId && conversationDetail.groupMetadata) {
                         var conversationMetadata = {
                             groupId: groupId,
-                            metadata: conversationDetail.conversationMetadata,
+                            metadata: conversationDetail.groupMetadata,
                         };
                         conversationMetadata &&
                             Kommunicate.updateConversationMetadata(

--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -124,6 +124,17 @@ Kommunicate.client = {
                     if (typeof callback == 'function') {
                         callback(response.data.value);
                     }
+                    var groupId = response.data.value;
+                    if (groupId && conversationDetail.conversationMetadata) {
+                        var conversationMetadata = {
+                            groupId: groupId,
+                            metadata: conversationDetail.conversationMetadata,
+                        };
+                        conversationMetadata &&
+                            Kommunicate.updateConversationMetadata(
+                                conversationMetadata
+                            );
+                    }
                     KommunicateUI.hideFaq();
                     KommunicateUI.showClosedConversationBanner(false);
                     /* conversation table migrated to Applozic

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -88,7 +88,7 @@ $applozic.extend(true, Kommunicate, {
             skipBotEvent: params.skipBotEvent,
             customWelcomeEvent: params.customWelcomeEvent,
             metadata: groupMetadata,
-            conversationMetadata: params.metadata,
+            groupMetadata: params.conversationMetadata,
             teamId: params.teamId,
         };
         if (IS_SOCKET_CONNECTED) {
@@ -120,13 +120,15 @@ $applozic.extend(true, Kommunicate, {
 
     updateConversationMetadata: function (conversationMetadata) {
         if (conversationMetadata) {
+            var metadataToSend = {};
+            conversationMetadata.metadata &&
+                (metadataToSend.metadata = conversationMetadata.metadata);
             if (
                 kommunicateCommons.isObject(conversationMetadata) &&
-                kommunicateCommons.isObject(conversationMetadata.metadata) &&
                 conversationMetadata.groupId &&
-                conversationMetadata.metadata
+                metadataToSend &&
+                kommunicateCommons.isObject(metadataToSend)
             ) {
-                var metadataToSend = conversationMetadata.metadata;
                 const groupDataResponse = Applozic.ALApiService.groupUpdate({
                     data: {
                         groupId: conversationMetadata.groupId,
@@ -145,12 +147,12 @@ $applozic.extend(true, Kommunicate, {
                 });
                 return groupDataResponse;
             } else {
-                throw new TypeError(
+                console.error(
                     'updateConversationMetadata expects an object as an argument'
                 );
             }
         } else {
-            throw new Error(
+            console.error(
                 'updateConversationMetadata expect an object but got null'
             );
         }

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -74,6 +74,9 @@ $applozic.extend(true, Kommunicate, {
 
         params.WELCOME_MESSAGE &&
             (groupMetadata.WELCOME_MESSAGE = params.WELCOME_MESSAGE);
+        params.conversationMetadata &&
+            kommunicateCommons.isObject(params.conversationMetadata) &&
+            (groupMetadata = params.conversationMetadata);
 
         var conversationDetail = {
             groupName: groupName,
@@ -88,7 +91,6 @@ $applozic.extend(true, Kommunicate, {
             skipBotEvent: params.skipBotEvent,
             customWelcomeEvent: params.customWelcomeEvent,
             metadata: groupMetadata,
-            groupMetadata: params.conversationMetadata,
             teamId: params.teamId,
         };
         if (IS_SOCKET_CONNECTED) {
@@ -120,15 +122,13 @@ $applozic.extend(true, Kommunicate, {
 
     updateConversationMetadata: function (conversationMetadata) {
         if (conversationMetadata) {
-            var metadataToSend = {};
-            conversationMetadata.metadata &&
-                (metadataToSend.metadata = conversationMetadata.metadata);
             if (
                 kommunicateCommons.isObject(conversationMetadata) &&
+                kommunicateCommons.isObject(conversationMetadata.metadata) &&
                 conversationMetadata.groupId &&
-                metadataToSend &&
-                kommunicateCommons.isObject(metadataToSend)
+                conversationMetadata.metadata
             ) {
+                var metadataToSend = conversationMetadata.metadata;
                 const groupDataResponse = Applozic.ALApiService.groupUpdate({
                     data: {
                         groupId: conversationMetadata.groupId,
@@ -147,12 +147,12 @@ $applozic.extend(true, Kommunicate, {
                 });
                 return groupDataResponse;
             } else {
-                console.error(
+                throw new TypeError(
                     'updateConversationMetadata expects an object as an argument'
                 );
             }
         } else {
-            console.error(
+            throw new Error(
                 'updateConversationMetadata expect an object but got null'
             );
         }

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -88,6 +88,7 @@ $applozic.extend(true, Kommunicate, {
             skipBotEvent: params.skipBotEvent,
             customWelcomeEvent: params.customWelcomeEvent,
             metadata: groupMetadata,
+            conversationMetadata: params.metadata,
             teamId: params.teamId,
         };
         if (IS_SOCKET_CONNECTED) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add a support of group metadata on start conversation function.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Use the below script to test the functionality.

```
(function (d, m) {
      var kommunicateSettings = {
        appId: "8ced8a81108c654234a393115cc2ea4f",
        popupWidget: true,
        onInit: function () {
          var conversationDetail = {
            conversationMetadata: {
              "key1": "honda",
              "key2": "city",
            },
          };
          Kommunicate.startConversation(
            conversationDetail,
            function (response) {
              console.log("new conversation created");
            }
          );
        },
      };
      var s = document.createElement("script");
      s.type = "text/javascript";
      s.async = true;
      s.src = "http://localhost:3030/v2/kommunicate.app";
      var h = document.getElementsByTagName("head")[0];
      h.appendChild(s);
      window.kommunicate = m;
      m._globals = kommunicateSettings;
    })(document, window.kommunicate || {});
```
---
![image](https://user-images.githubusercontent.com/22856546/117974408-27685480-b34b-11eb-970c-6e69ad6504b0.png)

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch