### PR TITLE
FW-3499 The form should be disabled post submission

### DIFF
--- a/webplugin/css/app/km-rich-message.css
+++ b/webplugin/css/app/km-rich-message.css
@@ -1298,6 +1298,14 @@
     background-color: #ffffff;
     font-size: 16px;
 }
+.mck-form-text-wrapper input:disabled,
+.mck-form-dropdown-wrapper select:disabled,
+.mck-form-textarea-wrapper textarea:disabled,
+.mck-form-template-container button:disabled {
+    cursor: not-allowed;
+    background: #dddddd;
+    color: #5C6677;
+}
 .mck-form-text-wrapper label,
 .mck-form-dropdown-wrapper label,
 .mck-form-textarea-wrapper label {

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -658,8 +658,13 @@ Kommunicate.richMsgEventHandler = {
         var messagePxy = {};
         var msgMetadata = {};
         var postFormDataAsMessage='';
+        var postBackToBotPlatform = false;
+        var formMsgKey = form.getAttribute('data-msg-key')
         if(Kommunicate._globals.hidePostFormSubmit){
             postBackAsMessage = true;
+        }
+        if(Kommunicate._globals.disableFormPostSubmit){
+            postBackToBotPlatform = true;
         }
         if (postBackAsMessage && Object.keys(data).length) {
             for (var i = 0; i < Object.keys(data).length; i++) {
@@ -675,8 +680,8 @@ Kommunicate.richMsgEventHandler = {
                 : replyText; //message to send
         
         isActionableForm &&
-            requestType == KommunicateConstants.POST_BACK_TO_BOT_PLATFORM &&
-            (msgMetadata['KM_CHAT_CONTEXT'] = { formData: data });
+            (requestType == KommunicateConstants.POST_BACK_TO_BOT_PLATFORM || postBackToBotPlatform) &&
+            (msgMetadata['KM_CHAT_CONTEXT'] = { formData: data, formMsgKey: formMsgKey });
         var formDataMessageTemplate =
             postBackToKommunicate &&
             Kommunicate.markup.getFormDataMessageTemplate(postBackData);

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -659,7 +659,7 @@ Kommunicate.richMsgEventHandler = {
         var msgMetadata = {};
         var postFormDataAsMessage='';
         var postBackToBotPlatform = false;
-        var formMsgKey = form.getAttribute('data-msg-key')
+        var formMsgKey = form.getAttribute('data-msg-key');
         if(Kommunicate._globals.hidePostFormSubmit){
             postBackAsMessage = true;
         }

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -411,7 +411,7 @@ Kommunicate.markup = {
     },
     getFormTemplate: function () {
         return `<div class="mck-msg-box-rich-text-container mck-form-template-container" data-hidePostFormSubmit="{{hidePostFormSubmit}}">
-                <form class="km-btn-hidden-form mck-actionable-form" action="{{actionUrl}}" method="post">
+                <form class="km-btn-hidden-form mck-actionable-form" action="{{actionUrl}}" method="post" data-msg-key={{msgKey}} >
                     <div class="mck-form-template-wrapper">
                         {{#payload}}
                             {{#.}}

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -599,6 +599,7 @@ $applozic.extend(true, Kommunicate, {
                     .GENERIC_BUTTONS_V2:
                     return Kommunicate.markup.getGenericButtonMarkup(metadata);
                 case KommunicateConstants.ACTIONABLE_MESSAGE_TEMPLATE.FORM:
+                    metadata['msgKey'] = message.key; 
                     return Kommunicate.markup.getActionableFormMarkup(metadata);
                     break;
                 case KommunicateConstants.ACTIONABLE_MESSAGE_TEMPLATE.VIDEO:

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -464,6 +464,10 @@ function ApplozicSidebox() {
                 options.hidePostFormSubmit != null
                     ? options.hidePostFormSubmit
                     : widgetSettings && widgetSettings.hidePostFormSubmit;
+            options.disableFormPostSubmit =
+                options.disableFormPostSubmit != null
+                    ? options.disableFormPostSubmit
+                    : widgetSettings && widgetSettings.disableFormPostSubmit;
             options.voiceNote =
                 options.voiceNote != null
                     ? options.voiceNote

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -465,9 +465,8 @@ function ApplozicSidebox() {
                     ? options.hidePostFormSubmit
                     : widgetSettings && widgetSettings.hidePostFormSubmit;
             options.disableFormPostSubmit =
-                options.disableFormPostSubmit != null
-                    ? options.disableFormPostSubmit
-                    : widgetSettings && widgetSettings.disableFormPostSubmit;
+                options.disableFormPostSubmit || 
+                    (widgetSettings && widgetSettings.disableFormPostSubmit);
             options.voiceNote =
                 options.voiceNote != null
                     ? options.voiceNote


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The input fields should be disabled upon form submission
- submit button should hide
- The submitted details should appear in the form if chat is reloaded

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [x] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- pass disableFormPostSubmit: true in kommunicateSettings
![Screenshot 2022-01-27 at 11 56 05 AM](https://user-images.githubusercontent.com/19753380/151303694-995ff2be-2708-4c72-a543-ece9e7ac1295.png)
![Screenshot 2022-01-27 at 11 55 58 AM](https://user-images.githubusercontent.com/19753380/151303706-c47764f8-1989-4e71-b609-7d4abd2c00be.png)


### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch