### PR TITLE
FWH-525 Add support for showing custom message if file limit is exceeded

### DIFF
--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -12,6 +12,7 @@ Kommunicate.defaultLabels = {
     'limit.characters': 'characters',
     'limit.remaining': 'remaining',
     'file.uploading.wait': 'Please wait file is uploading.',
+    'file.size.limit.exceeded': "File size cannot be more than $maxAttachmentSize MB",
     'empty.groups': 'No groups yet!',
     'empty.contacts': 'No contacts yet!',
     'empty.messages': 'No messages yet!',

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -484,7 +484,16 @@ function ApplozicSidebox() {
             options.attachmentHandler = options.attachmentHandler != null 
                     ? options.attachmentHandler 
                     : function (file) { return file; };
-            options.defaultUploadOverride = widgetSettings && widgetSettings.defaultUploadOverride
+            options.defaultUploadOverride = widgetSettings && widgetSettings.defaultUploadOverride;
+
+            options.maxAttachmentSize = (options.maxAttachmentSize != null 
+                    ? options.maxAttachmentSize 
+                    : widgetSettings && widgetSettings.maxAttachmentSize);
+            options.maxAttachmentSizeErrorMsg = options.maxAttachmentSizeErrorMsg != null 
+                    ? options.maxAttachmentSizeErrorMsg 
+                    : widgetSettings && widgetSettings.maxAttachmentSizeErrorMsg;
+            
+            
             options.checkboxAsMultipleButton = options.checkboxAsMultipleButton || (widgetSettings && widgetSettings.checkboxAsMultipleButton);
             
             // staticTopMessage and staticTopIcon keys are used in mobile SDKs therefore using same.

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -76,6 +76,8 @@ var userOverride = {
         voiceOutput: false,
         capturePhoto: false,
         captureVideo: false,
+        maxAttachmentSize: 25, // default size is 25MB
+        maxAttachmentSizeErrorMsg: "File size cannot be more than $maxAttachmentSize MB"
     };
     var message_default_options = {
         messageType: 5,
@@ -409,6 +411,7 @@ var userOverride = {
         };
         var MCK_CONTACT_NUMBER = appOptions.contactNumber;
         var MCK_FILEMAXSIZE = appOptions.maxAttachmentSize;
+        var MCK_MSG_FILEMAXSIZE = appOptions.maxAttachmentSizeErrorMsg;
         var MCK_APP_MODULE_NAME = appOptions.appModuleName;
         var MCK_GETTOPICDETAIL = appOptions.getTopicDetail;
         var MCK_GETUSERNAME = appOptions.contactDisplayName;
@@ -1223,6 +1226,7 @@ var userOverride = {
             MCK_APP_MODULE_NAME = optns.appModuleName;
             MCK_GETTOPICDETAIL = optns.getTopicDetail;
             MCK_FILEMAXSIZE = optns.maxAttachmentSize;
+            MCK_MSG_FILEMAXSIZE = appOptions.maxAttachmentSizeErrorMsg;
             MCK_MSG_VALIDATION = optns.validateMessage;
             MCK_GETUSERNAME = optns.contactDisplayName;
             MCK_GROUP_MEMBER_SEARCH_ARRAY = new Array();
@@ -14787,11 +14791,13 @@ var userOverride = {
                     );
                 }
                 if (file['size'] > MCK_FILEMAXSIZE * ONE_MB) {
-                    uploadErrors.push(
-                        'file size can not be more than ' +
-                            MCK_FILEMAXSIZE +
-                            ' MB'
-                    );
+                    MCK_MSG_FILEMAXSIZE &&
+                        uploadErrors.push(
+                            MCK_MSG_FILEMAXSIZE.replace(
+                                "$maxAttachmentSize",
+                                MCK_FILEMAXSIZE
+                            )
+                        );
                 }
                 if (uploadErrors.length > 0) {
                     alert(uploadErrors.toString());
@@ -14984,11 +14990,13 @@ var userOverride = {
                     );
                 }
                 if (file['size'] > MCK_FILEMAXSIZE * ONE_MB) {
-                    uploadErrors.push(
-                        'file size can not be more than ' +
-                            MCK_FILEMAXSIZE +
-                            ' MB'
-                    );
+                    MCK_MSG_FILEMAXSIZE &&
+                        uploadErrors.push(
+                            MCK_MSG_FILEMAXSIZE.replace(
+                                "$maxAttachmentSize",
+                                MCK_FILEMAXSIZE
+                            )
+                        );
                 }
                 if (uploadErrors.length > 0) {
                     alert(uploadErrors.toString());

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -77,7 +77,6 @@ var userOverride = {
         capturePhoto: false,
         captureVideo: false,
         maxAttachmentSize: 25, // default size is 25MB
-        maxAttachmentSizeErrorMsg: "File size cannot be more than $maxAttachmentSize MB"
     };
     var message_default_options = {
         messageType: 5,
@@ -411,7 +410,7 @@ var userOverride = {
         };
         var MCK_CONTACT_NUMBER = appOptions.contactNumber;
         var MCK_FILEMAXSIZE = appOptions.maxAttachmentSize;
-        var MCK_MSG_FILEMAXSIZE = appOptions.maxAttachmentSizeErrorMsg;
+        var MCK_MSG_FILEMAXSIZE = appOptions.maxAttachmentSizeErrorMsg || MCK_LABELS['file.size.limit.exceeded'];
         var MCK_APP_MODULE_NAME = appOptions.appModuleName;
         var MCK_GETTOPICDETAIL = appOptions.getTopicDetail;
         var MCK_GETUSERNAME = appOptions.contactDisplayName;
@@ -1226,7 +1225,7 @@ var userOverride = {
             MCK_APP_MODULE_NAME = optns.appModuleName;
             MCK_GETTOPICDETAIL = optns.getTopicDetail;
             MCK_FILEMAXSIZE = optns.maxAttachmentSize;
-            MCK_MSG_FILEMAXSIZE = appOptions.maxAttachmentSizeErrorMsg;
+            MCK_MSG_FILEMAXSIZE = appOptions.maxAttachmentSizeErrorMsg || MCK_LABELS['file.size.limit.exceeded'];
             MCK_MSG_VALIDATION = optns.validateMessage;
             MCK_GETUSERNAME = optns.contactDisplayName;
             MCK_GROUP_MEMBER_SEARCH_ARRAY = new Array();


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add support for showing custom message if file limit is exceeded

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- There are a total of three base cases
1. Test the widget normally
2. Test the widget after making changes in appSettings table 
3. Test the widget after adding changes in kommunicateSettings

The default limit for file upload is 25 mb and the message displayed is File size cannot be more than $maxAttachmentSize MB

This can be now changed. 
One can update the chat_widget column in appSettings table in DB or he/she can provide the below mentioned properties in kommunicateSettings while initialising the script

Sample of the properties
maxAttachmentSize: 25
maxAttachmentSizeErrorMsg: "File size cannot be more than $maxAttachmentSize MB"

Note if $maxAttachmentSize is provided then it will get replaced to the value

![Screenshot 2023-05-24 at 11 33 47 AM](https://github.com/Kommunicate-io/Kommunicate-Web-SDK/assets/121277435/45ce8b58-6045-4fc7-9e88-957dd0dba365)

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
