### PR TITLE
FW-2482 Kompose bot stuck in the middle if the conversation is too long [Chat widget]

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -22,6 +22,12 @@ KommunicateUI = {
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><circle class="km-custom-widget-fill" cx="12" cy="12" r="12" fill="#5553B7" fill-rule="nonzero" opacity=".654"/><g transform="translate(6.545 5.818)"><polygon fill="#FFF" points=".033 2.236 .033 12.057 10.732 12.057 10.732 .02 3.324 .02"/><rect class="km-custom-widget-fill" width="6.433" height="1" x="2.144" y="5.468" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><rect class="km-custom-widget-fill" width="4.289" height="1" x="2.144" y="8.095" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><polygon class="km-custom-widget-fill" fill="#5553B7" points="2.656 .563 3.384 2.487 1.162 3.439" opacity=".65" transform="rotate(26 2.273 2.001)"/></g></g></svg>',
     CONSTS: {},
     updateScroll: function (element) {
+        element.animate(
+            {
+                scrollTop: element.scrollHeight,
+            },
+            0
+        );
         element.scrollTop = element.scrollHeight;
     },
     updateLeadCollectionStatus: function (err, message, data) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -11899,13 +11899,11 @@ var userOverride = {
                     );
                     $applozic('.km-typing-wrapper').remove();
                     if (message) {
+                        var msgBody = document.querySelectorAll(
+                            '.mck-message-inner.mck-group-inner'
+                        )[0];
                         message.classList.remove('n-vis');
-                        $mck_msg_inner.animate(
-                            {
-                                scrollTop: $mck_msg_inner.prop('scrollHeight'),
-                            },
-                            0
-                        );
+                        KommunicateUI.updateScroll(msgBody);
                     }
                     MCK_BOT_MESSAGE_QUEUE.shift();
                     MCK_BOT_MESSAGE_QUEUE.length != 0 &&


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Kompose bot stuck in the middle if the conversation is too long.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Check for scrolling of long messages in chat widget.
---
https://user-images.githubusercontent.com/22856546/125408305-690f8d00-e3d8-11eb-9608-5758d593d2de.mov



### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch