### PR TITLE
Zendesk chat integration ground work

### DIFF
--- a/server/config/config-env.js
+++ b/server/config/config-env.js
@@ -6,6 +6,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-test.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
             hostUrl: 'http://localhost:3030',
+            dashboardUrl: 'https://dashboard-test.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -29,6 +30,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-test.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
             hostUrl: 'https://widget-test.kommunicate.io',
+            dashboardUrl: 'https://dashboard-test.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -52,6 +54,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-staging.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
             hostUrl: 'https://widget-staging.kommunicate.io',
+            dashboardUrl: 'https://dashboard-staging.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -75,6 +78,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api.kommunicate.io',
             botPlatformApi: 'https://bots.kommunicate.io',
             hostUrl: 'https://widget.kommunicate.io',
+            dashboardUrl: 'https://dashboard.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -97,6 +101,7 @@ const configEnv = {
             applozicBaseUrl: 'https://chat-ca.kommunicate.io',
             kommunicateBaseUrl: 'https://api-ca.kommunicate.io',
             hostUrl: 'https://widget-ca.kommunicate.io',
+            dashboardUrl: 'https://dashboard-ca.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -121,6 +126,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-in.kommunicate.io',
             botPlatformApi: 'https://bots-in.kommunicate.io',
             hostUrl: 'https://widget-in.kommunicate.io',
+            dashboardUrl: 'https://dashboard-in.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -143,6 +149,7 @@ const configEnv = {
             applozicBaseUrl: 'https://chat-ire.kommunicate.io',
             kommunicateBaseUrl: 'https://api-ire.kommunicate.io',
             hostUrl: 'https://widget-ire.kommunicate.io',
+            dashboardUrl: 'https://dashboard-ire.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -169,6 +176,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-enterprise.kommunicate.io',
             botPlatformApi: 'https://bots.kommunicate.io',
             hostUrl: 'https://widget-enterprise.kommunicate.io',
+            dashboardUrl: 'https://dashboard-enterprise.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,
@@ -192,6 +200,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api.kommunicate.io',
             botPlatformApi: 'https://bots.kommunicate.io',
             hostUrl: 'https://widget-beta.kommunicate.io',
+            dashboardUrl: 'https://dashboard-beta.kommunicate.io',
         },
         pluginProperties: {
             pseudoNameEnabled: true,

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -447,6 +447,10 @@ function ApplozicSidebox() {
                 options.hidePostCTA != null
                     ? options.hidePostCTA
                     : widgetSettings && widgetSettings.hidePostCTA;
+            options.zendeskApiKey =
+                options.zendeskApiKey != null
+                    ? options.zendeskApiKey
+                    : widgetSettings && widgetSettings.zendeskApiKey;
             options.capturePhoto =
                 options.capturePhoto != null
                     ? options.capturePhoto

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2654,6 +2654,9 @@ var userOverride = {
                     zChat.sendChatMsg(`This chat is initiated from kommunicate widget, look for more here: ${KM_PLUGIN_SETTINGS.dashboardUrl}/conversations/${CURRENT_GROUP_DATA.tabId}`, function (err, data) {
                         console.log("zChat.sendChatMsg ", err, data)
                     });
+                    zChat.on("chat", function (e) {
+                        console.log('[ZendeskChat] zChat.on("chat") ', e);
+                    });
                 }
             }
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2611,6 +2611,11 @@ var userOverride = {
                     // callback when plugin initilized successfully.
                     MCK_ON_PLUGIN_INIT('success', data);
                 }
+                
+                // Loading zopim sdk for zendesk chat integration
+                if (kommunicate._globals.zendeskApiKey) {
+                    loadZopimSDK();
+                }
 
                 var kmChatLoginModal = document.getElementById(
                     'km-chat-login-modal'
@@ -2618,6 +2623,14 @@ var userOverride = {
                 kmChatLoginModal.style.visibility = 'hidden';
             };
 
+            function loadZopimSDK() {
+                var s = document.createElement("script");
+                s.type = "text/javascript";
+                s.async = true;
+                s.src = "https://dev.zopim.com/web-sdk/latest/web-sdk.js";
+                var h = document.getElementsByTagName("head")[0];
+                h.appendChild(s);
+            }
             _this.loadDataPostInitialization = function () {
                 IS_PLUGIN_INITIALIZATION_PROCESS_COMPLETED = true;
                 var data = INIT_APP_DATA;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1898,8 +1898,14 @@ var userOverride = {
                         events.onMessageSentUpdate;
                 }
                 if (typeof events.onMessageSent === 'function') {
-                    window.Applozic.ALSocket.events.onMessageSent =
-                        events.onMessageSent;
+                    if (window.Applozic.ALSocket.events.onMessageSent) {
+                        var oldCallback = window.Applozic.ALSocket.events.onMessageSent;
+                        window.Applozic.ALSocket.events.onMessageSent = function (data) {
+                            console.log("onMessageSent callback ", data);
+                            oldCallback(data);
+                            events.onMessageSent(data);
+                        }
+                    }
                 }
                 if (typeof events.onUserBlocked === 'function') {
                     window.Applozic.ALSocket.events.onUserBlocked =
@@ -2623,6 +2629,7 @@ var userOverride = {
                 if (kommunicate._globals.zendeskApiKey) {
                     loadZopimSDK();
                     var events = {
+                        'onMessageSent': handleUserMessage,
                         'onMessageReceived': handleBotMessage,
                     };
                     Kommunicate.subscribeToEvents(events);
@@ -2642,6 +2649,17 @@ var userOverride = {
                 var h = document.getElementsByTagName("head")[0];
                 h.appendChild(s);
             }
+            
+            function handleUserMessage(event) {
+                if (!event.message) return;
+                if (!ZENDESK_SDK_INITIALIZED) return;
+                console.log("handleUserMessage: ", event);
+                zChat.sendChatMsg(event.message.message, function (err, data) {
+                    console.log("zChat.sendChatMsg ", err, data)
+                });
+                // TODO look for attachment
+            }
+            
             function handleBotMessage(event) {
                 console.log("handleBotMessage: ", event);
                 if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -371,7 +371,6 @@ var userOverride = {
         var EMOJI_LIBRARY = appOptions.emojilibrary;
         var CSAT_ENABLED = appOptions.collectFeedback;
         var HIDE_POST_CTA = appOptions.hidePostCTA;
-        var ZENDESK_SDK_INITIALIZED = false;
         var MCK_MODE = appOptions.mode;
         MCK_LABELS = appOptions.labels;
         MCK_BASE_URL = appOptions.baseUrl;
@@ -567,6 +566,7 @@ var userOverride = {
         var mckNotificationUtils = new MckNotificationUtils();
         var alNotificationService = new AlNotificationService();
         var alUserService = new AlUserService();
+        var zendeskChatService = new ZendeskChatService();
         var $mckChatLauncherIcon = $applozic('.chat-launcher-icon');
         var mckNotificationTone = null;
         var mckChatPopupNotificationTone = null;
@@ -2627,12 +2627,7 @@ var userOverride = {
                 
                 // Loading zopim sdk for zendesk chat integration
                 if (kommunicate._globals.zendeskApiKey) {
-                    loadZopimSDK();
-                    var events = {
-                        'onMessageSent': handleUserMessage,
-                        'onMessageReceived': handleBotMessage,
-                    };
-                    Kommunicate.subscribeToEvents(events);
+                    zendeskChatService.inIt(kommunicate._globals.zendeskApiKey);
                 }
 
                 var kmChatLoginModal = document.getElementById(
@@ -2640,43 +2635,7 @@ var userOverride = {
                 );
                 kmChatLoginModal.style.visibility = 'hidden';
             };
-
-            function loadZopimSDK() {
-                var s = document.createElement("script");
-                s.type = "text/javascript";
-                s.async = true;
-                s.src = "https://dev.zopim.com/web-sdk/latest/web-sdk.js";
-                var h = document.getElementsByTagName("head")[0];
-                h.appendChild(s);
-            }
             
-            function handleUserMessage(event) {
-                if (!event.message) return;
-                if (!ZENDESK_SDK_INITIALIZED) return;
-                console.log("handleUserMessage: ", event);
-                zChat.sendChatMsg(event.message.message, function (err, data) {
-                    console.log("zChat.sendChatMsg ", err, data)
-                });
-                // TODO look for attachment
-            }
-            
-            function handleBotMessage(event) {
-                console.log("handleBotMessage: ", event);
-                if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
-                    if (!ZENDESK_SDK_INITIALIZED) {
-                        zChat.init({
-                            account_key: kommunicate._globals.zendeskApiKey,
-                        });
-                        ZENDESK_SDK_INITIALIZED = true;
-                    }
-                    zChat.sendChatMsg(`This chat is initiated from kommunicate widget, look for more here: ${KM_PLUGIN_SETTINGS.dashboardUrl}/conversations/${CURRENT_GROUP_DATA.tabId}`, function (err, data) {
-                        console.log("zChat.sendChatMsg ", err, data)
-                    });
-                    zChat.on("chat", function (e) {
-                        console.log('[ZendeskChat] zChat.on("chat") ', e);
-                    });
-                }
-            }
 
             _this.loadDataPostInitialization = function () {
                 IS_PLUGIN_INITIALIZATION_PROCESS_COMPLETED = true;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2627,7 +2627,7 @@ var userOverride = {
                 
                 // Loading zopim sdk for zendesk chat integration
                 if (kommunicate._globals.zendeskApiKey) {
-                    zendeskChatService.inIt(kommunicate._globals.zendeskApiKey);
+                    zendeskChatService.init(kommunicate._globals.zendeskApiKey);
                 }
 
                 var kmChatLoginModal = document.getElementById(

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -3,7 +3,7 @@ function ZendeskChatService() {
     var ZENDESK_SDK_INITIALIZED = false;
     var ZENDESK_API_KEY = "";
     
-    _this.inIt = function (zendeskApiKey) {
+    _this.init = function (zendeskApiKey) {
         ZENDESK_API_KEY = zendeskApiKey;
         _this.loadZopimSDK();
         var events = {

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -23,8 +23,9 @@ function ZendeskChatService() {
     };
 
     _this.handleUserMessage = function (event) {
-        if (!event.message) return;
-        if (!ZENDESK_SDK_INITIALIZED) return;
+        if (!event.message || !ZENDESK_SDK_INITIALIZED) {
+            return;
+        }
         console.log("handleUserMessage: ", event);
         zChat.sendChatMsg(event.message.message, function (err, data) {
             console.log("zChat.sendChatMsg ", err, data)

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -26,15 +26,15 @@ function ZendeskChatService() {
         if (!event.message || !ZENDESK_SDK_INITIALIZED) {
             return;
         }
-        console.log("handleUserMessage: ", event);
+        window.console.log("handleUserMessage: ", event);
         zChat.sendChatMsg(event.message.message, function (err, data) {
-            console.log("zChat.sendChatMsg ", err, data)
+            window.console.log("zChat.sendChatMsg ", err, data)
         });
         // TODO look for attachment
     };
 
     _this.handleBotMessage = function (event) {
-        console.log("handleBotMessage: ", event);
+        window.console.log("handleBotMessage: ", event);
         if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
             if (!ZENDESK_SDK_INITIALIZED && ZENDESK_API_KEY) {
                 zChat.init({
@@ -43,10 +43,10 @@ function ZendeskChatService() {
                 ZENDESK_SDK_INITIALIZED = true;
             }
             zChat.sendChatMsg(`This chat is initiated from kommunicate widget, look for more here: ${KM_PLUGIN_SETTINGS.dashboardUrl}/conversations/${CURRENT_GROUP_DATA.tabId}`, function (err, data) {
-                console.log("zChat.sendChatMsg ", err, data)
+                window.console.log("zChat.sendChatMsg ", err, data)
             });
             zChat.on("chat", function (e) {
-                console.log('[ZendeskChat] zChat.on("chat") ', e);
+                window.console.log('[ZendeskChat] zChat.on("chat") ', e);
             });
         }
     };

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -1,0 +1,52 @@
+function ZendeskChatService() {
+    var _this = this;
+    var ZENDESK_SDK_INITIALIZED = false;
+    var ZENDESK_API_KEY = "";
+    
+    _this.inIt = function (zendeskApiKey) {
+        ZENDESK_API_KEY = zendeskApiKey;
+        _this.loadZopimSDK();
+        var events = {
+            'onMessageSent': _this.handleUserMessage,
+            'onMessageReceived': _this.handleBotMessage,
+        };
+        Kommunicate.subscribeToEvents(events);
+    };
+
+    _this.loadZopimSDK = function () {
+        var s = document.createElement("script");
+        s.type = "text/javascript";
+        s.async = true;
+        s.src = "https://dev.zopim.com/web-sdk/latest/web-sdk.js";
+        var h = document.getElementsByTagName("head")[0];
+        h.appendChild(s);
+    };
+
+    _this.handleUserMessage = function (event) {
+        if (!event.message) return;
+        if (!ZENDESK_SDK_INITIALIZED) return;
+        console.log("handleUserMessage: ", event);
+        zChat.sendChatMsg(event.message.message, function (err, data) {
+            console.log("zChat.sendChatMsg ", err, data)
+        });
+        // TODO look for attachment
+    };
+
+    _this.handleBotMessage = function (event) {
+        console.log("handleBotMessage: ", event);
+        if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
+            if (!ZENDESK_SDK_INITIALIZED && ZENDESK_API_KEY) {
+                zChat.init({
+                    account_key: ZENDESK_API_KEY,
+                });
+                ZENDESK_SDK_INITIALIZED = true;
+            }
+            zChat.sendChatMsg(`This chat is initiated from kommunicate widget, look for more here: ${KM_PLUGIN_SETTINGS.dashboardUrl}/conversations/${CURRENT_GROUP_DATA.tabId}`, function (err, data) {
+                console.log("zChat.sendChatMsg ", err, data)
+            });
+            zChat.on("chat", function (e) {
+                console.log('[ZendeskChat] zChat.on("chat") ', e);
+            });
+        }
+    };
+};

--- a/webplugin/pluginOptimizer.js
+++ b/webplugin/pluginOptimizer.js
@@ -35,7 +35,7 @@ let BUILD_URL = isAwsUploadEnabled
     ? CDN_HOST_URL + '/' + version
     : MCK_STATIC_PATH + '/build';
 // Change "env" to "false" to un-compress all files.
-let env = config.getEnvId() !== 'development';
+let env = false;
 let jsCompressor = !env ? noCompress : gcc;
 let terserCompressor = !env ? noCompress : terser;
 let cssCompressor = !env ? noCompress : cleanCSS;

--- a/webplugin/pluginOptimizer.js
+++ b/webplugin/pluginOptimizer.js
@@ -27,6 +27,8 @@ PLUGIN_SETTING.botPlatformApi =
     PLUGIN_SETTING.botPlatformApi || config.urls.botPlatformApi;
 PLUGIN_SETTING.applozicBaseUrl =
     PLUGIN_SETTING.applozicBaseUrl || config.urls.applozicBaseUrl;
+PLUGIN_SETTING.dashboardUrl =
+    PLUGIN_SETTING.dashboardUrl || config.urls.dashboardUrl;
 let PLUGIN_FILE_DATA = new Object();
 let isAwsUploadEnabled = argv.upload;
 let BUILD_URL = isAwsUploadEnabled

--- a/webplugin/pluginOptimizer.js
+++ b/webplugin/pluginOptimizer.js
@@ -35,7 +35,7 @@ let BUILD_URL = isAwsUploadEnabled
     ? CDN_HOST_URL + '/' + version
     : MCK_STATIC_PATH + '/build';
 // Change "env" to "false" to un-compress all files.
-let env = false;
+let env = config.getEnvId() !== 'development';
 let jsCompressor = !env ? noCompress : gcc;
 let terserCompressor = !env ? noCompress : terser;
 let cssCompressor = !env ? noCompress : cleanCSS;

--- a/webplugin/pluginOptimizer.js
+++ b/webplugin/pluginOptimizer.js
@@ -146,6 +146,7 @@ const compressAndOptimize = () => {
             path.resolve(__dirname, 'js/app/km-event-listner.js'),
             path.resolve(__dirname, 'js/app/km-widget-custom-events.js'),
             path.resolve(__dirname, 'js/app/km-attachment-service.js'),
+            path.resolve(__dirname, 'js/app/zendesk-chat-service.js'),
             path.resolve(__dirname, 'js/app/mck-sidebox-1.0.js'),
             path.resolve(__dirname, 'js/app/kommunicate.custom.theme.js'),
             path.resolve(__dirname, 'js/app/kommunicateCommons.js'),


### PR DESCRIPTION
## What do you want to achieve?
- Add basic functionality for zendesk chat integration
- Customer can pass `zendeskApiKey` or save it in the app settings API. Key passed in the script will have priority over key saved in app settings API.
- Functionalities added:
  - initialize zendesk-zopim sdk
    - For now, the first message is hardcoded, having dashboard link, but in future, we will attach chat transcript for Zendesk Agent's reference and provide chat context.
  - send user messages to zendesk agent
  - receive agent messages and console log them
    - There are some complications in sending agent messages to Kommunicate. We will do that separately.

## How to update zendesk token in app settings:
```curl
curl --location --request PATCH 'https://api-test.kommunicate.io/rest/ws/settings/application/detail' \
--header 'authorization: {{authorization}}' \
--header 'Content-Type: application/json' \
--data-raw '{
    "chatWidget": {
        "zendeskApiKey": "{{zendeskApiKey}}"
    }
}'
```


## PR Checklist
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have tested it in IE Browser.

## How was the code tested?
- In below images notice: 
  - Agent message "kaka" was being logged in console of test widget
  - User message "sure" is visible in zendesk chat dashboard.
![Screenshot 2021-09-22 at 12 02 01 AM](https://user-images.githubusercontent.com/23008972/134229172-470c458c-0171-4901-ba78-95c80761c3d3.png)
![Screenshot 2021-09-22 at 12 01 52 AM](https://user-images.githubusercontent.com/23008972/134229155-a14ad779-e504-490a-a2de-801178e96ee1.png)
![Screenshot 2021-09-22 at 12 02 22 AM](https://user-images.githubusercontent.com/23008972/134229174-d1d64ef3-6bb6-4e8e-9c2d-9170b051c4d5.png)


## What new thing you came across while writing this code? 
- Basics about widget