### PR TITLE
FW-3201 FAQ is displayed in the Chat widget if there is a caterogy without a single article

### DIFF
--- a/webplugin/js/app/km-post-initialization.js
+++ b/webplugin/js/app/km-post-initialization.js
@@ -63,20 +63,18 @@ Kommunicate.getFaqCategories = function(data){
     KommunicateKB.getCategories({
         data: {appId: data.appId, baseUrl: Kommunicate.getBaseUrl()},
         success: function (response) {
-            if (
-                response.data &&
-                response.data.length > 0 &&
-                $applozic('.km-kb-container').hasClass('n-vis')
-            ) {
-                $applozic('.km-kb-container')
-                    .removeClass('n-vis')
-                    .addClass('vis');
-                KommunicateUI.adjustConversationTitleHeadingWidth(
-                    kommunicate._globals.popupWidget
-                );
-            }
+            var initializeFAQ = false;
+            if (response.data && response.data.length == 1) {
+                // if only 1 category is present then no need to show the category.
+                kommunicate &&
+                    kommunicate._globals &&
+                    (kommunicate._globals.faqCategory = response.data[0].name);
+                Kommunicate.getFaqList(data, response.data[0].name);
+                return;
+            };
             $applozic.each(response.data, function (i, category) {
                 if(!category || !category.articleCount || !category.name || !category.description){ return };
+                initializeFAQ = true;
                 var categoryName = category.name;
                 var categoryDescription = category.description;
                 $applozic('#km-faq-category-list-container').append(
@@ -90,7 +88,19 @@ Kommunicate.getFaqCategories = function(data){
                     '</div> </div>'
                 );
             });
-            KommunicateUI.initFaq()
+
+            if (
+                $applozic('.km-kb-container').hasClass('n-vis') &&
+                initializeFAQ
+            ) {
+                $applozic('.km-kb-container')
+                    .removeClass('n-vis')
+                    .addClass('vis');
+                KommunicateUI.adjustConversationTitleHeadingWidth(
+                    kommunicate._globals.popupWidget
+                );
+            };
+            initializeFAQ && KommunicateUI.initFaq();
         },
         error: function () { },
     })


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- if only one article is present then show the list of articles directly
- if none of the categories have articles inside them then don't show FAQ button.


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- create single / multiple categories from dashboard
- open the chat widget 
- previously the faq button would be visible and upon clicking, a black page would appear. Now FAQ button will not appear
- if only one category is present then the list of articles would be displayed instead of one category card.

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- 

NOTE: Make sure you're comparing your branch with the correct base branch