### PR TITLE
FW-2731 Don't show the Category in FAQ in chat widget if it has zero articles

### DIFF
--- a/webplugin/js/app/km-post-initialization.js
+++ b/webplugin/js/app/km-post-initialization.js
@@ -76,8 +76,9 @@ Kommunicate.getFaqCategories = function(data){
                 );
             }
             $applozic.each(response.data, function (i, category) {
-                var categoryName = category && category.name;
-                var categoryDescription = category && category.description;
+                if(!category || !category.articleCount || !category.name || !category.description){ return };
+                var categoryName = category.name;
+                var categoryDescription = category.description;
                 $applozic('#km-faq-category-list-container').append(
                     '<div class="km-faq-category-card km-custom-widget-border-color" data-category-name="'+ categoryName.replace(/ /g, "-")
                     +'">'+


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The category should not be displayed in the faq section of widget if the category has no published articles

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- add categories such that it has either no articles or it has unpublished articles 
![Screenshot 2021-09-22 at 9 55 10 AM](https://user-images.githubusercontent.com/19753380/134283345-0d248474-fc61-4b06-8063-feddce034e8b.png)

- these articles should not appear in faq category
![Screenshot 2021-09-22 at 9 54 56 AM](https://user-images.githubusercontent.com/19753380/134283490-b91305c6-620d-4235-9838-d241d1af9eb5.png)

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch