### PR TITLE
Fix close button in feedback banner [chat-widget]

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1044,6 +1044,11 @@ KommunicateUI = {
             );
         } else if (isConversationClosed && KommunicateUI.isConvJustResolved) {
             KommunicateUI.triggerCSAT();
+            kommunicateCommons.modifyClassList(
+                { id: ['mck-csat-close'] },
+                'n-vis',
+                'vis'
+            );
         } else if (isConversationClosed) {
             conversationStatusDiv &&
                 (conversationStatusDiv.innerHTML = messageText);

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4479,6 +4479,11 @@ var userOverride = {
                 ) {
                     e.preventDefault();
                     KommunicateUI.triggerCSAT();
+                    kommunicateCommons.modifyClassList(
+                        { id: ['mck-csat-close'] },
+                        'vis',
+                        'n-vis'
+                    );
                 };
                 document.getElementById('km-csat-close-button').onclick = function(e){
                     e.preventDefault();

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -324,7 +324,7 @@
 								</svg>
 							</div>
 						</div>
-					<div id="mck-csat-close">
+					<div id="mck-csat-close" class="n-vis">
 						<button type="button" id="km-csat-close-button" class="mck-csat-close-button">
 							<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 								<path


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Show CSAT close button only when user click on the Rate conversation button in chat widget side.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->

- Parent PR: (#692)
---
https://user-images.githubusercontent.com/22856546/122930433-9f359000-d389-11eb-8780-f7ea4592d2b0.mov


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch