### PR TITLE
Changed default to make socket connection only click on Chat icon

### DIFF
--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -11,8 +11,7 @@ function KommunicateCommons() {
         CUSTOMER_CREATED_AT = optns.customerCreatedAt;
         USE_BRANDING = typeof optns.useBranding == 'boolean' ? optns.useBranding : true;
         WIDGET_SETTINGS = optns.widgetSettings;
-        KommunicateCommons.CONNECT_SOCKET_ON_WIDGET_CLICK =
-            optns.connectSocketOnWidgetClick || false;
+        KommunicateCommons.CONNECT_SOCKET_ON_WIDGET_CLICK = true;
     };
 
     _this.isTrialPlan = function (pricingPackage) {
@@ -190,7 +189,7 @@ function KommunicateCommons() {
     _this.setWidgetStateOpen = function (isWidgetOpen) {
         if (KommunicateCommons.IS_WIDGET_OPEN === isWidgetOpen) return; // return if same value is already assigned to IS_WIDGET_OPEN.
         KommunicateCommons.IS_WIDGET_OPEN = isWidgetOpen;
-        if (IS_SOCKET_CONNECTED) {
+        if (IS_SOCKET_CONNECTED && isWidgetOpen) {
             window.Applozic.SOCKET_DISCONNECT_PROCEDURE.stop();
         } else {
             KommunicateCommons.CONNECT_SOCKET_ON_WIDGET_CLICK


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-  if user did not clicked on the chat widgeticon then  a disconnecting socket connection after one minute and reconnect once user clicks on chat icon.
-  for the new users  the connection only established after clickning on the chat widget

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
