### PR TITLE
Fix conversation message on message 

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9482,6 +9482,14 @@ const firstVisibleMsg = {
                 }
 
                 if (
+                    msg &&
+                    msg.metadata &&
+                    msg.metadata.hasOwnProperty('KM_SUMMARY')
+                ) {
+                    return;
+                }
+
+                if (
                     $applozic('#mck-message-cell .' + msg.key).length > 0 &&
                     !(CURRENT_GROUP_DATA.TOKENIZE_RESPONSE && msg.type !== 5)
                 ) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -12453,7 +12453,10 @@ const firstVisibleMsg = {
                 message,
                 contact
             ) {
-                if (message?.metadata?.category === "HIDDEN") {
+                if (
+                    message?.metadata?.category === 'HIDDEN' ||
+                    message?.metadata?.hasOwnProperty('KM_SUMMARY')
+                ) {
                     return;
                 }
                 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9416,6 +9416,14 @@ const firstVisibleMsg = {
                 allowReload,
                 msgThroughListAPI
             ) {
+                if (
+                    msg &&
+                    msg.metadata &&
+                    msg.metadata.hasOwnProperty('KM_SUMMARY')
+                ) {
+                    return;
+                }
+
                 var metadatarepiledto = '';
                 var replymessage = '';
                 var replyMsg = '';
@@ -9479,14 +9487,6 @@ const firstVisibleMsg = {
                             msgReplyToVisible = 'n-vis';
                         }
                     }
-                }
-
-                if (
-                    msg &&
-                    msg.metadata &&
-                    msg.metadata.hasOwnProperty('KM_SUMMARY')
-                ) {
-                    return;
                 }
 
                 if (


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Add hard check to disable any conversation summary summary message in widget conversation list and message list

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Tested locally

### Issue
- Message received after talk to human button is click doesn't contain hidden in metadata. Now, we are returning if it contain KM_SUMMARY so that no message which contain this field is added to the widget. 

### Screenshot
- after fix
![Screenshot 2024-11-05 at 1 35 29 PM](https://github.com/user-attachments/assets/dc50c0ba-24d7-450c-a027-40db317ace3c)

- before fix 
![Screenshot 2024-11-05 at 1 20 13 PM](https://github.com/user-attachments/assets/52365e0b-4a71-484a-974a-f2e0d874bc9d)


NOTE: Make sure you're comparing your branch with the correct base branch
