### PR TITLE
FW-2507 If support user login fails then the chat widget is not displayed pro…

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2314,7 +2314,7 @@ var userOverride = {
                                 placeholder: MCK_LABELS['lead.collection'].password.toLowerCase(),
                                 required: 'true',
                             });
-                            return false;
+                           
                             if (typeof MCK_ON_PLUGIN_INIT === 'function') {
                                 MCK_ON_PLUGIN_INIT({
                                     status: 'error',


### PR DESCRIPTION

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- If support user login fails then the chat widget is not displayed properly.
please refer this pr https://github.com/Kommunicate-io/Kommunicate-Dashboard/pull/991
### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch