### PR TITLE
Tdh 1776 Restrict Human Handover

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5196,13 +5196,11 @@ const firstVisibleMsg = {
                         key: mckUtils.randomId(),
                         metadata: {
                             TALK_TO_HUMAN: true,
-                            KM_CHAT_CONTEXT: JSON.stringify(
-                                _this.getChatContext(messagePxy)
-                            ),
                         },
                         groupId: CURRENT_GROUP_DATA.tabId,
                         source: 1,
                     };
+                    messagePxy.metadata.KM_CHAT_CONTEXT = JSON.stringify(_this.getChatContext(messagePxy));
                     _this.sendMessage(messagePxy);
                     const lastMessageBeforeSend = $applozic(
                         "#mck-message-cell .mck-message-inner div[name='message']:last-child"

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5204,7 +5204,7 @@ const firstVisibleMsg = {
                         source: 1,
                     };
                     _this.sendMessage(messagePxy);
-                    var lastMessageBeforeSend = $applozic(
+                    const lastMessageBeforeSend = $applozic(
                         "#mck-message-cell .mck-message-inner div[name='message']:last-child"
                     );
                     if (HIDE_POST_CTA) {
@@ -13111,17 +13111,6 @@ const firstVisibleMsg = {
                 // if (!_this.isMessageSentByBot(message, contact)) {
                 //     typingService.hideTypingIndicator();
                 // }
-                if (messageType === 'APPLOZIC_01') {
-                    let talkToHumanButton = document.getElementById(
-                        'km-talk-to-human'
-                    );
-                    if (
-                        talkToHumanButton?.disabled &&
-                        message?.metadata?.KM_ASSIGN_TO === ''
-                    ) {
-                        talkToHumanButton.disabled = false;
-                    }
-                }
                 var tabId = $mck_msg_inner.data('mck-id');
                 var isValidMeta = mckMessageLayout.isValidMetaData(message);
                 if (typeof tabId === 'undefined' || tabId === '') {
@@ -17724,6 +17713,15 @@ const firstVisibleMsg = {
                             Kommunicate.KmEventHandler.onMessageReceived(
                                 messageCopy
                             );
+                            const talkToHumanButton = document.getElementById(
+                                'km-talk-to-human'
+                            );
+                            if (
+                                talkToHumanButton?.disabled &&
+                                message?.metadata?.KM_ASSIGN_TO === ''
+                            ) {
+                                talkToHumanButton.disabled = false;
+                            }
                         } else if (messageType === 'APPLOZIC_02') {
                             Kommunicate.KmEventHandler.onMessageSent(message);
                         }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5202,7 +5202,7 @@ const firstVisibleMsg = {
                     };
                     messagePxy.metadata.KM_CHAT_CONTEXT = JSON.stringify(_this.getChatContext(messagePxy));
                     _this.sendMessage(messagePxy);
-                    const lastMessageBeforeSend = $applozic(
+                    const lastMessageBeforeSend = document.querySelector(
                         "#mck-message-cell .mck-message-inner div[name='message']:last-child"
                     );
                     if (HIDE_POST_CTA) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Instead of Assignee change api now we will use send message api. Because assignee change api will always change assignee but if bot to human handover is off when agents are away/offline in that case we want to show away message too

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch