### PR TITLE
Fix the bug where the widget stuck in loading state on click of back button

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6390,7 +6390,7 @@ var userOverride = {
                     success: function (data) {
                         var isMessages = true;
                         //Display/hide lead(email) collection template
-                        CURRENT_GROUP_DATA.createdAt = data.groupFeeds[0].createdAtTime;
+                        CURRENT_GROUP_DATA.createdAt = data && data.groupFeeds[0] && data.groupFeeds[0].createdAtTime;
                         CURRENT_GROUP_DATA.isgroup = params.isGroup;
                         CURRENT_GROUP_DATA.conversationStatus =
                             data &&


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The widget was getting stuck in loading state when the back button was getting clicked
- this was happening in the normal flow

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Created a multiple conversations in the normal flow
- created multiple conversations in zopim flow.

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- a check was missing for the groupFeeds array

NOTE: Make sure you're comparing your branch with the correct base branch