### PR TITLE
FW-3047 Hide form submit button post submission [Important]  

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -6364,3 +6364,12 @@ body.accesibility :focus {
 .mck-msg-left.contains-quick-replies-only:not(:last-child) {
 	display: none;
 }
+
+/* -----------------Support for hiding form post form submission------------- */
+.mck-msg-left [data-hidepostformsubmit="true"] {
+	display: none;
+}
+.mck-msg-left:last-child [data-hidepostformsubmit="true"] {
+	display: block;
+	visibility: visible;
+}

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -658,11 +658,14 @@ Kommunicate.richMsgEventHandler = {
         var messagePxy = {};
         var msgMetadata = {};
         var postFormDataAsMessage='';
+        if(Kommunicate._globals.hidePostFormSubmit){
+            postBackAsMessage = true;
+        }
         if (postBackAsMessage && Object.keys(data).length) {
             for (var i = 0; i < Object.keys(data).length; i++) {
                 var key = Object.keys(data)[i];
                 postFormDataAsMessage = postFormDataAsMessage.concat(
-                    key + ':' + data[key] + '\n'
+                    key + ' : ' + data[key] + '\n'
                 );
             }
         }

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -410,7 +410,7 @@ Kommunicate.markup = {
             <div class="{{cardDescriptionClass}}"><div class="km-carousel-card-description">{{description}}</div></div>`;
     },
     getFormTemplate: function () {
-        return `<div class="mck-msg-box-rich-text-container mck-form-template-container">
+        return `<div class="mck-msg-box-rich-text-container mck-form-template-container" data-hidePostFormSubmit="{{hidePostFormSubmit}}">
                 <form class="km-btn-hidden-form mck-actionable-form" action="{{actionUrl}}" method="post">
                     <div class="mck-form-template-wrapper">
                         {{#payload}}
@@ -491,7 +491,7 @@ Kommunicate.markup = {
                         {{/payload}}
                     </div>
                         {{#buttons}}
-                            <button type="{{type}}" class="km-cta-button km-custom-widget-text-color km-custom-widget-border-color mck-form-submit-button" data-requesttype="{{requestType}}" title="{{message}}" data-post-back-to-kommunicate="{{postBackToKommunicate}}" data-post-back-as-message="{{postFormDataAsMessage}}">{{label}}</button>      
+                            <button type="{{type}}" class="km-cta-button km-custom-widget-text-color km-custom-widget-border-color mck-form-submit-button" data-requesttype="{{requestType}}" title="{{message}}" data-post-back-to-kommunicate="{{postBackToKommunicate}}" data-post-back-as-message="{{postFormDataAsMessage}}" data-hidePostFormSubmit="{{hidePostFormSubmit}}">{{label}}</button>      
                         {{/buttons}}   
                 </form>   
             </div>`;
@@ -863,6 +863,7 @@ Kommunicate.markup.getActionableFormMarkup = function (options) {
                 options.payload[index].className = 'km-cta-button';
                 options.buttons.push(item);
                 options.payload.splice(index, 1);
+                options.hidePostFormSubmit = Kommunicate._globals.hidePostFormSubmit;
             } else {
                 options.payload[index].supported =
                     KommunicateConstants.FORM_SUPPORTED_FIELDS.indexOf(

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -460,6 +460,10 @@ function ApplozicSidebox() {
                 options.captureVideo != null
                     ? options.captureVideo
                     : widgetSettings && widgetSettings.captureVideo;
+            options.hidePostFormSubmit =
+                options.hidePostFormSubmit != null
+                    ? options.hidePostFormSubmit
+                    : widgetSettings && widgetSettings.hidePostFormSubmit;
             KommunicateUtils.deleteDataFromKmSession('settings');
 
             if (


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add a feature where the form would get hidden once it gets submitted.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- create a bot having from
- initialise the widget with `hidePostFormSubmit: true` in kommunicateSettings
- submit the form

https://user-images.githubusercontent.com/19753380/140905699-e578582c-6792-4947-8f90-bf4cdf6da289.mov



### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch