### PR TITLE
add support to pass user information to zendesk

### DIFF
--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -67,7 +67,7 @@ function ZendeskChatService() {
                 }
             });
             zChat.on("chat", function (eventDetails) {
-                window.console.log('[ZendeskChat] zChat.on("chat") ', eventDetails);
+                console.log('[ZendeskChat] zChat.on("chat") ', eventDetails);
                 if (eventDetails.type == "chat.msg") { //If agent sends normal message
                     _this.handleZendeskAgentMessageEvent(eventDetails);
                 } else if (eventDetails.type == "chat.file") { //If agent sends file attachments
@@ -81,11 +81,11 @@ function ZendeskChatService() {
         if (!event.message || !ZENDESK_SDK_INITIALIZED) {
             return;
         }
-        window.console.log("handleUserMessage: ", event);
+        console.log("handleUserMessage: ", event);
 
         if (event.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT) {
             zChat.sendChatMsg(event.message.message, function (err, data) {
-                window.console.log("zChat.sendChatMsg ", err, data)
+                console.log("zChat.sendChatMsg ", err, data)
             });
         } else if (event.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.ATTACHMENT) {
 
@@ -95,9 +95,9 @@ function ZendeskChatService() {
 
             zChat.sendFile(file, function (err, data) {
                 if (err) {
-                    window.console.log("Error while sending file : ", err);
+                    console.log("Error while sending file : ", err);
                 } else {
-                    window.console.log("File has been sent successfully : ", data);
+                    console.log("File has been sent successfully : ", data);
                 }
             });
         }
@@ -105,7 +105,7 @@ function ZendeskChatService() {
     };
 
     _this.handleBotMessage = function (event) {
-        window.console.log("handleBotMessage: ", event);
+        console.log("handleBotMessage: ", event);
         if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
             zChat.sendChatMsg(
                 'This chat is initiated from kommunicate widget, look for more here: ' +
@@ -113,7 +113,7 @@ function ZendeskChatService() {
                 '/conversations/' +
                 CURRENT_GROUP_DATA.tabId,
                 function (err, data) {
-                    window.console.log('zChat.sendChatMsg ', err, data);
+                    console.log('zChat.sendChatMsg ', err, data);
                 }
             );
         }
@@ -121,7 +121,7 @@ function ZendeskChatService() {
 
     _this.handleZendeskAgentMessageEvent = function (event) {
 
-        window.console.log("handleZendeskAgentMessageEvent ", event);
+        console.log("handleZendeskAgentMessageEvent ", event);
 
         var messagePxy = {
             message: event.msg,
@@ -138,18 +138,18 @@ function ZendeskChatService() {
                 'x-authorization': window.Applozic.ALApiService.AUTH_TOKEN,
             },
             success: function (result) {
-                window.console.log("result zendesk chat get user details ", result);
+                console.log("result zendesk chat get user details ", result);
                 typeof callback == 'function' && callback(agentUserName);
             },
             error: function (err) {
-                window.console.log('err while getting user details in zendesk service');
+                console.log('err while getting user details in zendesk service');
             },
         });
     };
 
     _this.handleZendeskAgentFileSendEvent = function (event) {
 
-        window.console.log("handleZendeskAgentFileSendEvent ", event);
+        console.log("handleZendeskAgentFileSendEvent ", event);
 
         var messagePxy = {
             fileAttachment: event.attachment,
@@ -167,11 +167,11 @@ function ZendeskChatService() {
                 'x-authorization': window.Applozic.ALApiService.AUTH_TOKEN,
             },
             success: function (result) {
-                window.console.log("Sent File message data to the server ", result);
+                console.log("Sent File message data to the server ", result);
                 typeof callback == 'function' && callback(agentUserName);
             },
             error: function (err) {
-                window.console.log('err while sending File message data to the server');
+                console.log('err while sending File message data to the server');
             },
         });
 

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -31,16 +31,15 @@ function ZendeskChatService() {
 
     _this.initializeSDK = function () {
         if (!ZENDESK_SDK_INITIALIZED && ZENDESK_CHAT_SDK_KEY) {
-            zChat.init({
+            var zendeskInitOptions = {
                 account_key: ZENDESK_CHAT_SDK_KEY,
-                authentication: {
+            }
+            var name = kommunicate._globals.name || kommunicate._globals.userName;
+            var email = kommunicate._globals.email;
+            var externalId = kommunicate._globals.userId;
+            if (name && email && externalId) {
+                zendeskInitOptions.authentication = {
                     jwt_fn: function (callback) {
-                        var name = kommunicate._globals.name || kommunicate._globals.userName;
-                        var email = kommunicate._globals.email;
-                        var externalId = kommunicate._globals.userId;
-                        if (!name || !email || !externalId) {
-                            return;
-                        }
                         var userPxy = {
                             name,
                             email,
@@ -65,7 +64,8 @@ function ZendeskChatService() {
                         });
                     }
                 }
-            });
+            }
+            zChat.init(zendeskInitOptions);
             zChat.on("chat", function (eventDetails) {
                 console.log('[ZendeskChat] zChat.on("chat") ', eventDetails);
                 if (eventDetails.type == "chat.msg") { //If agent sends normal message

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -74,7 +74,6 @@ function ZendeskChatService() {
                     _this.handleZendeskAgentFileSendEvent(eventDetails);
                 }
             });
-            ZENDESK_SDK_INITIALIZED = true;
         }
     };
     _this.handleUserMessage = function (event) {
@@ -107,6 +106,7 @@ function ZendeskChatService() {
     _this.handleBotMessage = function (event) {
         console.log("handleBotMessage: ", event);
         if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
+            ZENDESK_SDK_INITIALIZED = true;
             zChat.sendChatMsg(
                 'This chat is initiated from kommunicate widget, look for more here: ' +
                 KM_PLUGIN_SETTINGS.dashboardUrl +


### PR DESCRIPTION
## What do you want to achieve?
- add support to pass user information to zendesk.
- with these changes, user display-name, email will get reflected in zendesk chat side.
- There are 2 changes in this PR:
1. Created an API in the server to get JWT.
2. Pass server-generated JWT to zendesk SDK.

## PR Checklist
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

## How was the code tested?
- in below snip notice user's name, email is coming in zendesk.
![Screenshot 2022-01-18 at 4 52 27 PM](https://user-images.githubusercontent.com/23008972/149949813-5e83a511-bb13-4dd4-bdac-64049a01757b.png)

## Related Server PR:
https://github.com/Kommunicate-io/Kommunicate-Server/pull/406