### PR TITLE
bugfix of chat widget going into infinite loop if bot routing is not enabled

### DIFF
--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -1,3 +1,5 @@
+var newConversationCreated = false;
+
 function ZendeskChatService() {
     // This integration is supported by zopim, for any apis please refer their docs.
     var _this = this;
@@ -186,7 +188,8 @@ var onTabClickedHandlerForZendeskConversations = function (event) {
         var assigneeInfo = currentGroupData && currentGroupData.users && Object.values(currentGroupData.users).find(function (member) {
             return member.userId == currentGroupData.metadata.CONVERSATION_ASSIGNEE
         })
-        if (assigneeInfo && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
+        if (!newConversationCreated && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
+            newConversationCreated = true;
             Kommunicate.startConversation();
         }
     }


### PR DESCRIPTION
## What do you want to achieve?
- bugfix of chat widget going into infinite loop if bot routing is not enabled

## PR Checklist
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

## How was the code tested?
- disabled bot routing and checked widget logs. Earlier it used to just go into infinite loop now it stops after 2 create event.
- In below image notice on tab clicked event is coming just 2 times. this is the one which used to come infinitely.
![Screenshot 2022-02-04 at 1 19 04 AM](https://user-images.githubusercontent.com/23008972/152418441-ee456f26-2991-4662-ad02-b59a12a2507a.png)
