### PR TITLE
FW-3825 Delete user's messages from the dashboard and chat widget

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -8414,6 +8414,7 @@ var userOverride = {
                 } else {
                     ALStorage.updateMckMessageArray(data.message);
                     $applozic.each(data.message, function (i, message) {
+                        if (message && message.metadata && message.metadata["AL_DELETE_GROUP_MESSAGE_FOR_ALL"]) return true;
                         if (!(typeof message.to === 'undefined')) {
                             !enableAttachment &&
                                 (enableAttachment =
@@ -15993,6 +15994,14 @@ var userOverride = {
                         conversationAssigneeDetails.roleType,
                         isAgentOffline
                     ); 
+                } else if (messageType === 'APPLOZIC_33') {
+                    if(resp.message.metadata["AL_DELETE_GROUP_MESSAGE_FOR_ALL"]){
+                        var key = resp.message.key;
+                        var groupId = resp.message.groupId;
+                        var isGroup = true;
+                        mckMessageLayout.removedDeletedMessage(key, tabId, isGroup);
+                        // events.onMessageDeleted(eventResponse);
+                    }
                 } else {
                     var message = resp.message;
                     // var userIdArray =


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Acknowledge the APPLOZIC_33 message type and hide the deleted message

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- start a conversation.
- send a message and reply from the dashboard side.
- delete the message from dashboard. 
- the message should not be displayed in chat widget.

Note:
1. to see the change on dashboard side please make sure that the changes mentioned in [this PR](https://github.com/Kommunicate-io/Kommunicate-Dashboard/pull/1161) are live.

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Netlify link of dashboard

- https://fw-3825.netlify.app/


NOTE: Make sure you're comparing your branch with the correct base branch