### PR TITLE
FW-2475 Make scrollbar of pre-chat lead collection same as Chrome for Firefox [Chat-widget]

### DIFF
--- a/webplugin/css/app/km-login-model.css
+++ b/webplugin/css/app/km-login-model.css
@@ -153,7 +153,8 @@
 	height: calc(100% - 61px);
 	border-radius: 0px 0px 6px 6px;
 	background-color: #fff;
-	overflow-y: scroll;
+	overflow-y: auto;
+	scrollbar-width: thin;
 }
 .km-sidemodal--modal-header {
 	padding: 0 10px;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Make scroll bar visible when required.
- scroll bar should be having thin width similar to chrome

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- enable prechat lead collection
- go to any random site and initiate chat widget
- the prechat lead form will have scroll bar only if the form is long
- the scroll bar will have appearance similar to that of chrome

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch