### PR TITLE
[TD-2790] Change Code-structure to handle Zendesk Events

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1867,9 +1867,10 @@ var userOverride = {
          * Note: This function should not be called more than one time as it will override the previous values as we're assigning event functions to object keys.
          * Where window.Applozic.ALSocket.events is the object we're referring to in the above scenario.
          */
-        _this.subscribeToEvents = function (events, callback) {
+        _this.subscribeToEvents = function (events, callback) {           
             if (!IS_SOCKET_CONNECTED) {
                 SUBSCRIBE_TO_EVENTS_BACKUP = events;
+                return;
             }
             if (typeof events === 'object') {
                 if (typeof events.onConnectFailed === 'function') {
@@ -1914,26 +1915,19 @@ var userOverride = {
                 if (typeof events.onConversationRead === 'function') {
                     window.Applozic.ALSocket.events.onConversationRead =
                         events.onConversationRead;
-                }
+                } 
                 if (typeof events.onMessageReceived === 'function') {
-                    if (window.Applozic.ALSocket.events.onMessageReceived) {
-                        var oldCallback = window.Applozic.ALSocket.events.onMessageReceived;
-                        window.Applozic.ALSocket.events.onMessageReceived = function (data) {
-                            console.log("onMessageReceived callback ", data);
-                            oldCallback(data);
-                            events.onMessageReceived(data);
-                        }
-                    }
+                    window.Applozic.ALSocket.events.onMessageReceived =
+                        events.onMessageReceived;
                 }
                 if (typeof events.onMessageSentUpdate === 'function') {
                     window.Applozic.ALSocket.events.onMessageSentUpdate =
                         events.onMessageSentUpdate;
                 }
                 if (typeof events.onMessageSent === 'function') {
-                    if (window.Applozic.ALSocket.events.onMessageSent) {
-                        window.Applozic.ALSocket.events.onMessageSent =
-                            events.onMessageSent;
-                    }
+                    window.Applozic.ALSocket.events.onMessageSent =
+                        events.onMessageSent;
+                    
                 }
                 if (typeof events.onUserBlocked === 'function') {
                     window.Applozic.ALSocket.events.onUserBlocked =
@@ -16188,8 +16182,15 @@ var userOverride = {
                             Kommunicate.KmEventHandler.onMessageReceived(
                                 messageCopy
                             );
+                            if (kommunicate._globals.zendeskChatSdkKey) {
+                                zendeskChatService.handleBotMessage(message);
+                            }
                         } else if (messageType === 'APPLOZIC_02') {
                             Kommunicate.KmEventHandler.onMessageSent(message);
+                            if (kommunicate._globals.zendeskChatSdkKey) {
+                                zendeskChatService.handleUserMessage(message);
+                            }
+
                         }
                         if (message.conversationId) {
                             var conversationPxy =

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -12,11 +12,7 @@ function ZendeskChatService() {
         ZENDESK_CHAT_SDK_KEY = zendeskChatSdkKey;
         preChatLeadData = preChatData;
         _this.loadZopimSDK();
-        var events = {
-            'onMessageSent': _this.handleUserMessage,
-            'onMessageReceived': _this.handleBotMessage,
-        };
-        Kommunicate.subscribeToEvents(events);
+        
         // Hide back button
         document.getElementById('mck-contacts-content').classList.add('force-n-vis');
         document.querySelector('.mck-back-btn-container').classList.add('force-n-vis');
@@ -84,16 +80,16 @@ function ZendeskChatService() {
         }
     };
     _this.handleUserMessage = function (event) {
-        if (!event.message || !ZENDESK_SDK_INITIALIZED) {
+        if (!ZENDESK_SDK_INITIALIZED) {
             return;
         }
         console.log("handleUserMessage: ", event);
 
-        if (event.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT) {
-            zChat.sendChatMsg(event.message.message, function (err, data) {
+        if (event.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT) {
+            zChat.sendChatMsg(event.message, function (err, data) {
                 console.log("zChat.sendChatMsg ", err, data)
             });
-        } else if (event.message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.ATTACHMENT) {
+        } else if (event.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.ATTACHMENT) {
 
             var fileInputElement = document.getElementById("mck-file-input");
 
@@ -111,8 +107,8 @@ function ZendeskChatService() {
     };
 
     _this.handleBotMessage = function (event) {
-        console.log("handleBotMessage: ", event);
-        if (event.message.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
+        console.log("3. handleBotMessage: ", event);
+        if (event.metadata.hasOwnProperty("KM_ASSIGN_TO")) {
             ZENDESK_SDK_INITIALIZED = true;
             zChat.sendChatMsg(
                 'This chat is initiated from kommunicate widget, look for more here: ' +
@@ -294,7 +290,6 @@ function ZendeskChatService() {
 
     }; 
 };
-
 
 var onTabClickedHandlerForZendeskConversations = function (event) {
     console.log("onTabClicked from zendesk: ", event, MCK_GROUP_MAP[event.tabId]);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Currently Zendesk-events and other chat-widget events get subscribed to the same Events-List. In this PR that is changed. Here we have updated the Event subscription procedure for Zendesk. 
- We basically separated the Zendesk-workflow from custom/normal events workflow. 

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.

### How was the code tested?
<!-- Be as specific as possible. -->
- Tested locally with active Zendesk integration and custom-events.
- Verified that all Zendesk features are working properly. (SendMessage, receiveMessage, zendeskEndChatCase etc.)
- Verified all the custom events are working properly.
- Verified with Socket connection Delay