### PR TITLE
CUS-730 Chat widget should open again if entered password is wrong and page is refreshed.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,13 +7,22 @@ substitutions:
   _FIREBASE_SITE_ID: "${_BUILD_ENV}_site_id"  # Placeholder for Firebase site ID
 
 steps:
-  # Step 1: Install dependencies
+ # Step 1: Install Node.js dependencies
   - name: 'gcr.io/cloud-builders/npm'
-    args: ['install']
+    entrypoint: 'sh'
+    args:
+      - '-c'
+      - |
+        echo clean
+        npm cache clean --force
+        echo remove
+        rm -rf node_modules package-lock.json
+        echo Installing source NPM dependencies...
+        npm install
 
   # Step 2: Conditionally run builds based on _BUILD_ENV
   - name: 'gcr.io/cloud-builders/npm'
-    entrypoint: 'bash'
+    entrypoint: 'sh'
     args:
       - '-c'
       - |

--- a/firebase.json
+++ b/firebase.json
@@ -65,6 +65,11 @@
         "type": "404"
       },
       {
+        "source": "/robots.txt",
+        "destination": "/robots.txt", 
+        "type": "200"
+      },
+      {
         "source": "/chat",
         "destination": "/chat.html",
         "type": "200"

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/webplugin/gulpfile.js
+++ b/webplugin/gulpfile.js
@@ -246,6 +246,9 @@ const generateBuildFiles = () => {
             `${resourceLocation}/third-party-scripts/mck-emojis.min.js`
         );
 
+        // generate robots.txt for build dir
+        copyFileToBuild('../robots.txt', `${buildDir}/robots.txt`);
+
         THIRD_PARTY_FILE_INFO.forEach((file) => {
             const des = `${resourceLocation}/third-party-scripts`;
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2452,7 +2452,22 @@ const firstVisibleMsg = {
                             }
                             // if there is error then removing LeadCollection from cookies
                             kmCookieStorage.deleteCookie({
-                                name: KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,
+                                name:
+                                    KommunicateConstants.COOKIES
+                                        .IS_USER_ID_FOR_LEAD_COLLECTION,
+                                domain: MCK_COOKIE_DOMAIN,
+                            });
+                            kmCookieStorage.deleteCookie({
+                                name:
+                                    KommunicateConstants.COOKIES
+                                        .KOMMUNICATE_LOGGED_IN_USERNAME,
+                                domain: MCK_COOKIE_DOMAIN,
+                            });
+                            kmCookieStorage.deleteCookie({
+                                name:
+                                    KommunicateConstants.COOKIES
+                                        .KOMMUNICATE_LOGGED_IN_ID,
+                                domain: MCK_COOKIE_DOMAIN,
                             });
                             throw new Error('INVALID_PASSWORD');
                         } else if (result === 'INVALID_APPID') {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2450,6 +2450,10 @@ const firstVisibleMsg = {
                                     errorMessage: 'INVALID PASSWORD',
                                 });
                             }
+                            // if there is error then removing LeadCollection from cookies
+                            kmCookieStorage.deleteCookie({
+                                name: KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION,
+                            });
                             throw new Error('INVALID_PASSWORD');
                         } else if (result === 'INVALID_APPID') {
                             Kommunicate.displayKommunicateWidget(false);

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2450,25 +2450,9 @@ const firstVisibleMsg = {
                                     errorMessage: 'INVALID PASSWORD',
                                 });
                             }
-                            // if there is error then removing LeadCollection from cookies
-                            kmCookieStorage.deleteCookie({
-                                name:
-                                    KommunicateConstants.COOKIES
-                                        .IS_USER_ID_FOR_LEAD_COLLECTION,
-                                domain: MCK_COOKIE_DOMAIN,
-                            });
-                            kmCookieStorage.deleteCookie({
-                                name:
-                                    KommunicateConstants.COOKIES
-                                        .KOMMUNICATE_LOGGED_IN_USERNAME,
-                                domain: MCK_COOKIE_DOMAIN,
-                            });
-                            kmCookieStorage.deleteCookie({
-                                name:
-                                    KommunicateConstants.COOKIES
-                                        .KOMMUNICATE_LOGGED_IN_ID,
-                                domain: MCK_COOKIE_DOMAIN,
-                            });
+                            // if password invalid then clear cookies
+                            kmCookieStorage.deleteUserCookiesOnLogout();
+                            
                             throw new Error('INVALID_PASSWORD');
                         } else if (result === 'INVALID_APPID') {
                             Kommunicate.displayKommunicateWidget(false);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- After entering agent Email it ask for password if you enter wrong password and refresh the page Widget UI breaks.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Locally


### In case you fixed a bug then please describe the root cause of it? 
- The issue arises because we are storing LeadCollection: true in the cookies. Upon page reload, we check if LeadCollection is set to true, and if so, we avoid asking for the user's details again, automatically logging them in with the previously stored email. However, since a password is also required, this causes the UI to break when an invalid password is entered. To resolve this, we now delete the LeadCollection value from the cookies whenever an "Invalid Password" error occurs.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `robots.txt` file to manage web crawler access.
  - Added a new rewrite rule in `firebase.json` to serve the `robots.txt` file correctly.
  - Enhanced the build process to include the generation of the `robots.txt` file.

- **Bug Fixes**
  - Improved dependency management during the build process for Node.js applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->