### PR TITLE
Fix overflow for IE in quick replies menu [Chat widget]

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -1784,7 +1784,8 @@
 	min-width: 130px;
 	max-width: 220px;
 	max-height: 150px;
-	overflow: hidden auto;
+	overflow-x: hidden;
+	overflow-y: auto;
 	scrollbar-width: thin;
 	border-radius: 4px;
 	font-size: 14px;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix overflow for IE in quick replies menu.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
---
![image](https://user-images.githubusercontent.com/22856546/124954111-62c58d80-e033-11eb-9274-6c773af5e40b.png)


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- CSS property is not compatible with IE.

NOTE: Make sure you're comparing your branch with the correct base branch