### PR TITLE
 If the encrypted user uses the pre chat lead then API is not encrypted in type 3 and in type 5 widget not opening

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4825,6 +4825,7 @@ var userOverride = {
                         googleApiKey: MCK_GOOGLE_API_KEY,
                         chatNotificationMailSent: true,
                         authenticationTypeId: MCK_AUTHENTICATION_TYPE_ID,
+                        enableEncryption: true
                     };
                     if (email) {
                         options.email = email.toLowerCase();


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- If the encrypted user uses the pre-chat lead then API is not encrypted in type 3 and in type 5 widget not opening
- this is because we don't ` enableEncryption` property in the payload

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Test for pre chat encrypted account [type 3,5]
- without prechat lead in encrypted account
- Test without encrypted account also

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

NOTE: Make sure you're comparing your branch with the correct base branch