### PR TITLE
TDH-62 Language code for non welcome msgs are not coming to bot server by default

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5920,6 +5920,15 @@ var userOverride = {
                 var chatContext = KommunicateUtils.getSettings(
                     'KM_CHAT_CONTEXT'
                 );
+                var userLocale = kommunicate._globals.userLocale;
+                var currentLanguage = {
+                    kmUserLocale: userLocale
+                        ? userLocale.split('-')[0]
+                        : (
+                              window.navigator.language || window.navigator.userLanguage
+                          ).split('-')[0],
+                };
+                chatContext = $applozic.extend(chatContext, currentLanguage);
                 chatContext = typeof chatContext == 'object' ? chatContext : {};
                 MCK_DEFAULT_MESSAGE_METADATA =
                     typeof MCK_DEFAULT_MESSAGE_METADATA == 'object'


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Language codes for non-welcome messages should come to bot server

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Locally

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- Before 
![Screenshot (405)_LI](https://user-images.githubusercontent.com/83231509/220626480-d1dbedd7-4230-44ad-9225-0ea44a239475.jpg)

- After
![Screenshot (404)_LI](https://user-images.githubusercontent.com/83231509/220626114-466f8841-0f91-431c-977e-1e37c9ac3d4e.jpg)

NOTE: Make sure you're comparing your branch with the correct base branch
