### PR TITLE
FW-2376 User is able to reply after conversation got resolved [VOGO][PROD]

### DIFF
--- a/webplugin/js/app/events/applozic-event-handler.js
+++ b/webplugin/js/app/events/applozic-event-handler.js
@@ -58,7 +58,13 @@ Kommunicate.KmEventHandler = {
         }
     },
     onMessageSent: function (message) {
-        if (!(message && message.metadata && message.metadata.feedback)) {
+        if (!(
+                message && 
+                message.metadata && 
+                message.metadata.feedback || 
+                message.metadata.KM_STATUS == KommunicateConstants.CONVERSATION_CLOSED_STATUS ||
+                message.metadata.KM_STATUS == KommunicateConstants.CONVERSATION_RESOLVED_STATUS
+                )) {
             KommunicateUI.showClosedConversationBanner(false);
         }
     },


### PR DESCRIPTION

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The end user should not be able to reply once conv is resolved

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- create a conversation
- assign to human agent
- use https://apps-test.applozic.com/rest/ws/group/status/change?groupId=433196&status=2 api to change the status
- upon success response the conv should get resolved

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- the resp coming in onMessage() is having type 'APPLOZIC_02' and for this case the showClosedConversationBanner() was getting false as argument

NOTE: Make sure you're comparing your branch with the correct base branch