### PR TITLE
FW-2221 HidePostCTA is not working for Dialogflow [Fix]

### DIFF
--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -249,9 +249,11 @@ Kommunicate.markup = {
     },
     getQuickRepliesTemplate: function () {
         return `
+        <div class='km-cta-multi-button-container' >
             {{#payload}}
                  <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-hidePostCTA="{{hidePostCTA}}">{{title}}</button>
             {{/payload}}
+        <div>
             `;
     },
     getGenericSuggestedReplyButton: function () {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- HidePostCTA is not working for Dialogflow.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Select any Dialogflow bot and set the hidePostCTA to `true` in script settings.
- check if hidePostCTA is working fine or not.

https://user-images.githubusercontent.com/22856546/118983735-5eb5b180-b99a-11eb-8550-b1fd7f797fc1.mov



### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- Markup return for the Rich message is not having the proper class name

NOTE: Make sure you're comparing your branch with the correct base branch