### PR TITLE
Handle preview if url is protected or giving cloud flare error

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -139,15 +139,35 @@ KommunicateUI = {
             type: 'GET',
             global: false,
             success: function (result) {
+                const { title, description } = result.data;
+                // Check if the title contains Cloudflare or security challenge related words
+                if (
+                    title &&
+                    title.includes('Attention Required!')
+                ) {
+                    throw Error("Cloudflare or security block detected. No preview available.") // Skip rendering the preview or return a default message
+                }
+
+                // Check for other possible issues with the preview data (e.g., missing meta information)
+                if (!title || !description) {
+                    throw Error("Missing metadata for preview. No preview available.")
+                }
                 if (result) {
                     var images = result.data.images;
-                    result.data.images = images.length ? KommunicateUI.checkSvgHasChildren(images) : [];
+                    result.data.images = images.length
+                        ? KommunicateUI.checkSvgHasChildren(images)
+                        : [];
 
                     // this happens when the link gets redirected
-                    if (result.data.title === "ERROR: The request could not be satisfied") return;
+                    if (
+                        result.data.title ===
+                        'ERROR: The request could not be satisfied'
+                    )
+                        return;
 
                     var previewTemplate = kommunicate.markup.getLinkPreviewTemplate(
-                        result, isMckRightMsg
+                        result,
+                        isMckRightMsg
                     );
                     callback(previewTemplate);
                 }

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -139,21 +139,22 @@ KommunicateUI = {
             type: 'GET',
             global: false,
             success: function (result) {
-                const { title, description } = result.data;
-                // Check if the title contains Cloudflare or security challenge related words
+                const { title, description } = result?.data ? result.data : {};
+
                 if (
                     title &&
                     title.includes('Attention Required!')
                 ) {
-                    throw Error("Cloudflare or security block detected. No preview available.") // Skip rendering the preview or return a default message
+                    console.error("Cloudflare or security block detected. No preview available.");
+                    return;
                 }
 
-                // Check for other possible issues with the preview data (e.g., missing meta information)
                 if (!title || !description) {
-                    throw Error("Missing metadata for preview. No preview available.")
+                    console.error("Missing metadata for preview. No preview available.")
+                    return;
                 }
                 if (result) {
-                    var images = result.data.images;
+                    var images = result?.data?.images || [];
                     result.data.images = images.length
                         ? KommunicateUI.checkSvgHasChildren(images)
                         : [];

--- a/webplugin/scss/components/_km-message-area.scss
+++ b/webplugin/scss/components/_km-message-area.scss
@@ -70,7 +70,7 @@
     }
     &.mck-left-link-box,
     &.mck-right-link-box {
-        padding: 0;
+        padding: 12px;
 
         & .mck-msg-text > div:first-child {
             padding: $msg-box-padding;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Preventing preview if url is protected or giving cloud flare error

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- In api server we are using a library link-preview-js to get data for preview. So if any website having captcha or if there any website is using security service to protect itself from online attacks then also this library gives success response. And it shows whatever data response it gets from the API. So to prevent this added some checks and if it not passes those checks then it will not show preview.

Here are some website which are having captcha or security services.
- https://www.saveonfoods.com/deals
![Screenshot 2025-02-10 at 4 04 29 PM](https://github.com/user-attachments/assets/70a96cda-ef03-4356-ae13-72940dcb79cd)

- https://securityheaders.com/
![Screenshot 2025-02-10 at 4 05 09 PM](https://github.com/user-attachments/assets/9352fb1e-c31a-4861-9a09-45b8274dc309)


### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved link preview reliability by adding error handling for missing titles and descriptions, ensuring only valid content is displayed.
- **Style**
	- Enhanced visual spacing in message components by updating padding for a cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->