### PR TITLE
FW -: 4252  Fix the bug, when user delete the message form dashboard then user profile not visible in chat widget

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -11340,6 +11340,16 @@ var userOverride = {
                     }
                 }
             };
+            _this.showPrevMsgPicAfterDeleteMsg = function () {
+                var allMessage = $applozic(
+                    '#mck-message-cell .mck-message-inner div[name="message"]'
+                )
+                var lastElement = allMessage[allMessage.length - 1];
+
+                if(lastElement){
+                    lastElement.classList.remove("km-clubbing-first")
+                }
+            }
             _this.getScriptMessagePreview = function (message, emoji_template) {
                 if (
                     message &&
@@ -16060,6 +16070,7 @@ var userOverride = {
                         var groupId = resp.message.groupId;
                         var isGroup = true;
                         mckMessageLayout.removedDeletedMessage(key, tabId, isGroup);
+                        mckMessageLayout.showPrevMsgPicAfterDeleteMsg()
                         // events.onMessageDeleted(eventResponse);
                     }
                 } else {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Now user profile picture not will be removed from the chat widget when the user deletes the message from the dashboard.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch