### PR TITLE
CUS-766 Disable handover button till api response is received after click

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5175,6 +5175,8 @@ const firstVisibleMsg = {
 
                 $applozic(d).on('click', '#km-talk-to-human', function (e) {
                     e.preventDefault();
+                    var $button = $applozic(this);
+                    $button.prop('disabled', true);
 
                     window.Applozic.ALApiService.ajax({
                         type: 'PATCH',
@@ -5201,8 +5203,10 @@ const firstVisibleMsg = {
                                         );
                                 }
                             }
+                            $button.prop('disabled', false); // enable button
                         },
                         error: function (data) {
+                            $button.prop('disabled', false); // enable button
                             console.error(data);
                         },
                     });


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Disable handover button till api response is received after talk to agent button is clicked.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- locally


### In case you fixed a bug then please describe the root cause of it? 
- Talk to human button was not getting disabled when api call is happening.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
