### PR TITLE
fix for the case where the outline was comming for list rich message in hidePostCTA

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -8360,24 +8360,25 @@ var userOverride = {
                 ) {
                     botMessageDelayClass = 'n-vis';
                 }
-                if (
+                 if (
                     HIDE_POST_CTA &&
                     richText &&
                     (
                         kmRichTextMarkup.indexOf('km-cta-multi-button-container') != -1 || 
                         kmRichTextMarkup.indexOf('km-faq-list--footer_button-container') != -1 
                     ) &&
-                    kmRichTextMarkup.indexOf('<button') != -1 &&
+                    (   
+                        kmRichTextMarkup.indexOf('<button') != -1 || 
+                        kmRichTextMarkup.indexOf('km-list-item-handler') != -1 
+                    ) 
+                    &&
                     kmRichTextMarkup.indexOf('km-link-button') == -1
                 ) {
-                    if(!append){
-                        // if type of message is richmessage having CTA buttons and it does not include links then it should not be visible
-                        botMessageDelayClass = 'n-vis';
-                    }else{
                         // this class is added to the message template if the message contains CTA buttons having only quick replies.
-                        botMessageDelayClass = botMessageDelayClass + " contains-quick-replies-only";
-                    }
+                       botMessageDelayClass = botMessageDelayClass + " contains-quick-replies-only";
+                 
                 }
+                
 
                 // if (!richText && !attachment && messageClass == "n-vis"){
                 //     // if it is not a rich msg and neither contains any text then dont precess it because in UI it is shown as empty text box which does not look good.


### PR DESCRIPTION

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- the list type rich message should be handled properly
- the outline shown below should not appear
![Screenshot 2021-05-20 at 4 21 23 PM](https://user-images.githubusercontent.com/19753380/118966854-a54de080-b987-11eb-8334-b8d75b3a2b54.png)


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- use following payload to test in dialogflow and kompose
- `{
    "message": "This is the sample json for list template",
    "platform": "kommunicate",
    "metadata": {
        "contentType": "300",
        "templateId": "7",
        "payload": {
            "elements": [
                {
                    "imgSrc": "",
                    "title": "quick reply",
                    "description": "Description for the list item",
                    "action": {
                        "type": "quick_reply",
                        "text": "This text will be sent as message"
                    }
                },
                {
                    "imgSrc": "",
                    "title": "quick reply",
                    "description": "Description for the list item",
                    "action": {
                        "type": "quick_reply",
                        "text": "This text will be sent as message"
                    }
                }
            ]
        }
    }
}`

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch