### PR TITLE
CUS-464 When we copy paste message in chat widget the send option doesn't appear needs to enter space to enable

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3907,7 +3907,7 @@ const firstVisibleMsg = {
                     mckMessageLayout.addGroupsToGroupSearchList();
                 });
 
-                mck_text_box.addEventListener('keyup', function () {
+                mck_text_box.addEventListener('input', function () {
                     _this.toggleMediaOptions(this);
                 });
                 _this.cursorPosition = function (element) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- When we copy paste message in chat widget the send option doesn't appear needs to enter space to enable

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- keyup event was used due which send button was not showing so added input event

### Screenshot
- 
![Screenshot (578)](https://github.com/user-attachments/assets/3db35f56-001e-4224-8ec3-57b568c5154c)

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the message input field to respond to all input changes, including paste and cut actions, for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->