### PR TITLE
FW-2740 [Important] Add Form inputs in chat transcript 

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -1350,7 +1350,7 @@
     color: #333333;
 }
 .mck-form-template-container button {
-    width: 23%;
+    min-width: 23%;
     border-radius: 19px;
     padding: 5px;
     margin-top: 12px;

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -658,8 +658,13 @@ Kommunicate.richMsgEventHandler = {
         var messagePxy = {};
         var msgMetadata = {};
         replyText && (messagePxy.message = replyText); //message to send
-        var postFormDataAsMessage = 
-        data && JSON.stringify(data).replaceAll("{", "").replaceAll('\"', '').replaceAll("}", "").replaceAll(",","\n");
+        var postFormDataAsMessage =
+            data &&
+            JSON.stringify(data)
+                .replaceAll('{', '')
+                .replaceAll('"', '')
+                .replaceAll('}', '')
+                .replaceAll(',', '\n');
         
         isActionableForm &&
             requestType == KommunicateConstants.POST_BACK_TO_BOT_PLATFORM &&

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -556,7 +556,7 @@ Kommunicate.richMsgEventHandler = {
         var postBackToKommunicate = isActionableForm
             ? JSON.parse(target.dataset.postBackToKommunicate.toLowerCase())
             : false;
-        var ispostBackAsMessage = isActionableForm
+        var postBackAsMessage = isActionableForm
             ? JSON.parse(target.dataset.postBackAsMessage.toLowerCase())
             : false;
         var replyText = target.title || target.innerHTML;
@@ -657,14 +657,15 @@ Kommunicate.richMsgEventHandler = {
         }
         var messagePxy = {};
         var msgMetadata = {};
-        var postFormDataAsMessage =
-            ispostBackAsMessage &&
-            data &&
-            JSON.stringify(data)
-                .replaceAll('{', '')
-                .replaceAll('"', '')
-                .replaceAll('}', '')
-                .replaceAll(',', '\n');
+        var postFormDataAsMessage='';
+        if (postBackAsMessage && Object.keys(data).length) {
+            for (var i = 0; i < Object.keys(data).length; i++) {
+                var key = Object.keys(data)[i];
+                postFormDataAsMessage = postFormDataAsMessage.concat(
+                    key + ':' + data[key] + '\n'
+                );
+            }
+        }
         messagePxy.message = replyText
             && postFormDataAsMessage
                 ? replyText.concat('\n' + postFormDataAsMessage)

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -556,7 +556,7 @@ Kommunicate.richMsgEventHandler = {
         var postBackToKommunicate = isActionableForm
             ? JSON.parse(target.dataset.postBackToKommunicate.toLowerCase())
             : false;
-        var postFormDataAsMessage = isActionableForm
+        var ispostBackAsMessage = isActionableForm
             ? JSON.parse(target.dataset.postBackAsMessage.toLowerCase())
             : false;
         var replyText = target.title || target.innerHTML;
@@ -657,14 +657,18 @@ Kommunicate.richMsgEventHandler = {
         }
         var messagePxy = {};
         var msgMetadata = {};
-        replyText && (messagePxy.message = replyText); //message to send
         var postFormDataAsMessage =
+            ispostBackAsMessage &&
             data &&
             JSON.stringify(data)
                 .replaceAll('{', '')
                 .replaceAll('"', '')
                 .replaceAll('}', '')
                 .replaceAll(',', '\n');
+        messagePxy.message = replyText
+            && postFormDataAsMessage
+                ? replyText.concat('\n' + postFormDataAsMessage)
+                : replyText; //message to send
         
         isActionableForm &&
             requestType == KommunicateConstants.POST_BACK_TO_BOT_PLATFORM &&
@@ -682,11 +686,6 @@ Kommunicate.richMsgEventHandler = {
         (Object.keys(msgMetadata).length > 0 ||
             Object.keys(messagePxy).length > 0) &&
         Kommunicate.sendMessage(messagePxy);
-        postFormDataAsMessage && 
-        Kommunicate.sendMessage({
-            message: postFormDataAsMessage,
-            type: KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT,
-        });
     },
     handleFormErrorMessage: function (form, name, errorText, validationFailed) {
         var element = form.getElementsByClassName(

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -556,6 +556,9 @@ Kommunicate.richMsgEventHandler = {
         var postBackToKommunicate = isActionableForm
             ? JSON.parse(target.dataset.postBackToKommunicate.toLowerCase())
             : false;
+        var postFormDataAsMessage = isActionableForm
+            ? JSON.parse(target.dataset.postBackAsMessage.toLowerCase())
+            : false;
         var replyText = target.title || target.innerHTML;
         var formElements = [];
         formElements = Array.prototype.concat.apply(
@@ -655,7 +658,9 @@ Kommunicate.richMsgEventHandler = {
         var messagePxy = {};
         var msgMetadata = {};
         replyText && (messagePxy.message = replyText); //message to send
-
+        var postFormDataAsMessage = 
+        data && JSON.stringify(data).replaceAll("{", "").replaceAll('\"', '').replaceAll("}", "").replaceAll(",","\n");
+        
         isActionableForm &&
             requestType == KommunicateConstants.POST_BACK_TO_BOT_PLATFORM &&
             (msgMetadata['KM_CHAT_CONTEXT'] = { formData: data });
@@ -671,7 +676,12 @@ Kommunicate.richMsgEventHandler = {
             (messagePxy['metadata'] = msgMetadata);
         (Object.keys(msgMetadata).length > 0 ||
             Object.keys(messagePxy).length > 0) &&
-            Kommunicate.sendMessage(messagePxy);
+        Kommunicate.sendMessage(messagePxy);
+        postFormDataAsMessage && 
+        Kommunicate.sendMessage({
+            message: postFormDataAsMessage,
+            type: KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT,
+        });
     },
     handleFormErrorMessage: function (form, name, errorText, validationFailed) {
         var element = form.getElementsByClassName(

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -490,7 +490,7 @@ Kommunicate.markup = {
                         {{/payload}}
                     </div>
                         {{#buttons}}
-                            <button type="{{type}}" class="km-cta-button km-custom-widget-text-color km-custom-widget-border-color mck-form-submit-button" data-requesttype="{{requestType}}" title="{{message}}" data-post-back-to-kommunicate="{{postBackToKommunicate}}">{{label}}</button>      
+                            <button type="{{type}}" class="km-cta-button km-custom-widget-text-color km-custom-widget-border-color mck-form-submit-button" data-requesttype="{{requestType}}" title="{{message}}" data-post-back-to-kommunicate="{{postBackToKommunicate}}" data-post-back-as-message="{{postFormDataAsMessage}}">{{label}}</button>      
                         {{/buttons}}   
                 </form>   
             </div>`;
@@ -852,6 +852,9 @@ Kommunicate.markup.getActionableFormMarkup = function (options) {
                     (isActionObject && item.action.requestType);
                 options.postBackToKommunicate =
                     (isActionObject && item.action.postBackToKommunicate) ||
+                    false;
+                options.postFormDataAsMessage =
+                    (isActionObject && item.action.postFormDataAsMessage) ||
                     false;
                 options.label = item.name || item.label;
                 options.message =

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -521,7 +521,6 @@ $applozic.extend(true, Kommunicate, {
             return 'km-fixed-container';
         }
     },
-    processPaymentRequest: function (options) {},
     sendMessage: function (messagePxy) {
         var $mck_msg_inner = $applozic('#mck-message-cell .mck-message-inner');
         var $mck_msg_to = $applozic('#mck-msg-to');


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add support of Form inputs in chat transcript.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-  Use this new property `"postFormDataAsMessage": "true"` inside the `action ` of form templete.
```
"action": {
      "message": "Submit details",
      "requestType": "postBackToBotPlatform",
      "postFormDataAsMessage": "true",
      "formAction": "https://reqres.in/api/users"
  }
```
- Click on send transcript to user button in the conversation section and check for form data in the chat transcript.
---

https://user-images.githubusercontent.com/22856546/132954722-b7d1ebdc-182f-4351-bbbf-06cc5213000b.mov



### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch