### PR TITLE
generate the unique user id for pre chat lead

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -636,7 +636,10 @@ function ApplozicSidebox() {
             options.googleApiKey =
                 isSettingEnable('googleApiKey') ??
                 'AIzaSyCcC8PixPO1yzz35TnjWYIhQvCljTPSU7M';
-            options.uniqueUserIdForPreChatLead = isSettingEnable('uniqueUserIdForPreChatLead');
+                
+            options.anonymousUserIdForPreChatLead = isSettingEnable(
+                'anonymousUserIdForPreChatLead'
+            );
 
             appOptionSession.deletePropertyDataFromSession('settings');
 

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -636,6 +636,7 @@ function ApplozicSidebox() {
             options.googleApiKey =
                 isSettingEnable('googleApiKey') ??
                 'AIzaSyCcC8PixPO1yzz35TnjWYIhQvCljTPSU7M';
+            options.uniqueUserIdForPreChatLead = isSettingEnable('uniqueUserIdForPreChatLead');
 
             appOptionSession.deletePropertyDataFromSession('settings');
 
@@ -794,9 +795,10 @@ function ApplozicSidebox() {
             ? kommunicateIframe.getAttribute('data-url')
             : parent.window.location.href;
         userId =
+            options.userId ||
             kmCookieStorage.getCookie(
                 KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
-            ) || userId;
+            );
 
         try {
             const sentryGlobalScope = Sentry.getGlobalScope();

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5224,7 +5224,7 @@ const firstVisibleMsg = {
                             // get number in international format as a string
                             contactNumber = INTL_TEL_INSTANCE.getNumber();
                         }
-                        if (!appOptions.uniqueUserIdForPreChatLead) {
+                        if (!appOptions.anonymousUserIdForPreChatLead) {
                             userId = contactNumber;
                         }
 
@@ -5237,7 +5237,7 @@ const firstVisibleMsg = {
                             );
                     }
                     if (email) {
-                        const userIdForCookie = appOptions.uniqueUserIdForPreChatLead
+                        const userIdForCookie = appOptions.anonymousUserIdForPreChatLead
                             ? userId
                             : email;
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1366,7 +1366,7 @@ const firstVisibleMsg = {
         };
         _this.logout = function () {
             if (typeof window.Applozic.ALSocket !== 'undefined') {
-                kmLocalStorage.removeItemFromLocalStorage("feedbackGroups");
+                kmLocalStorage.removeItemFromLocalStorage('feedbackGroups');
                 window.Applozic.ALSocket.disconnect();
                 appOptionSession.deleteSessionData();
                 window.Applozic.ALApiService.setAjaxHeaders('', '', '', '', '');
@@ -3198,7 +3198,9 @@ const firstVisibleMsg = {
                     return kmChatInputDiv;
                 });
             _this.createInputField = function (preLeadCollection) {
-                var inputId = 'km-' + preLeadCollection.field.toLowerCase().replace(" ","-");
+                var inputId =
+                    'km-' +
+                    preLeadCollection.field.toLowerCase().replace(' ', '-');
                 var kmChatInputDiv = _this.createInputContainer(inputId);
                 var kmLabelDiv = _this.createPreChatLabel(
                     preLeadCollection,
@@ -3243,7 +3245,7 @@ const firstVisibleMsg = {
                     );
                     kmChatInput.setAttribute(
                         'aria-label',
-                        preLeadCollection.field.replace(" ","-")
+                        preLeadCollection.field.replace(' ', '-')
                     );
                     if (preLeadCollection.type == 'email') {
                         kmChatInput.setAttribute(
@@ -4107,7 +4109,9 @@ const firstVisibleMsg = {
                 var metadata = {};
                 var field = '';
                 KM_PRELEAD_COLLECTION.map(function (element) {
-                    field = element.field && element.field.toLowerCase().replace(" ","-");
+                    field =
+                        element.field &&
+                        element.field.toLowerCase().replace(' ', '-');
                     if (KM_USER_DETAIL.indexOf(field) === -1) {
                         metadata[element.field] = $applozic(
                             '#km-' + field
@@ -5220,7 +5224,10 @@ const firstVisibleMsg = {
                             // get number in international format as a string
                             contactNumber = INTL_TEL_INSTANCE.getNumber();
                         }
-                        userId = contactNumber;
+                        if (!appOptions.uniqueUserIdForPreChatLead) {
+                            userId = contactNumber;
+                        }
+
                         // Remove listener from phone number
                         document
                             .getElementById('km-phone')
@@ -5230,12 +5237,15 @@ const firstVisibleMsg = {
                             );
                     }
                     if (email) {
-                        userId = email;
+                        const userIdForCookie = appOptions.uniqueUserIdForPreChatLead
+                            ? userId
+                            : email;
+
                         kmCookieStorage.setCookie({
                             name:
                                 KommunicateConstants.COOKIES
                                     .KOMMUNICATE_LOGGED_IN_ID,
-                            value: email,
+                            value: userIdForCookie,
                             expiresInDays: 30,
                             domain: MCK_COOKIE_DOMAIN,
                         });

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5216,6 +5216,8 @@ const firstVisibleMsg = {
                     var userName = $applozic('#km-name').val();
                     var contactNumber = $applozic('#km-phone').val();
                     var password = $applozic('#km-password').val();
+                    const anonymousUserIdForPreChatLead =
+                        appOptions.anonymousUserIdForPreChatLead;
                     if (password) {
                         MCK_ACCESS_TOKEN = password;
                     }
@@ -5224,7 +5226,7 @@ const firstVisibleMsg = {
                             // get number in international format as a string
                             contactNumber = INTL_TEL_INSTANCE.getNumber();
                         }
-                        if (!appOptions.anonymousUserIdForPreChatLead) {
+                        if (!anonymousUserIdForPreChatLead) {
                             userId = contactNumber;
                         }
 
@@ -5237,9 +5239,11 @@ const firstVisibleMsg = {
                             );
                     }
                     if (email) {
-                        const userIdForCookie = appOptions.anonymousUserIdForPreChatLead
+                        const userIdForCookie = anonymousUserIdForPreChatLead
                             ? userId
                             : email;
+
+                        userId = userIdForCookie;
 
                         kmCookieStorage.setCookie({
                             name:


### PR DESCRIPTION
Generate the unique user ID for the pre-chat lead instead of using the phone or email as userId

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-  Generate the unique user ID for the pre-chat lead form instead of using the phone or email as userId

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unique user identifier for pre-chat lead collection.
  - Enhanced session management with improved handling of anonymous users.
  - Added support for additional widget settings during initialization.

- **Bug Fixes**
  - Improved error handling for user ID assignment in error tracking.
  - Refined logic for managing user cookies based on lead collection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->