### PR TITLE
FW 2458 Added support for Google Analytics traking id from dashboard [chat widget]

### DIFF
--- a/webplugin/js/app/km-widget-custom-events.js
+++ b/webplugin/js/app/km-widget-custom-events.js
@@ -10,7 +10,10 @@ var kmWidgetEvents = {
         eventLabel,
         eventValue
     ) {
-        var trackingID = applozic._globals.gaTrackingID;
+        var trackingID =
+                applozic._globals.gaTrackingID ||
+                (applozic._globals.appSettings.chatWidget.isGAEnabled &&
+                    applozic._globals.appSettings.chatWidget.gaTrackingId);
         if (trackingID && typeof window.top.ga !== 'undefined') {
             window.top.ga('create', trackingID.toString(), 'auto');
             window.top.ga('send', {
@@ -31,7 +34,11 @@ var kmWidgetEvents = {
             if (customValue) {
                 eventObject.data.eventValue = customValue;
             }
-            applozic._globals.gaTrackingID &&
+            var trackingID =
+                applozic._globals.gaTrackingID ||
+                (applozic._globals.appSettings.chatWidget.isGAEnabled &&
+                    applozic._globals.appSettings.chatWidget.gaTrackingId);
+            trackingID &&
                 kmWidgetEvents.sendEventToGoogleAnalytics(
                     eventObject.data.eventCateogry,
                     eventObject.data.eventAction,


### PR DESCRIPTION

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Send chat widget events to Google Analytics.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->

- Parent PR: https://github.com/Kommunicate-io/Kommunicate-Dashboard/pull/698
- Track all events are sending to the Google Analytics from the chat widget by setting GA TRacking Id from both side( kommunicateSettings or dashboard settings).
---
https://user-images.githubusercontent.com/22856546/125790787-267c2c6e-0936-4da2-b228-fcb84ee25d2c.mov
### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch

