### PR TITLE
[TD-2651] Fixed bug (Should not create multiple threads if Zopim chat integration)

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -691,6 +691,9 @@ var userOverride = {
                     );
                     KommunicateUI.activateTypingField();
                     mckMessageLayout.loadDropdownOptions();
+                    if (kommunicate._globals.zendeskChatSdkKey) {
+                        kommunicate.startConversation();
+                    }
                 }
             );
             $applozic('#mck-msg-preview-visual-indicator').hasClass('vis')

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -322,9 +322,11 @@ var onTabClickedHandlerForZendeskConversations = function (event) {
         var assigneeInfo = currentGroupData && currentGroupData.users && Object.values(currentGroupData.users).find(function (member) {
             return member.userId == currentGroupData.metadata.CONVERSATION_ASSIGNEE
         })
+        if (document.getElementById('mck-tab-title').innerHTML == "Conversations" && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
+            kommunicate.startConversation();
+        }
         if (!newConversationCreated && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
             newConversationCreated = true;
-            Kommunicate.startConversation();
         }
     }
 };

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -324,7 +324,6 @@ var onTabClickedHandlerForZendeskConversations = function (event) {
         })
         if (!newConversationCreated && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
             newConversationCreated = true;
-            Kommunicate.startConversation();
         }
     }
 };

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -324,6 +324,7 @@ var onTabClickedHandlerForZendeskConversations = function (event) {
         })
         if (!newConversationCreated && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
             newConversationCreated = true;
+            Kommunicate.startConversation();
         }
     }
 };

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -322,10 +322,10 @@ var onTabClickedHandlerForZendeskConversations = function (event) {
         var assigneeInfo = currentGroupData && currentGroupData.users && Object.values(currentGroupData.users).find(function (member) {
             return member.userId == currentGroupData.metadata.CONVERSATION_ASSIGNEE
         });
-        
         if (
-            document.getElementById('mck-tab-title').innerHTML == MCK_LABELS['conversations.title'] &&
-            assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT
+            (document.getElementById('mck-tab-title').innerHTML == MCK_LABELS['conversations.title'] &&
+            assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) ||
+            MCK_GROUP_MAP[event.tabId].users.hasOwnProperty(MCK_GROUP_MAP[event.tabId].displayName) 
         ) {
             kommunicate.startConversation();
         }

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -321,8 +321,12 @@ var onTabClickedHandlerForZendeskConversations = function (event) {
         Kommunicate.updateConversationMetadata(conversationInfo);
         var assigneeInfo = currentGroupData && currentGroupData.users && Object.values(currentGroupData.users).find(function (member) {
             return member.userId == currentGroupData.metadata.CONVERSATION_ASSIGNEE
-        })
-        if (document.getElementById('mck-tab-title').innerHTML == "Conversations" && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {
+        });
+        
+        if (
+            document.getElementById('mck-tab-title').innerHTML == MCK_LABELS['conversations.title'] &&
+            assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT
+        ) {
             kommunicate.startConversation();
         }
         if (!newConversationCreated && assigneeInfo.role != KommunicateConstants.GROUP_ROLE.MODERATOR_OR_BOT) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Stop creating multiple threads for Zopim chat integration

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.

### Testcases this change was tested against
- Firstly verified whether the main bug is coming anymore or not.
- Checked if new conversation is getting created when user restarts the conversation after the chat gets resolved from Zendesk. Its working. 
- Verified if new conversation is getting created after widget reload. Its working.
- Verified that user should not be able to continue with the last conversation after the chat gets resolved or reloaded.