### PR TITLE
fix source not coming in new line

### DIFF
--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -585,7 +585,7 @@ KommunicateUtils = {
             .split('\n')
             .map((line) => line.replace(/^\s*-\s*/, '- ').trimEnd()) // Trim right-side spaces
             .filter((line) => line !== '') // Remove empty lines
-            .join('\n');
+            .join('\n\n');
     },
 
     containsRawHTML: function (text) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- fix source not coming in new line

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
- According to the Markdown specification, a single newline (\n) is treated as a space or a soft line break. It does not create a new paragraph. So, marked.js saw 'Hello\nWorld' and rendered it as if it were on the same line: <p>Hello World</p>.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown formatting by adding extra spacing between lines in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->