### PR TITLE
[TD-2686] Chat widget should work like Zendesk

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1178,6 +1178,45 @@ KommunicateUI = {
                     'vis'
                 );   
             }
+            var restartConversation = document.getElementById(
+                'mck-restart-conversation'
+            );
+            restartConversation.addEventListener('click', function () {
+                Kommunicate.startConversation(); 
+            })
+            document.getElementById('mck-submit-comment').disabled = false;
+            kommunicateCommons.modifyClassList(
+                { class: ['mck-rating-box'] },
+                '',
+                'selected'
+            );
+            kommunicateCommons.modifyClassList(
+                {
+                    class: ['mck-box-form'],
+                },
+                'n-vis',
+                'vis'
+            );
+            kommunicateCommons.modifyClassList(
+                {
+                    class: ['mck-csat-text-1'],
+                },
+                '',
+                'n-vis'
+            );
+            kommunicateCommons.modifyClassList(
+                {
+                    id: ['mck-sidebox-ft'],
+                },
+                'km-mid-conv-csat'
+            );
+            kommunicateCommons.modifyClassList(
+                {
+                    id: ['csat-1'],
+                },
+                'vis',
+                'n-vis'
+            );
             return;
         }
         if (


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Chat Widget Should work like Zendesk Chat where if we end chat in zendesk zopim chat and click restart conversation on chat widget a new conversation should just like how it is on zendesk

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-integrate zendesk, run chat widget locally and check if messages are coming on zopim chat or not after which end conversation from zendesk. try restarting conversation to check if a new conversation is starting or not

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch