### PR TITLE
TDH-1788 | On restarting the conversation, default language Welcome message is triggering

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3363,6 +3363,7 @@ const firstVisibleMsg = {
                                 metadata: {
                                     category: 'HIDDEN',
                                     KM_TRIGGER_EVENT: eventToTrigger,
+                                    KM_CHAT_CONTEXT: JSON.stringify({kmUserLocale: kommunicate._globals.userLocale})
                                 },
                                 source: 1,
                             },


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Passed KM_CHAT_CONTEXT: "{"kmUserLocale":"en"}" on restart conversation.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced context support for chat messages, enabling the inclusion of localized context information for a more tailored messaging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->