### PR TITLE
 added character limit for ES and CX bot. TDH-1685

### DIFF
--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -7,7 +7,7 @@ class KMLabel {
             'search.contacts': 'Contacts',
             'search.groups': 'Groups',
             'char.limit.warn':
-                'Keep your message within 256 characters to help the bot understand easily',
+                'Keep your message within LIMIT characters to help the bot understand easily',
             'limit.remove': 'Remove',
             'limit.characters': 'characters',
             'limit.remaining': 'remaining',

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -16,6 +16,8 @@ var WAITING_QUEUE = [];
 var AVAILABLE_VOICES_FOR_TTS = new Array();
 var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ['application', 'text', 'image'];
 const DEFAULT_TEAM_NAME = ['Default Team', 'Default'];
+const CHARACTER_LIMIT = {"ES": 256 , "CX": 500};
+const WARNING_LENGTH = {"ES": 199 , "CX": 450};
 var userOverride = {
     voiceOutput: true,
 };
@@ -4610,8 +4612,8 @@ const firstVisibleMsg = {
                         return;
                     }
                     if (CURRENT_GROUP_DATA.CHAR_CHECK) {
-                        var warningLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? 450 : 199;
-                        var maxLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? 500 : 256;
+                        var warningLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? WARNING_LENGTH["CX"]: WARNING_LENGTH["ES"];
+                        var maxLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? CHARACTER_LIMIT["CX"] : CHARACTER_LIMIT["ES"];
                         var textBox = $mck_text_box[0]; //using separate selector for vanilla JS functions
                         if (!document.getElementById('mck-char-count')) {
                             warningText.innerHTML = MCK_LABELS["char.limit.warn"].replace("LIMIT",maxLength) +
@@ -14493,7 +14495,7 @@ const firstVisibleMsg = {
             _this.disableSendButton = function (value) {
                 var textBox = document.getElementById('mck-text-box');
                 var str = mckUtils.textVal(textBox);
-                var maxLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? 500 : 256;
+                var maxLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? CHARACTER_LIMIT['CX'] : CHARACTER_LIMIT['ES'];
                 var sendButton = document.getElementById('mck-msg-sbmt');
                 var trimmedStr = str.trim();
                 var textLength = trimmedStr.length;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4610,11 +4610,11 @@ const firstVisibleMsg = {
                         return;
                     }
                     if (CURRENT_GROUP_DATA.CHAR_CHECK) {
-                        var warningLength = 199;
-                        var maxLength = 256;
+                        var warningLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? 450 : 199;
+                        var maxLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? 500 : 256;
                         var textBox = $mck_text_box[0]; //using separate selector for vanilla JS functions
                         if (!document.getElementById('mck-char-count')) {
-                            warningText.innerHTML +=
+                            warningText.innerHTML = MCK_LABELS["char.limit.warn"].replace("LIMIT",maxLength) +
                                 '<span> | </span><span id="mck-char-count"></span>';
                         }
                         var remtxt;
@@ -14464,6 +14464,7 @@ const firstVisibleMsg = {
                         CURRENT_GROUP_DATA.isConversationAssigneeBot = true;
                         CURRENT_GROUP_DATA.answerFeedback =
                             res?.answerFeedback || false;
+                        CURRENT_GROUP_DATA.isDialogflowCXBot = res?.dialogflowCXBot || false;
                     },
                     error: function () {
                         CURRENT_GROUP_DATA.CHAR_CHECK = false;
@@ -14492,7 +14493,7 @@ const firstVisibleMsg = {
             _this.disableSendButton = function (value) {
                 var textBox = document.getElementById('mck-text-box');
                 var str = mckUtils.textVal(textBox);
-                var maxLength = 256;
+                var maxLength = CURRENT_GROUP_DATA.isDialogflowCXBot ? 500 : 256;
                 var sendButton = document.getElementById('mck-msg-sbmt');
                 var trimmedStr = str.trim();
                 var textLength = trimmedStr.length;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-  adding different character limit from dialogflow ES and CX bot 
 for ES - limit is 256 
 For CX - limit is 500

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated default label text for character limit warning to use a more generic placeholder message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->