### PR TITLE
increment unread count only for complete message not for each token

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -10975,7 +10975,8 @@ const firstVisibleMsg = {
                             : 'user_' + contact.contactId;
                         if (isValidMeta) {
                             if (message.contentType !== 10 && message.contentType !== 102) {
-                                mckMessageLayout.incrementUnreadCount(ucTabId);
+                                !message.tokenMessage &&
+                                    mckMessageLayout.incrementUnreadCount(ucTabId);
                             }
                             if (
                                 !(document.getElementById('mck-sidebox').style.display === 'block')


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- currenly if generative response is enabled then it increment  unread message count for each token message.
- fix : skip unread count for  token message.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unread message count no longer increases for tokenized messages, ensuring only relevant messages affect the unread count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->