### PR TITLE
CSAT is working as expected

### DIFF
--- a/webplugin/js/app/conversation/km-conversation-service.js
+++ b/webplugin/js/app/conversation/km-conversation-service.js
@@ -20,11 +20,18 @@ Kommunicate.conversation = {
             );
             return;
         }
+
         var conversationDetail = data && data.groupFeeds[0];
+        const isConversationRated = kmLocalStorage.getItemFromLocalStorage(
+            conversationDetail.id
+        );
+
         KommunicateUI.showClosedConversationBanner(
-            Kommunicate.conversationHelper.isConversationClosed(
-                conversationDetail
-            )
+            isConversationRated.isConversationClosed
+                ? false
+                : Kommunicate.conversationHelper.isConversationClosed(
+                      conversationDetail
+                  )
         );
     },
 };

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -16,6 +16,7 @@ var WAITING_QUEUE = [];
 var AVAILABLE_VOICES_FOR_TTS = new Array();
 var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ['application', 'text', 'image'];
 const DEFAULT_TEAM_NAME = ['Default Team', 'Default'];
+var CHAT_GROUP_ID = "";
 var userOverride = {
     voiceOutput: true,
 };
@@ -414,6 +415,7 @@ const firstVisibleMsg = {
         var MCK_GROUPMAXSIZE = appOptions.maxGroupSize;
         var MCK_ON_TAB_CLICKED = function (event) {
             console.log('In on_tab_clicked', event);
+            CHAT_GROUP_ID = event && event.tabId;
             const details = event && event.data && event.data.groupDetails;
             if (details) {
                 const assignee =
@@ -5046,6 +5048,10 @@ const firstVisibleMsg = {
                     'km-csat-close-button'
                 ).onclick = function (e) {
                     e.preventDefault();
+                    kmLocalStorage.setItemToLocalStorage(
+                        CHAT_GROUP_ID, { isConversationClosed : true }
+                    )
+
                     KommunicateUI.showClosedConversationBanner(false);
                 };
 
@@ -6445,6 +6451,11 @@ const firstVisibleMsg = {
                     data: w.JSON.stringify(messagePxy),
                     contentType: 'application/json',
                     success: function (data) {
+                        const {groupId} = messagePxy;
+
+                        kmLocalStorage.setItemToLocalStorage(
+                            groupId, { isConversationClosed :false }
+                        )
                         if (kommunicate._globals.zendeskChatSdkKey) {
                             zendeskChatService.handleUserMessage(messagePxy);
                         }


### PR DESCRIPTION
### What do you want to achieve?
CSAT should not be reappear everytime

**Previous Behavior:**
- The CSAT (Customer Satisfaction) rating prompt appears every time we resolve a conversation. The prompt remains active until the customer provides a rating.

**Current Behavior:**
- The CSAT prompt should close and not reappear under the following conditions:
  1. When we restart the conversation and then resolve it.
  2. If we do not close the CSAT using the button and instead refresh the page. This is necessary because if the customer does not close the CSAT or provide a rating, we want to ensure it reappears as needed.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally, and all functionalities are working correctly.
- [ ] I have compared it with design mocks, and all elements match.
- [ ] I have tested it in Internet Explorer.

### Code Testing Details
- The code has been thoroughly tested locally to ensure all functionalities are operating as expected.