### PR TITLE
FW-3132 A banner should be visible if socket connection drops

### DIFF
--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -98,7 +98,7 @@ Kommunicate.defaultLabels = {
     'conversation.rated': 'rated the conversation',
     'offline.msg':
         'Uh oh! No internet connection. Please check your network settings and try again.',
-    'socket-disconnect.msg': 'Conversations will not be refreshed in real time due to network issue.',
+    'socket-disconnect.msg': 'Error while syncing messages. Check your firewall settings or try again after some time.',
     'group.metadata': {
         CREATE_GROUP_MESSAGE: ':adminName created group :groupName',
         REMOVE_MEMBER_MESSAGE: ':adminName removed :userName',

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -98,7 +98,7 @@ Kommunicate.defaultLabels = {
     'conversation.rated': 'rated the conversation',
     'offline.msg':
         'Uh oh! No internet connection. Please check your network settings and try again.',
-    'socket-disconnect.msg': 'Conversations will not be updated in real-time as socket is not connected.',
+    'socket-disconnect.msg': 'Conversations will not be refreshed in real time due to network issue.',
     'group.metadata': {
         CREATE_GROUP_MESSAGE: ':adminName created group :groupName',
         REMOVE_MEMBER_MESSAGE: ':adminName removed :userName',

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -98,6 +98,7 @@ Kommunicate.defaultLabels = {
     'conversation.rated': 'rated the conversation',
     'offline.msg':
         'Uh oh! No internet connection. Please check your network settings and try again.',
+    'socket-disconnect.msg': 'Conversations will not be updated in real-time as socket is not connected.',
     'group.metadata': {
         CREATE_GROUP_MESSAGE: ':adminName created group :groupName',
         REMOVE_MEMBER_MESSAGE: ':adminName removed :userName',

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -618,6 +618,7 @@ var userOverride = {
             WIDGET_SETTINGS.hasOwnProperty('position')
                 ? WIDGET_SETTINGS.position
                 : KommunicateConstants.POSITION.RIGHT;
+        var SOCKET_RECONNECT_FAIL_COUNT = 0;
         window.Applozic.SOCKET_DISCONNECT_PROCEDURE = {
             SOCKET_DISCONNECT_TIMER_VALUE: 120000, // 2 minutes : 120000 milliSeconds
             DISCONNECTED: false,
@@ -716,6 +717,12 @@ var userOverride = {
                 if (navigator.onLine) {
                     window.Applozic.ALSocket.reconnect();
                 }
+                SOCKET_RECONNECT_FAIL_COUNT++;
+                SOCKET_RECONNECT_FAIL_COUNT > 2 && kommunicateCommons.modifyClassList(
+                    { id: ['km-socket-disconnect-msg'] },
+                    '',
+                    'n-vis'
+                );
             },
             onConnect: function (resp) {
                 IS_SOCKET_CONNECTED = true;
@@ -724,6 +731,12 @@ var userOverride = {
                     'n-vis',
                     'vis'
                 );
+                kommunicateCommons.modifyClassList(
+                    { id: ['km-socket-disconnect-msg'] },
+                    'n-vis',
+                    ''
+                );
+                SOCKET_RECONNECT_FAIL_COUNT = 0;
                 if (
                     typeof SUBSCRIBE_TO_EVENTS_BACKUP == 'object' &&
                     Object.keys(SUBSCRIBE_TO_EVENTS_BACKUP).length != 0
@@ -3307,6 +3320,9 @@ var userOverride = {
                 document.getElementById(
                     'km-internet-disconnect-msg'
                 ).innerHTML = MCK_LABELS['offline.msg'];
+                document.getElementById(
+                    'km-socket-disconnect-msg'
+                ).innerHTML = MCK_LABELS['socket-disconnect.msg'];
                 document.getElementById('talk-to-human-link').innerHTML =
                     MCK_LABELS['talk.to.agent'];
                 document.getElementById('mck-collect-email').innerHTML =

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -107,6 +107,7 @@
 				</div>
 			</div>
 			<div id="km-internet-disconnect-msg" class="km-offline-msg n-vis">  </div>
+            <div id="km-socket-disconnect-msg" class="km-offline-msg n-vis"> </div>
 			<div id="km-local-file-system-warning" class="n-vis">
 				<span id="km-local-file-system-warning-description">
 					Conversation will not be updated in real-time as you are running the installation script from your local file system.


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- banner should be visible if socket reconnect fail count is > 2
![Screenshot 2021-12-23 at 12 31 26 PM](https://user-images.githubusercontent.com/19753380/147201549-2f3cfead-55fc-4aff-8425-ae895faa3905.png)


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- 
![Screenshot 2021-12-23 at 12 33 09 PM](https://user-images.githubusercontent.com/19753380/147201732-54bf1fed-bcbe-4602-b5c3-0568a06e180c.png)


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch