### PR TITLE
add agent message flow for zendesk chat integration

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -448,10 +448,10 @@ function ApplozicSidebox() {
                 options.hidePostCTA != null
                     ? options.hidePostCTA
                     : widgetSettings && widgetSettings.hidePostCTA;
-            options.zendeskApiKey =
-                options.zendeskApiKey != null
-                    ? options.zendeskApiKey
-                    : widgetSettings && widgetSettings.zendeskApiKey;
+            options.zendeskChatSdkKey =
+                options.zendeskChatSdkKey != null
+                    ? options.zendeskChatSdkKey
+                    : widgetSettings && widgetSettings.zendeskChatSdkKey;
             options.capturePhoto =
                 options.capturePhoto != null
                     ? options.capturePhoto

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2640,8 +2640,8 @@ var userOverride = {
                 }
                 
                 // Loading zopim sdk for zendesk chat integration
-                if (kommunicate._globals.zendeskApiKey) {
-                    zendeskChatService.init(kommunicate._globals.zendeskApiKey);
+                if (kommunicate._globals.zendeskChatSdkKey) {
+                    zendeskChatService.init(kommunicate._globals.zendeskChatSdkKey);
                 }
 
                 var kmChatLoginModal = document.getElementById(

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -1,4 +1,5 @@
 function ZendeskChatService() {
+    // This integration is supported by zopim, for any apis please refer their docs.
     var _this = this;
     var ZENDESK_SDK_INITIALIZED = false;
     var ZENDESK_CHAT_SDK_KEY = "";

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -1,10 +1,10 @@
 function ZendeskChatService() {
     var _this = this;
     var ZENDESK_SDK_INITIALIZED = false;
-    var ZENDESK_API_KEY = "";
+    var ZENDESK_CHAT_SDK_KEY = "";
 
-    _this.init = function (zendeskApiKey) {
-        ZENDESK_API_KEY = zendeskApiKey;
+    _this.init = function (zendeskChatSdkKey) {
+        ZENDESK_CHAT_SDK_KEY = zendeskChatSdkKey;
         _this.loadZopimSDK();
         var events = {
             'onMessageSent': _this.handleUserMessage,
@@ -36,9 +36,9 @@ function ZendeskChatService() {
     _this.handleBotMessage = function (event) {
         window.console.log("handleBotMessage: ", event);
         if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
-            if (!ZENDESK_SDK_INITIALIZED && ZENDESK_API_KEY) {
+            if (!ZENDESK_SDK_INITIALIZED && ZENDESK_CHAT_SDK_KEY) {
                 zChat.init({
-                    account_key: ZENDESK_API_KEY,
+                    account_key: ZENDESK_CHAT_SDK_KEY,
                 });
                 zChat.on("chat", function (eventDetails) {
                     window.console.log('[ZendeskChat] zChat.on("chat") ', eventDetails);

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -18,7 +18,7 @@ function ZendeskChatService() {
         var s = document.createElement("script");
         s.type = "text/javascript";
         s.async = true;
-        s.src = "https://km-prod-cdn.s3.us-east-1.amazonaws.com/kommunicate/zendesk-web-sdk-1.11.2.js";
+        s.src = "https://cdn.kommunicate.io/kommunicate/zendesk-web-sdk-1.11.2.js";
         var h = document.getElementsByTagName("head")[0];
         h.appendChild(s);
     };

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -61,7 +61,7 @@ function ZendeskChatService() {
     };
 
     _this.handleZendeskAgentMessageEvent = function (event) {
-        console.log("getUserDetailsByZendeskId ", event);
+        console.log("handleZendeskAgentMessageEvent ", event);
         var messagePxy = {
             message: event.msg,
             fromUserName: event.nick.split(":")[1],

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -18,7 +18,7 @@ function ZendeskChatService() {
         var s = document.createElement("script");
         s.type = "text/javascript";
         s.async = true;
-        s.src = "https://dev.zopim.com/web-sdk/latest/web-sdk.js";
+        s.src = "https://km-prod-cdn.s3.us-east-1.amazonaws.com/kommunicate/zendesk-web-sdk-1.11.2.js";
         var h = document.getElementsByTagName("head")[0];
         h.appendChild(s);
     };


### PR DESCRIPTION
## What do you want to achieve?
- add agent message flow for zendesk chat integration. in this we will call a new send message API, which will accept zendesk userId, message, groupId and send those to particular conversation.

## PR Checklist
- [x] I have tested it locally and all functionalities are working fine.

## How was the code tested?
- In the below image, notice agent messages from zendesk chat dashboard are being shown in the km widget

![Screenshot 2021-11-24 at 12 05 50 AM](https://user-images.githubusercontent.com/23008972/143085141-25100dea-d78e-4e89-90c5-0df19f571117.png)
![Screenshot 2021-11-24 at 12 05 59 AM](https://user-images.githubusercontent.com/23008972/143085145-33bdff9d-80c3-4c21-b9e0-228a7be6b0da.png)


## Related PR:
- https://github.com/Kommunicate-io/Kommunicate-Server/pull/363