### PR TITLE
 connect socket even if user does not have previous conversation but chat widget is open

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2327,12 +2327,12 @@ const firstVisibleMsg = {
                             null,
                             function (err, checkIfUserHasConversations) {
                                 err && console.log(err);
-                                checkIfUserHasConversations ||
-                                    (KommunicateCommons.IS_WIDGET_OPEN &&
-                                        $applozic.fn.applozic(
-                                            'initializeSocketConnection',
-                                            IS_REINITIALIZE
-                                        ));
+                                (checkIfUserHasConversations ||
+                                    KommunicateCommons.IS_WIDGET_OPEN) &&
+                                    $applozic.fn.applozic(
+                                        'initializeSocketConnection',
+                                        IS_REINITIALIZE
+                                    );
                             }
                         );
                     } else {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2327,12 +2327,12 @@ const firstVisibleMsg = {
                             null,
                             function (err, checkIfUserHasConversations) {
                                 err && console.log(err);
-                                checkIfUserHasConversations &&
-                                    KommunicateCommons.IS_WIDGET_OPEN &&
-                                    $applozic.fn.applozic(
-                                        'initializeSocketConnection',
-                                        IS_REINITIALIZE
-                                    );
+                                checkIfUserHasConversations ||
+                                    (KommunicateCommons.IS_WIDGET_OPEN &&
+                                        $applozic.fn.applozic(
+                                            'initializeSocketConnection',
+                                            IS_REINITIALIZE
+                                        ));
                             }
                         );
                     } else {


### PR DESCRIPTION
…chat widget is open

<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-  connect socket even if user does not have previous conversation but chat widget is open

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the logic for initializing the chat connection to activate when the user has conversations or the widget is open, enhancing chat availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->