### PR TITLE
FWH-98 Some times when we click on the text area in the chat widget the Text Cursor doesnot appear

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -91,6 +91,9 @@
     content: attr(data-text);
 	color: #949494;
 	opacity:0.6;
+    /* the properties mentioned below fixes text cursor disappear issue */
+    position: relative;
+    z-index: -1;
 }
 
 .mck-running-on > a:hover{
@@ -1699,7 +1702,6 @@
 	min-height: 18px;
 	max-height: 78px;
 	resize: none;
-	background-color: white;
 	width: auto;
 	outline: none !important;
 	margin: 0px;
@@ -1712,6 +1714,11 @@
 	box-shadow: none !important;
 	-webkit-user-select: text;
 	border: none;
+    /* the properties mentioned below fixes text cursor disappear issue */
+    background: transparent;
+    caret-color: black; 
+    position: relative;
+    z-index: 0;
 }
 
 .mck-text-box-panel {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- The text cursor should appear every time

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
test case 1
- copy a white html text and paste in the input box
- the text caret should appear

test case 2
- watch the video mentioned in the comments of the ticket

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- We're using contenteditable div as text input and css was not configured properly
- We’re using :before to show placeholder. On clicking the placeholder the focus is not happening.Pseudo-elements are not part of the DOM at all so we can't bind any events directly to them.  

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
