### PR TITLE
CUS-908 Email validation error

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5899,6 +5899,8 @@ const firstVisibleMsg = {
                                 messagePxy.message
                             );
                             if (!isValid) {
+                                mckMessageService.resetMessageSentToHumanAgent();
+                                $mck_msg_sbmt.attr('disabled', false);
                                 return false;
                             }
                         }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fixed Email validation error

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Locally


### In case you fixed a bug then please describe the root cause of it? 
- The root cause of the bug is related to the messageSentToHumanAgent counter variable's incorrect increment timing. When a user enters an invalid email, even though the validation fails, the counter messageSentToHumanAgent still gets incremented due to the line:
`!KommunicateUtils.isCurrentAssigneeBot() && messageSentToHumanAgent++;`

This increment happens regardless of email validation success or failure. As a result, when the user tries to enter the email again, the condition: `messageSentToHumanAgent == 1` is no longer true (since it's now > 1), causing the validation logic to be skipped entirely. This prevents the error message from being shown/hidden appropriately on subsequent email entry attempts.

The counter should only be incremented when a valid email is successfully sent, not on validation failure.


### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
