### PR TITLE
FW-2226 Make improvements in the file encryption logic in chat widget

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7956,8 +7956,8 @@ var userOverride = {
             _this.isFileEncryptedImage = function (fileMeta){
                 return (
                     fileMeta && 
-                    fileMeta.contentType && fileMeta.contentType.includes('image') &&
-                    fileMeta.name && fileMeta.name.includes('AWS-ENCRYPTED')
+                    fileMeta.contentType && fileMeta.contentType.indexOf('image') !== -1 &&
+                    fileMeta.name && fileMeta.name.indexOf('AWS-ENCRYPTED') !== -1
                     );
             };
             _this.processMessageList = function (
@@ -14281,31 +14281,8 @@ var userOverride = {
                     });
                 }
             };
-            _this.createFile = function (blob, fileName){
-                try{
-                    // for other browsers
-                    return new File(blob, fileName, {
-                        type: blob[0].type,
-                        lastModified: blob[0].lastModified
-                    });
-                } catch(error){
-                    // for IE
-                    var newBlob = new Blob(blob,{
-                                type: blob[0].type
-                    });
-                    newBlob.lastModifiedDate = blob[0].lastModifiedDate;
-                    newBlob.lastModified = blob[0].lastModified;
-                    newBlob.name = fileName;
-                    return newBlob 
-                };
-            };
             _this.uploadAttachment2AWS = function (params, messagePxy) {
                 var file = params.file;
-                if(file.type.includes('image')){
-                    var newFileName = 'AWS-ENCRYPTED-'+file.name;
-                    var newFile = _this.createFile([file], newFileName);
-                    file = newFile;
-                };
                 var data = new FormData();
                 var uploadErrors = [];
                 var stopUpload = false;
@@ -14381,7 +14358,15 @@ var userOverride = {
                     var uniqueId = params.name + file.size;
                     TAB_FILE_DRAFT[uniqueId] = currTab;
                     $mck_msg_sbmt.attr('disabled', true);
-                    data.append('file', file);
+                    
+                    if(file.type.indexOf('image') !== -1){
+                        // for encrypted images
+                        var newFileName = 'AWS-ENCRYPTED-'+file.name;
+                        data.append('file', file, newFileName);
+                    }else{
+                        data.append('file', file);
+                    }
+                
                     var xhr = new XMLHttpRequest();
                     (xhr.upload || xhr).addEventListener(
                         'progress',
@@ -14476,7 +14461,7 @@ var userOverride = {
                         }
                     });
                     var ATTACHMENT_UPLOAD_URL = '/rest/ws/upload/image';
-                    if (MCK_CUSTOM_UPLOAD_SETTINGS === 'awsS3Server' && file.type.includes('image')) {
+                    if (MCK_CUSTOM_UPLOAD_SETTINGS === 'awsS3Server' && file.type.indexOf('image') !== -1) {
                         ATTACHMENT_UPLOAD_URL = ATTACHMENT_UPLOAD_URL + '?aclsPrivate=true';
                     };  
                     var url = MCK_BASE_URL + ATTACHMENT_UPLOAD_URL;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -13779,6 +13779,7 @@ var userOverride = {
             var FILE_AWS_UPLOAD_URL = '/rest/ws/upload/file';
             var FILE_DELETE_URL = '/rest/ws/aws/file/delete';
             var CUSTOM_FILE_UPLOAD_URL = '/files/upload/';
+            var ATTACHMENT_UPLOAD_URL = '/rest/ws/upload/image';
             var mck_filebox_tmpl =
                 '<div id="mck-filebox-${fileIdExpr}" class="mck-file-box ${fileIdExpr}">' +
                 '<div class="mck-file-expr">' +
@@ -14460,11 +14461,12 @@ var userOverride = {
                             $file_remove.trigger('click');
                         }
                     });
-                    var ATTACHMENT_UPLOAD_URL = '/rest/ws/upload/image';
+                    var queryParams;
                     if (MCK_CUSTOM_UPLOAD_SETTINGS === 'awsS3Server' && file.type.indexOf('image') !== -1) {
-                        ATTACHMENT_UPLOAD_URL = ATTACHMENT_UPLOAD_URL + '?aclsPrivate=true';
+                        queryParams = '?aclsPrivate=true';
                     };  
                     var url = MCK_BASE_URL + ATTACHMENT_UPLOAD_URL;
+                    queryParams && (url = url + queryParams);
                     xhr.open('post', url, true);
                     window.Applozic.ALApiService.addRequestHeaders(xhr);
                     xhr.send(data);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The encrypted images should distinguishable from non-encrypted images.
- Both encrypted and non encrypted images should open.
- The videos should be handled 

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- open chat widget using plugin-6.6.4 or lower upload image A.
- open chat widget using this branch upload image B
- upload a video from this branch 
- all the three media should be visible in the chat widget

### What new thing you came across while writing this code? 
- 

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch