### PR TITLE
FFH-291 To show placeholder when the cursor is inside the Message Box in Chat Widget

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -87,11 +87,17 @@
 	color: #aeaaaa !important;
 }
 
-#mck-text-box[contenteditable=true]:empty:not(:focus):before {
+#mck-text-box[contenteditable=true]::before {
     content: attr(data-text);
 	color: #949494;
 	opacity:0.6;
     /* the properties mentioned below fixes text cursor disappear issue */
+    position: relative;
+    z-index: -1;
+}
+
+#mck-text-box[contenteditable=true]:not(:empty)::before {
+    content: "";
     position: relative;
     z-index: -1;
 }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-To show the placeholder text when user clicks on text area but haven't write anything yet

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Locally

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
