### PR TITLE
[TD-2506] Bot name should show instead of bot id [zendesk chat]

### DIFF
--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -132,15 +132,24 @@ function ZendeskChatService() {
 
                 var userId = kommunicate._globals.userId;
 
+                var currentGroupData = MCK_GROUP_MAP[CURRENT_GROUP_DATA.tabId];
+
                 var transcriptString = "Transcript:\n";
 
                 for (var i = messageListDetails.length-2; i >= 0 ; i--) {
                     var currentMessageDetail = messageListDetails[i];
                     
-                    var username = currentMessageDetail.to === userId ? 'User' : currentMessageDetail.to;
-                    var message = currentMessageDetail.message || 
-                                    currentMessageDetail.fileMeta.url || 
-                                    "TemplateId: " + currentMessageDetail.metadata.templateId;
+                    var username = "";
+
+                    if (currentMessageDetail.to === userId) {
+                        username = "User";
+                    } else {
+                        username = currentGroupData.displayName;
+                    }
+
+                    var message = currentMessageDetail.message ||
+                                    "TemplateId: " + currentMessageDetail.metadata.templateId ||
+                                    currentMessageDetail.fileMeta.url;
 
                     transcriptString += username + ": " + message +"\n";
                 }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- In Zendesk chat transcript, Bot name should show instead of bot id

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine..

### How was the code tested?
<!-- Be as specific as possible. -->
- Tested locally. worked fine. 

<img width="897" alt="image" src="https://user-images.githubusercontent.com/36797892/156512549-5956c1aa-d73b-48d5-aa04-464dd9b1e3cb.png">



NOTE: Make sure you're comparing your branch with the correct base branch