### PR TITLE
Fix remove extra text from the link preview [Chat widget]

### DIFF
--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -211,8 +211,7 @@ Kommunicate.markup = {
                 '"></div><div class="link-preview-content"><h5 class="link-preview-title link-preview-title-width"> ' +
                 (data.siteName || data.title) +
                 '</h5><p class="link-preview-div-description">' +
-                (data.description || data.title) +
-                '</p></div></div>'+MCK_LABELS["url.notation"]+':'
+                (data.description || data.title)
             );
         }
     },

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -132,7 +132,6 @@ Kommunicate.defaultLabels = {
         SUBMIT_RATING: 'Submit your rating',
     },
     'page.title.on.new.message': 'New message from ',
-    'url.notation': 'Here is the link',
     'emoji.hover.text': {
         poor: 'Poor',
         great: 'Great',


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Remove "Here is the llink"  text from the link preview.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Check for the "Here is the link" in link preview.
---
![image](https://user-images.githubusercontent.com/22856546/131951786-947a4504-18e0-4fc2-96f7-79f5c4e662fc.png) 

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch