### PR TITLE
 fixed issue with socket reconnection after internet disconnected for longer time 

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2367,7 +2367,10 @@ const firstVisibleMsg = {
                         'n-vis',
                         'vis'
                     );
-                    window.Applozic.ALSocket.reconnect();
+                    setTimeout(() => {
+                        console.log('reaconnecting socket');
+                        window.Applozic.ALSocket.reconnect();
+                    }, 500);
                 });
                 w.addEventListener('offline', function () {
                     kommunicateCommons.modifyClassList(


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?

  cause : Calling ALSocket.reconnect() immediately on the online event doesn't work because the Applozic SDK hasn't fully restored its internal state (e.g. user session, socket) yet.

fix: Adding a short setTimeout gives the SDK enough time to reinitialize from localStorage, so reconnect() works reliably.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
