### PR TITLE
FW-2485 Restart conversation button is missing if CSAT rating is disabled and the agent Resolves the chat

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -930,6 +930,14 @@ KommunicateUI = {
                 'n-vis'
             );
             KommunicateUI.updateScroll(messageBody);
+        } else {
+            kommunicateCommons.modifyClassList(
+                {
+                    class: ['mck-csat-text-1'],
+                },
+                'vis',
+                'n-vis'
+            );
         }
     },
     showClosedConversationBanner: function (isConversationClosed) {
@@ -1043,7 +1051,7 @@ KommunicateUI = {
                         'mck-submit-comment'
                     ).disabled = false;
                 }
-                KommunicateUI.updateScroll(messageBody)
+                KommunicateUI.updateScroll(messageBody);
             }
         } else if (
             isConversationClosed &&


### PR DESCRIPTION

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Restart conversation button is missing if CSAT rating is disabled and the agent Resolves the chat bug fix 

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Disable CSAT from the dashboard 
- Start the conversation from widget 
- Resolve the conversations from Dashboard
- Restart conversation button link should show on the chat widget 

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch