### PR TITLE
FW-2676 [Imp] Add video capture on Chat widget.

### DIFF
--- a/server/config/config-env.js
+++ b/server/config/config-env.js
@@ -5,7 +5,7 @@ const configEnv = {
             applozicBaseUrl: 'https://chat-test.kommunicate.io',
             kommunicateBaseUrl: 'https://api-test.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
-            hostUrl: 'http://192.168.0.106:3030',
+            hostUrl: 'http://localhost:3030',
         },
         pluginProperties: {
             pseudoNameEnabled: true,

--- a/server/config/config-env.js
+++ b/server/config/config-env.js
@@ -5,7 +5,7 @@ const configEnv = {
             applozicBaseUrl: 'https://chat-test.kommunicate.io',
             kommunicateBaseUrl: 'https://api-test.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
-            hostUrl: 'http://localhost:3030',
+            hostUrl: 'http://192.168.0.106:3030',
         },
         pluginProperties: {
             pseudoNameEnabled: true,

--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -1818,7 +1818,7 @@ ul.mck-intent-menu>li:hover {
 #mck-btn-attach-box.mck-text-box-panel {
 	width: auto !important;
 }
-#mck-attach-img-box{
+.mck-attach-img-vid-box{
 	width: auto !important;
 	float: right !important;
 	display: block;

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -451,6 +451,10 @@ function ApplozicSidebox() {
                 options.capturePhoto != null
                     ? options.capturePhoto
                     : widgetSettings && widgetSettings.capturePhoto;
+            options.captureVideo =
+                options.captureVideo != null
+                    ? options.captureVideo
+                    : widgetSettings && widgetSettings.captureVideo;
             KommunicateUtils.deleteDataFromKmSession('settings');
 
             if (

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3746,7 +3746,8 @@ var userOverride = {
                             'mck-file-up',
                             'mck-btn-loc',
                             'mck-btn-smiley-box',
-                            'mck-img-file-up'
+                            'mck-img-file-up',
+                            'mck-vid-file-up',
                         ],
                     },
                     'n-vis',
@@ -3766,7 +3767,7 @@ var userOverride = {
                     ''
                     );
                 !IS_CAPTURE_VIDEO && kommunicateCommons.modifyClassList(
-                    { id: ['mck-attach-vid-box']},
+                    { id: ['mck-vid-file-up']},
                     'n-vis',
                     ''
                     );
@@ -3803,7 +3804,7 @@ var userOverride = {
                         );
                 IS_CAPTURE_VIDEO &&
                     kommunicateCommons.modifyClassList(
-                        { id: ['mck-attach-vid-box'] },
+                        { id: ['mck-vid-file-up'] },
                         '',
                         'n-vis'
                         );

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -75,6 +75,7 @@ var userOverride = {
         voiceInput: false,
         voiceOutput: false,
         capturePhoto: false,
+        captureVideo: false,
     };
     var message_default_options = {
         messageType: 5,
@@ -388,6 +389,7 @@ var userOverride = {
         var MCK_USER_NAME = appOptions.userName;
         var IS_MCK_LOCSHARE = appOptions.locShare;
         var IS_CAPTURE_PHOTO = appOptions.capturePhoto;
+        var IS_CAPTURE_VIDEO = appOptions.captureVideo;
         var IS_CALL_ENABLED = appOptions.video;
         var MCK_FILE_URL = appOptions.fileBaseUrl;
         var MCK_ON_PLUGIN_INIT = appOptions.onInit;
@@ -831,6 +833,12 @@ var userOverride = {
                     'n-vis',
                     ''
             );
+            !IS_CAPTURE_VIDEO &&
+                kommunicateCommons.modifyClassList(
+                    { id: ['mck-attach-vid-box', 'mck-vid-file-up'] },
+                    'n-vis',
+                    ''
+            );
             VOICE_INPUT_ENABLED &&
                 Kommunicate.typingAreaService.showMicIfSpeechRecognitionSupported();
 
@@ -1153,6 +1161,7 @@ var userOverride = {
             MCK_FILE_URL = optns.fileBaseUrl;
             IS_MCK_LOCSHARE = optns.locShare;
             IS_CAPTURE_PHOTO = optns.capturePhoto;
+            IS_CAPTURE_VIDEO = optns.captureVideo;
             IS_CALL_ENABLED = appOptions.video;
             MCK_ON_PLUGIN_INIT = optns.onInit;
             MCK_ON_TOPIC_DETAILS = optns.onTopicDetails;
@@ -3756,6 +3765,11 @@ var userOverride = {
                     'n-vis',
                     ''
                     );
+                !IS_CAPTURE_VIDEO && kommunicateCommons.modifyClassList(
+                    { id: ['mck-attach-vid-box']},
+                    'n-vis',
+                    ''
+                    );
             };
 
             _this.hideSendButton = function () {
@@ -3784,6 +3798,12 @@ var userOverride = {
                 IS_CAPTURE_PHOTO &&
                     kommunicateCommons.modifyClassList(
                         { id: ['mck-img-file-up'] },
+                        '',
+                        'n-vis'
+                        );
+                IS_CAPTURE_VIDEO &&
+                    kommunicateCommons.modifyClassList(
+                        { id: ['mck-attach-vid-box'] },
                         '',
                         'n-vis'
                         );
@@ -14085,12 +14105,14 @@ var userOverride = {
             var $mck_text_box = $applozic('#mck-text-box');
             var $mck_file_input = $applozic('#mck-file-input');
             var $mck_img_file_input = $applozic('#mck-image-input');
+            var $mck_vid_file_input = $applozic('#mck-video-input');
             var $mck_autosuggest_search_input = $applozic(
                 '#mck-autosuggest-search-input'
             );
             var $mck_overlay_box = $applozic('.mck-overlay-box');
             var $mck_file_upload = $applozic('.mck-file-upload');
-            var $mck_img_upload = $applozic('#mck-img-file-up')
+            var $mck_img_upload = $applozic('#mck-img-file-up');
+            var $mck_vid_upload = $applozic('#mck-vid-file-up');
             var $mck_group_icon_upload = $applozic('#mck-group-icon-upload');
             var $mck_group_icon_change = $applozic('#mck-group-icon-change');
             var $mck_group_info_icon_box = $applozic(
@@ -14150,6 +14172,13 @@ var userOverride = {
                     );
                     $mck_img_file_input.trigger('click');
                 });
+                $mck_vid_upload.on('click', function (e) {
+                    e.preventDefault();
+                    kmWidgetEvents.eventTracking(
+                        eventMapping.onCameraButtonClick
+                    );
+                    $mck_vid_file_input.trigger('click');
+                });
                 $mck_group_icon_upload.on('change', function () {
                     var file = $applozic(this)[0].files[0];
                     _this.uplaodFileToAWS(file, UPLOAD_VIA[0]);
@@ -14164,7 +14193,7 @@ var userOverride = {
                 function uploadFileFunction () {
                     var file = $applozic(this)[0].files[0];
                     var tabId = $mck_msg_inner.data('mck-id');
-                    if (file && KommunicateUI.isAttachmentV2(file.type)) {
+                    if (file && KommunicateUI.isAttachmentV2(file.type) && !IS_CAPTURE_VIDEO) {
                         Kommunicate.attachmentService.getFileMeta(
                             file,
                             tabId,
@@ -14200,6 +14229,7 @@ var userOverride = {
                 }
                 $mck_file_input.on('change', uploadFileFunction );
                 $mck_img_file_input.on('change', uploadFileFunction );
+                $mck_vid_file_input.on('change', uploadFileFunction );
                 
                 $applozic(d).on('click', '.mck-remove-file', function () {
                     var $currFileBox = $applozic(this).parents('.mck-file-box');

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -431,12 +431,19 @@
 											</button>
 										</div>
 									</div>
-									<div id="mck-attach-img-box" class="mck-blk-12">
+									<div id="mck-attach-img-box" class="mck-blk-12 mck-attach-img-vid-box">
 										<button id="mck-img-file-up" type="button" class="mck-img-file-up mck-file-attach-label mck-btn mck-btn-text-panel" title="Upload Attachment" aria-disabled="false" aria-label="Upload Image" tabindex="0">
 											<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 												<path d="M11.8889 15.5556C13.3616 15.5556 14.5556 14.3616 14.5556 12.8889C14.5556 11.4161 13.3616 10.2222 11.8889 10.2222C10.4161 10.2222 9.22222 11.4161 9.22222 12.8889C9.22222 14.3616 10.4161 15.5556 11.8889 15.5556Z" fill="#787474"/>
 												<path d="M19 5.77778H16.1822L15.08 4.57778C14.7511 4.21333 14.2711 4 13.7733 4H10.0044C9.50667 4 9.02667 4.21333 8.68889 4.57778L7.59556 5.77778H4.77778C3.8 5.77778 3 6.57778 3 7.55556V18.2222C3 19.2 3.8 20 4.77778 20H19C19.9778 20 20.7778 19.2 20.7778 18.2222V7.55556C20.7778 6.57778 19.9778 5.77778 19 5.77778ZM11.8889 17.3333C9.43556 17.3333 7.44444 15.3422 7.44444 12.8889C7.44444 10.4356 9.43556 8.44444 11.8889 8.44444C14.3422 8.44444 16.3333 10.4356 16.3333 12.8889C16.3333 15.3422 14.3422 17.3333 11.8889 17.3333Z" fill="#787474"/>
 												</svg>												
+										</button>
+									</div>
+									<div id="mck-attach-vid-box" class="mck-blk-12 mck-attach-img-vid-box">
+										<button id="mck-vid-file-up" type="button" class="mck-img-vid-up mck-file-attach-label mck-btn mck-btn-text-panel" title="Upload Attachment" aria-disabled="false" aria-label="Upload Video" tabindex="0">
+											<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" fill="#787474">
+												<path d="M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l2.29 2.29c.63.63 1.71.18 1.71-.71V8.91c0-.89-1.08-1.34-1.71-.71L17 10.5z"/>
+											</svg>												
 										</button>
 									</div>
 									<div id ="mck-mic-animation-container" class="mck-mic-animation-container n-vis" aria-disabled="false" title="Voice Input" aria-label="Voice Input" tabindex="0">
@@ -486,6 +493,7 @@
 									
 									<input id="mck-file-input" class="mck-file-input n-vis" type="file" name="files[]">
 									<input id="mck-image-input" class="mck-image-input n-vis" type="file" name="files[]" accept="image/*" capture="user">
+									<input id="mck-video-input" class="n-vis" type="file" name="files[]" accept="video/*" capture>
 									<div id="mck-file-box" class="n-vis"></div>
 								</div>
 							</div>


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add the Video Capture button on the Chat widget for mobile devices.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Set  `captureVideo:true` in the kommunicateSettings. Now, you will see a video recording icon inside the chat widget.
- Try to record a video and send it on the chat.
---
https://user-images.githubusercontent.com/22856546/134118448-0663881a-9238-4349-ad56-149661a83aa2.mov

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch