### PR TITLE
FW-2422 Fix collect email id functionality in away and welcome messages

### DIFF
--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -548,5 +548,36 @@ KommunicateUtils = {
                 })
                 .join('&')
         );
+    },
+    /**
+     * When a new group is created, initially CURRENT_GROUP_DATA.groupMembers array has role of a member.
+     * @param {object} assigneeDetails 
+     * @returns boolean
+     */
+    isCurrentAssigneeBot: function (){
+        if (CURRENT_GROUP_DATA.groupMembers && CURRENT_GROUP_DATA.groupMembers.length) {
+            var currentConversationAssignee = {};
+            for (
+                var i = 0;
+                i <= CURRENT_GROUP_DATA.groupMembers.length;
+                i++
+            ) {
+                if (
+                    CURRENT_GROUP_DATA.groupMembers[i] &&
+                    CURRENT_GROUP_DATA.groupMembers[i].userId ==
+                    CURRENT_GROUP_DATA.conversationAssignee
+                ) {
+                    currentConversationAssignee = CURRENT_GROUP_DATA.groupMembers[i]
+                    break;
+                }
+            }
+
+            if(currentConversationAssignee.hasOwnProperty('role')){
+                return currentConversationAssignee.role === KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT;
+            }else if(currentConversationAssignee.hasOwnProperty('roleType')){
+                return currentConversationAssignee.roleType === KommunicateConstants.APPLOZIC_USER_ROLE_TYPE.BOT;
+            }
+        }
+        return false;
     }
 };


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The away messages functionality should work as aspected.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
1st 
- turn on away message and collect email
- go to conversation rules 
- turn of bot routing
- create a new chat widget instance and start a conversation
- the user should be prompted to input email when he send a message

2nd 
- turn on away message and collect email
- go to conversation rules 
- turn on bot routing
- create a new chat widget instance and start a conversation
- handoff the conversation to human agent (via handoff btn)
- the user should be prompted to input email when he send a message

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch