### PR TITLE
Refactor visibility logic in sidebox

### DIFF
--- a/webplugin/js/app/components/typing-service.js
+++ b/webplugin/js/app/components/typing-service.js
@@ -162,7 +162,7 @@ class TypingService {
     };
 
     scrollToTheCurrentMsg = (msgElement, msgKey) => {
-        msgElement.classList.remove('n-vis');
+        kommunicateCommons.classListChanger(msgElement, 'vis', 'n-vis');
         this.scrollToView(this.appOptions.showMsgFromStart, msgKey);
     };
 

--- a/webplugin/js/app/components/typing-service.js
+++ b/webplugin/js/app/components/typing-service.js
@@ -162,7 +162,8 @@ class TypingService {
     };
 
     scrollToTheCurrentMsg = (msgElement, msgKey) => {
-        kommunicateCommons.classListChanger(msgElement, 'vis', 'n-vis');
+        // ensure the message is visible before scrolling
+        kommunicateCommons.setVisibility(msgElement, true);
         this.scrollToView(this.appOptions.showMsgFromStart, msgKey);
     };
 

--- a/webplugin/js/app/events/applozic-event-handler.js
+++ b/webplugin/js/app/events/applozic-event-handler.js
@@ -2,10 +2,14 @@ Kommunicate.KmEventHandler = {
     openChatOnNotification: function (message) {
         if (!(document.getElementById('mck-sidebox').style.display === 'block')) {
             if (message && message.groupId) {
-                document.getElementById('launcher-agent-img-container').classList.remove('vis');
-                document.getElementById('launcher-agent-img-container').classList.add('n-vis');
-                document.getElementById('launcher-svg-container').classList.remove('n-vis');
-                document.getElementById('launcher-svg-container').classList.add('vis');
+                kommunicateCommons.setVisibility(
+                    { id: ['launcher-agent-img-container'] },
+                    false
+                );
+                kommunicateCommons.setVisibility(
+                    { id: ['launcher-svg-container'] },
+                    true
+                );
                 window.Kommunicate.openConversation(message.groupId);
             } else {
                 window.Kommunicate.openDirectConversation(message.to);
@@ -21,12 +25,12 @@ Kommunicate.KmEventHandler = {
         } else if (
             document.getElementById('launcher-agent-img-container').classList.contains('vis')
         ) {
-            document
-                .querySelector('#mck-sidebox-launcher #launcher-svg-container')
-                .classList.add('n-vis');
-            document
-                .querySelector('#mck-sidebox-launcher #launcher-svg-container')
-                .classList.remove('vis');
+            kommunicateCommons.modifyClassList(
+                { class: ['#mck-sidebox-launcher #launcher-svg-container'] },
+                'n-vis',
+                'vis',
+                true
+            );
         }
     },
     onMessageReceived: function (message, toggleSound) {

--- a/webplugin/js/app/km-message-markup-1.0.js
+++ b/webplugin/js/app/km-message-markup-1.0.js
@@ -83,7 +83,7 @@ Kommunicate.messageTemplate = {
                     data.blobKey = data.fileMeta.blobKey;
                 }
                 return Mustache.to_html(
-                    Kommunicate.messageTemplate.getAttachmentApplicationTemplate(data),
+                    Kommunicate.messageTemplate.getAttachmentApplicationTemplate(),
                     data
                 );
             default:

--- a/webplugin/js/app/km-message-markup-1.0.js
+++ b/webplugin/js/app/km-message-markup-1.0.js
@@ -161,7 +161,8 @@ Kommunicate.popupChatTemplate = {
         Kommunicate['chatPopupActions'] = {};
 
         if (Array.isArray(buttonDetails) && buttonDetails.length) {
-            for (var i = 0; i < 2 && i < buttonDetails.length; i++) {
+            // popup currently renders a maximum of two action buttons
+            for (var i = 0; i < buttonDetails.length && i < 2; i++) {
                 actionButton[i].label = buttonDetails[i].label;
                 Kommunicate['chatPopupActions'][i] =
                     typeof buttonDetails[i].onClickAction == 'function'

--- a/webplugin/js/app/km-message-markup-1.0.js
+++ b/webplugin/js/app/km-message-markup-1.0.js
@@ -2,7 +2,7 @@ Kommunicate.messageTemplate = {
     getAttachmentTemplate: function () {
         return `<div class="mck-file-text mck-attachment {{attachmentClass}} notranslate mck-attachment-{{key}}" data-groupId="{{groupId}}" data-filemetakey="{{fileMetaKey}}" data-stopupload="{{fileMeta.stopUpload}}" data-filename="{{fileMeta.name}}" data-thumbnailUrl="{{fileMeta.thumbnailUrl}}"  data-filetype="{{fileMeta.contentType}}" data-fileurl="{{fileUrl}" data-filesize="{{fileMeta.size}}+" data-msgkey ="{{key}}"><div>{{{fileExpr}}}</div><div class="{{attachmentDownloadClass}}">{{{downloadMediaUrlExpr}}}</div></div>`;
     },
-    getAttachmentApplicationTemplate: function (attachment) {
+    getAttachmentApplicationTemplate: function () {
         return `<div class="km-attachment-wrapper mck-attachment {{attachmentClass}} notranslate mck-attachment-{{key}}" data-groupId="{{groupId}}" data-filemetakey="{{fileMetaKey}}" data-filename="{{fileMeta.name}}" data-thumbnailUrl="{{fileMeta.thumbnailUrl}}"  data-filetype="{{fileMeta.contentType}}" data-fileurl="{{fileUrl}" data-filesize="{{fileMeta.size}}+" data-msgkey ="{{key}}"><div class="mck-msg-box vis {{previewContainerClass}}" data-groupId="{{groupId}}" data-filemetakey="{{fileMetaKey}}">
         <svg width="9" height="9" class="km-attachment-icon km-attachment-cancel-icon km-attachment-cancel-icon-{{key}} {{cancelIconClass}}" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.7338 0.275312C11.3788 -0.0796375 10.8055 -0.0796375 10.4505 0.275312L6 4.71672L1.54949 0.266213C1.19454 -0.0887375 0.621163 -0.0887375 0.266213 0.266213C-0.0887375 0.621163 -0.0887375 1.19454 0.266213 1.54949L4.71672 6L0.266213 10.4505C-0.0887375 10.8055 -0.0887375 11.3788 0.266213 11.7338C0.621163 12.0887 1.19454 12.0887 1.54949 11.7338L6 7.28328L10.4505 11.7338C10.8055 12.0887 11.3788 12.0887 11.7338 11.7338C12.0887 11.3788 12.0887 10.8055 11.7338 10.4505L7.28328 6L11.7338 1.54949C12.0796 1.20364 12.0796 0.621162 11.7338 0.275312Z" fill="white"/></svg>
         <svg width="16" height="16" class="km-attachment-icon km-attachment-upload-icon km-attachment-upload-icon-{{key}} {{uploadIconClass}}" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 0C3.55556 0 0 3.55556 0 8C0 12.4444 3.55556 16 8 16C12.4444 16 16 12.4444 16 8C16 3.55556 12.4444 0 8 0ZM5.88889 5.44444L7.88889 3.22222C7.88889 3.11111 8 3.11111 8.11111 3.11111C8.22222 3.11111 8.22222 3.11111 8.33333 3.22222L10.3333 5.44444C10.4444 5.55556 10.4444 5.66667 10.3333 5.77778C10.3333 5.88889 10.2222 5.88889 10.1111 5.88889H8.88889V9.44444C8.88889 9.55556 8.77778 9.66667 8.66667 9.66667H7.55556C7.44445 9.66667 7.33333 9.55556 7.33333 9.44444V5.88889H6.22222C6.11111 5.88889 6 5.77778 6 5.77778C5.77778 5.66667 5.77778 5.55556 5.88889 5.44444ZM12.2222 11.4444C12.2222 11.7778 12 12 11.6667 12H4.44444C4.11111 12 3.88889 11.7778 3.88889 11.4444V9.22222H5V10.8889H11.1111V9.22222H12.2222V11.4444Z" fill="white"/></svg><a class="km-attachment-preview-href-{{key}} {{fileEncClass}}" href="{{fileMeta.url}}" target="_blank" download data-blobkey="{{blobKey}}"><svg width="16" height="16" class="km-attachment-download-icon-{{key}} km-attachment-download-icon {{downloadIconClass}}" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 0C3.6 0 0 3.6 0 8C0 12.4 3.6 16 8 16C12.4 16 16 12.4 16 8C16 3.6 12.4 0 8 0ZM11.6 12H5V11.1H11.6V12ZM8.3 10.1L5 6.8H6.9V4H9.7V6.8H11.6L8.3 10.1Z" fill="white"></path></svg>
@@ -112,6 +112,22 @@ Kommunicate.messageTemplate = {
 };
 
 Kommunicate.popupChatTemplate = {
+    createActionButtons: function (actions) {
+        var markup = '<div id="chat-popup-actionable-btn-container">';
+        for (var i = 0; i < actions.length; i++) {
+            if (actions[i].label) {
+                markup +=
+                    '<button id="chat-popup-actionable-btn-' +
+                    (i + 1) +
+                    '" class="km-custom-widget-text-color km-custom-widget-border-color" onclick="window.kommunicate.chatPopupActions[' +
+                    i +
+                    ']()">' +
+                    actions[i].label +
+                    '</button>';
+            }
+        }
+        return markup + '</div>';
+    },
     getPopupChatTemplate: function (popupWidgetContent, chatWidget, isAnonymousChat) {
         var isPopupEnabled = kommunicateCommons.isObject(chatWidget) && chatWidget.popup;
         var chatPopupTemplateMarkup = '';
@@ -138,43 +154,23 @@ Kommunicate.popupChatTemplate = {
             popupMessageContent = popupMessageContent[randomIndex];
         }
 
-        var actionButton = {
-            0: {
-                label: '',
-                onClickAction: function () {},
-            },
-            1: {
-                label: '',
-                onClickAction: function () {},
-            },
-        };
+        var actionButton = [
+            { label: '', onClickAction: function () {} },
+            { label: '', onClickAction: function () {} },
+        ];
         Kommunicate['chatPopupActions'] = {};
 
         if (Array.isArray(buttonDetails) && buttonDetails.length) {
-            for (var i = 0; i < buttonDetails.length; i++) {
-                if (i <= 1) {
-                    actionButton[i].label = buttonDetails[i].label;
-                    if (typeof buttonDetails[i].onClickAction == 'function') {
-                        Kommunicate['chatPopupActions'][i] = buttonDetails[i].onClickAction;
-                    } else {
-                        Kommunicate['chatPopupActions'][i] = actionButton[i].onClickAction;
-                    }
-                } else {
-                    break;
-                }
+            for (var i = 0; i < 2 && i < buttonDetails.length; i++) {
+                actionButton[i].label = buttonDetails[i].label;
+                Kommunicate['chatPopupActions'][i] =
+                    typeof buttonDetails[i].onClickAction == 'function'
+                        ? buttonDetails[i].onClickAction
+                        : actionButton[i].onClickAction;
             }
         }
 
-        var actionableButtonTemplateMarkup =
-            '<div id="chat-popup-actionable-btn-container">' +
-            (actionButton[0].label &&
-                '<button id="chat-popup-actionable-btn-1" class="km-custom-widget-text-color km-custom-widget-border-color" onclick="window.kommunicate.chatPopupActions[0]()">' +
-                    actionButton[0].label +
-                    '</button>') +
-            (actionButton[1].label &&
-                '<button id="chat-popup-actionable-btn-2" class="km-custom-widget-text-color km-custom-widget-border-color" onclick="window.kommunicate.chatPopupActions[1]()">' +
-                    actionButton[1].label +
-                    '</button></div>');
+        var actionableButtonTemplateMarkup = this.createActionButtons(actionButton);
 
         if (isPopupEnabled) {
             var launcherClass = isAnonymousChat

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -686,9 +686,11 @@ Kommunicate.richMsgEventHandler = {
         var fieldName = name.toLowerCase().replace(/ +/g, '');
         var container = form.getElementsByClassName('mck-form-' + fieldName + '-error-container');
         if (container.length) {
-            validationFailed
-                ? container[0].classList.remove('n-vis')
-                : container[0].classList.add('n-vis');
+            kommunicateCommons.setVisibility(
+                { class: ['.mck-form-' + fieldName + '-error-container'] },
+                validationFailed,
+                true
+            );
         }
 
         var element = form.getElementsByClassName(

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -26,19 +26,18 @@ Kommunicate.markup = {
 </div>`
         );
     },
+    starSvg: '<svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24" class="{{class}}"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>',
+    getStarsMarkup: function (starObj) {
+        var html = '';
+        for (var i = 1; i <= 5; i++) {
+            html += '<span>' + this.starSvg.replace('{{class}}', starObj['star' + i]) + '</span>';
+        }
+        return html;
+    },
     getHotelCardTemplate: function (options, sessionId) {
-        var star = {
-            star1: 'km-star-empty',
-            star2: 'km-star-empty',
-            star3: 'km-star-empty',
-            star4: 'km-star-empty',
-            star5: 'km-star-empty',
-        };
-        if (options.StarRating) {
-            //populate the star rating
-            for (var i = 0; i < options.StarRating; i++) {
-                star['star' + (i + 1)] = 'km-star-filled';
-            }
+        var star = {};
+        for (var i = 1; i <= 5; i++) {
+            star['star' + i] = i <= (options.StarRating || 0) ? 'km-star-filled' : 'km-star-empty';
         }
         //Note: Setting price as 8%, modify it to change price calculation logic.
         var price =
@@ -61,48 +60,9 @@ Kommunicate.markup = {
             <h1 class="km-card-message-body-title">` +
             options.HotelName +
             `</h1>
-            <div class="km-card-message-body-ratings">
-                <span>
-                    <svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24" class="` +
-            star.star1 +
-            `">
-                        <path d="M0 0h24v24H0z" fill="none"/>
-                        <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
-                    </svg>
-                </span>
-                <span>
-                    <svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24" class="` +
-            star.star2 +
-            `">
-                        <path d="M0 0h24v24H0z" fill="none"/>
-                        <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
-                    </svg>
-                </span>
-                <span>
-                    <svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24" class="` +
-            star.star3 +
-            `">
-                        <path d="M0 0h24v24H0z" fill="none"/>
-                        <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
-                    </svg>
-                </span>
-                <span>
-                    <svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24" class="` +
-            star.star4 +
-            `">
-                        <path d="M0 0h24v24H0z" fill="none"/>
-                        <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
-                    </svg>
-                </span>
-                <span>
-                    <svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24" class="` +
-            star.star5 +
-            `">
-                        <path d="M0 0h24v24H0z" fill="none"/>
-                        <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
-                    </svg>
-                </span>
-            </div>
+            <div class="km-card-message-body-ratings">` +
+            Kommunicate.markup.getStarsMarkup(star) +
+            `</div>
             <div class="km-card-message-body-address">
                 <span class="km-card-message-body-address-icon">
                     <svg xmlns="http://www.w3.org/2000/svg"  height="24" viewBox="0 0 24 24" width="24">

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1572,10 +1572,24 @@ KommunicateUI = {
         ) {
             var startConversationButton = document.getElementById('mck-contacts-content');
             var backButton = document.querySelector('.mck-back-btn-container');
-            startConversationButton.classList.add('force-n-vis');
+            kommunicateCommons.modifyClassList(
+                { id: ['mck-contacts-content'] },
+                'force-n-vis',
+                ''
+            );
             hasMultipleConversations
-                ? backButton.classList.remove('force-n-vis')
-                : backButton.classList.add('force-n-vis');
+                ? kommunicateCommons.modifyClassList(
+                      { class: ['.mck-back-btn-container'] },
+                      '',
+                      'force-n-vis',
+                      true
+                  )
+                : kommunicateCommons.modifyClassList(
+                      { class: ['.mck-back-btn-container'] },
+                      'force-n-vis',
+                      '',
+                      true
+                  );
         }
     },
 

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -752,8 +752,11 @@ $applozic.extend(true, Kommunicate, {
 
         if (isCtaMultiContainerExist) {
             quickReplyCtaPrevSibling.style.display = 'block';
-            isCtaMultiContainerExist.classList.remove('vis');
-            isCtaMultiContainerExist.classList.add('n-vis');
+            kommunicateCommons.setVisibility(
+                { class: ['.mck-msg-box-rich-text-container.km-cta-multi-button-container'] },
+                false,
+                true
+            );
             return;
         }
 

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -148,49 +148,37 @@ function KommunicateCommons() {
             : false;
     };
     _this.getTimeOrDate = function (createdAtTime) {
-        var timeStampLabels = MCK_LABELS['time.stamp'];
+        var labels = MCK_LABELS['time.stamp'];
         var timeStamp = new Date(createdAtTime);
-        var currentTime = new Date(),
-            secondsPast = Math.max(0, (currentTime.getTime() - timeStamp.getTime()) / 1000);
-        if (secondsPast < 60) {
-            return (
-                parseInt(secondsPast) +
-                ' ' +
-                (parseInt(secondsPast) <= 1
-                    ? timeStampLabels['sec.ago']
-                    : timeStampLabels['secs.ago'])
-            );
+        var currentTime = new Date();
+        var secondsPast = Math.max(0, (currentTime - timeStamp) / 1000);
+        var ranges = [
+            [60, 1, 'sec.ago', 'secs.ago'],
+            [3600, 60, 'min.ago', 'mins.ago'],
+            [172800, 3600, 'hr.ago', 'hrs.ago'],
+        ];
+
+        for (var i = 0; i < ranges.length; i++) {
+            if (secondsPast < ranges[i][0]) {
+                var count = parseInt(secondsPast / ranges[i][1]);
+                return (
+                    count +
+                    ' ' +
+                    (count <= 1 ? labels[ranges[i][2]] : labels[ranges[i][3]])
+                );
+            }
         }
-        if (secondsPast < 3600) {
-            return (
-                parseInt(secondsPast / 60) +
-                ' ' +
-                (parseInt(secondsPast / 60) <= 1
-                    ? timeStampLabels['min.ago']
-                    : timeStampLabels['mins.ago'])
-            );
-        }
-        if (secondsPast <= 172800) {
-            return (
-                parseInt(secondsPast / 3600) +
-                ' ' +
-                (parseInt(secondsPast / 3600) <= 1
-                    ? timeStampLabels['hr.ago']
-                    : timeStampLabels['hrs.ago'])
-            );
-        }
-        if (secondsPast > 172800) {
-            day = timeStamp.getDate();
-            month = timeStamp
-                .toDateString()
-                .match(/ [a-zA-Z]*/)[0]
-                .replace(' ', '');
-            year =
-                timeStamp.getFullYear() == currentTime.getFullYear()
-                    ? ''
-                    : ' ' + timeStamp.getFullYear();
-            return day + ' ' + month + year;
-        }
+
+        var day = timeStamp.getDate();
+        var month = timeStamp
+            .toDateString()
+            .match(/ [a-zA-Z]*/)[0]
+            .replace(' ', '');
+        var year =
+            timeStamp.getFullYear() === currentTime.getFullYear()
+                ? ''
+                : ' ' + timeStamp.getFullYear();
+        return day + ' ' + month + year;
     };
 
     _this.setWidgetStateOpen = function (isWidgetOpen) {

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -85,6 +85,8 @@ function KommunicateCommons() {
     };
 
     _this.classListChanger = function (elem, add, remove) {
+        // classList.add ignores duplicate entries, ensuring classes are not
+        // appended more than once when this helper is reused
         add && elem.classList.add(add);
         remove && elem.classList.remove(remove);
     };

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -441,7 +441,7 @@ function ApplozicSidebox() {
                 var churnCust = document.getElementById('km-churn-customer');
                 if (churnCust) {
                     linkForChurn && linkForChurn.setAttribute('href', poweredByUrl);
-                    churnCust.classList.remove('n-vis');
+                    kommunicateCommons.setVisibility({ id: ['km-churn-customer'] }, true);
                 }
             }
 
@@ -661,7 +661,7 @@ function ApplozicSidebox() {
     function preLoadLauncherIconInterval() {
         var launcherInterval = setInterval(function () {
             if (document.getElementById('mck-sidebox-launcher')) {
-                document.getElementById('mck-sidebox-launcher').classList.remove('n-vis');
+                kommunicateCommons.setVisibility({ id: ['mck-sidebox-launcher'] }, true);
                 document
                     .getElementById('mck-sidebox-launcher')
                     .classList.add('km-launcher-animation');

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1,5 +1,4 @@
 var MCK_GROUP_MAP = [];
-var MCK_CLIENT_GROUP_MAP = [];
 var MCK_EVENT_HISTORY = [];
 var KM_PROGRESS_METER_CIRCUMFERENCE = 2 * Math.PI * 54;
 var count = 0;
@@ -527,7 +526,6 @@ const firstVisibleMsg = {
         var mckUtils = new MckUtils();
         var mckMapLayout = new MckMapLayout();
         var mckUserUtils = new MckUserUtils();
-        var mckMapService = new MckMapService();
         var mckGroupService = new MckGroupService();
         var mckGroupUtils = new MckGroupUtils();
         var mckGroupLayout = new MckGroupLayout();
@@ -4864,13 +4862,15 @@ const firstVisibleMsg = {
                                     errMsg = MCK_LABELS['lead.collection'].commonErrorMsg;
                                 }
                                 $applozic('#mck-form-field-error-alert').html(errMsg);
-                                $applozic('#mck-form-field-error-alert-box')
-                                    .removeClass('n-vis')
-                                    .addClass('vis');
+                                kommunicateCommons.setVisibility(
+                                    { id: ['mck-form-field-error-alert-box'] },
+                                    true
+                                );
                                 setTimeout(function () {
-                                    $applozic('#mck-form-field-error-alert-box')
-                                        .removeClass('vis')
-                                        .addClass('n-vis');
+                                    kommunicateCommons.setVisibility(
+                                        { id: ['mck-form-field-error-alert-box'] },
+                                        false
+                                    );
                                 }, 2000);
                                 return false;
                             }
@@ -6966,7 +6966,6 @@ const firstVisibleMsg = {
             var CLOUD_HOST_URL = 'www.googleapis.com';
             var LINK_EXPRESSION =
                 /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
-            var LINK_MATCHER = new RegExp(LINK_EXPRESSION);
             var markup =
                 '<div tabindex="-1" name="message" data-msgdelivered="${msgDeliveredExpr}" data-msgsent="${msgSentExpr}" data-msgtype="${msgTypeExpr}" data-msgtime="${msgCreatedAtTime}"' +
                 'data-msgcontent="${replyIdExpr}" data-msgkey="${msgKeyExpr}" data-contact="${toExpr}" class="mck-m-b ${msgKeyExpr} ${msgFloatExpr} ${msgAvatorClassExpr} ${botMsgDelayExpr} ${conversationTransferred}">' +
@@ -8013,7 +8012,6 @@ const firstVisibleMsg = {
                               ? 'n-vis'
                               : 'vis';
                 }
-                var downloadMediaUrl = '';
                 var floatWhere = 'mck-msg-right';
                 var msgBoxColorStyle = '';
                 var statusIcon = 'mck-pending-icon';
@@ -11326,10 +11324,10 @@ const firstVisibleMsg = {
                             typeof alUserService.MCK_USER_DETAIL_MAP[tabId] !== 'undefined' &&
                             userDetail.connected
                         ) {
-                            $this.removeClass('n-vis').addClass('vis');
+                            kommunicateCommons.classListChanger(this, 'vis', 'n-vis');
                             $this.next().html('(' + MCK_LABELS['online'] + ')');
                         } else {
-                            $this.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.classListChanger(this, 'n-vis', 'vis');
                             $this.next().html('(Offline)');
                         }
                     }
@@ -11736,7 +11734,11 @@ const firstVisibleMsg = {
                     .find('.mck-group-change-role-box');
                 var role = $applozic(this).parents('.mck-li-group-member').data('role');
                 $changeRoleBox.find('select').val(role);
-                $changeRoleBox.removeClass('n-vis').addClass('vis');
+                kommunicateCommons.classListChanger(
+                    $changeRoleBox[0],
+                    'vis',
+                    'n-vis'
+                );
                 kommunicateCommons.setVisibility({ id: ['mck-group-update-panel'] }, true);
             });
             $mck_btn_group_update.on('click', function () {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5040,25 +5040,15 @@ const firstVisibleMsg = {
                 KommunicateUI.showClosedConversationBanner(false);
                 $mck_sidebox.mckModal('hide');
                 kommunicateCommons.setVisibility({ id: ['mck-sidebox-launcher'] }, true);
-                if (
-                    document
-                        .getElementById('launcher-agent-img-container')
-                        .classList.contains('vis')
-                ) {
-                    document
-                        .querySelector('#mck-sidebox-launcher #launcher-svg-container')
-                        .classList.add('n-vis');
-                    document
-                        .querySelector('#mck-sidebox-launcher #launcher-svg-container')
-                        .classList.remove('vis');
-                } else {
-                    document
-                        .querySelector('#mck-sidebox-launcher #launcher-svg-container')
-                        .classList.add('vis');
-                    document
-                        .querySelector('#mck-sidebox-launcher #launcher-svg-container')
-                        .classList.remove('n-vis');
-                }
+                var showSvg = !document
+                    .getElementById('launcher-agent-img-container')
+                    .classList.contains('vis');
+                kommunicateCommons.modifyClassList(
+                    { class: ['#mck-sidebox-launcher #launcher-svg-container'] },
+                    showSvg ? 'vis' : 'n-vis',
+                    showSvg ? 'n-vis' : 'vis',
+                    true
+                );
                 var conversationId = $mck_msg_inner.data('mck-conversationid');
                 $mck_msg_inner.data('mck-id', '');
                 $mck_msg_inner.data('mck-topicid', '');
@@ -10056,9 +10046,12 @@ const firstVisibleMsg = {
                         $applozic('#li-' + contHtmlExpr + ' .mck-unread-count-text').html(
                             unreadCount
                         );
-                        $applozic('#li-' + contHtmlExpr + ' .mck-unread-count-box')
-                            .removeClass('n-vis')
-                            .addClass('vis');
+                        kommunicateCommons.modifyClassList(
+                            { class: ['#li-' + contHtmlExpr + ' .mck-unread-count-box'] },
+                            'vis',
+                            'n-vis',
+                            true
+                        );
                     }
                     var latestCreatedAtTime = $applozic('#' + $listId + ' li:nth-child(1)').data(
                         'msg-time'
@@ -10132,9 +10125,12 @@ const firstVisibleMsg = {
                         : 'mck-conversation-open';
 
                 $applozic('#li-' + contHtmlExpr + ' .mck-group-count-text').html(groupUserCount);
-                $applozic('#li-' + contHtmlExpr + ' .mck-group-count-box')
-                    .removeClass('n-vis')
-                    .addClass('vis');
+                kommunicateCommons.modifyClassList(
+                    { class: ['#li-' + contHtmlExpr + ' .mck-group-count-box'] },
+                    'vis',
+                    'n-vis',
+                    true
+                );
                 if (
                     !isGroupTab &&
                     !MCK_BLOCKED_TO_MAP[contact.contactId] &&
@@ -12010,20 +12006,40 @@ const firstVisibleMsg = {
                     }
                     if (group.adminName === MCK_USER_ID) {
                         if (MCK_OPEN_GROUP_SETTINGS.deleteChatAccess === 0) {
-                            $mck_tab_message_option.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.modifyClassList(
+                                { class: ['mck-tab-message-option'] },
+                                'n-vis',
+                                'vis',
+                                true
+                            );
                         }
                     } else {
                         if (!MCK_OPEN_GROUP_SETTINGS.allowInfoAccessGroupMembers) {
-                            $mck_group_menu_options.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.modifyClassList(
+                                { class: ['mck-group-menu-options'] },
+                                'n-vis',
+                                'vis',
+                                true
+                            );
                         }
                         if (MCK_OPEN_GROUP_SETTINGS.deleteChatAccess !== 2) {
-                            $mck_tab_message_option.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.modifyClassList(
+                                { class: ['mck-tab-message-option'] },
+                                'n-vis',
+                                'vis',
+                                true
+                            );
                         }
                         if (
                             !MCK_OPEN_GROUP_SETTINGS.allowInfoAccessGroupMembers &&
                             MCK_OPEN_GROUP_SETTINGS.deleteChatAccess !== 2
                         ) {
-                            $mck_tab_option_panel.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.modifyClassList(
+                                { class: ['mck-tab-option-panel'] },
+                                'n-vis',
+                                'vis',
+                                true
+                            );
                         }
                     }
                     return false;
@@ -12113,13 +12129,22 @@ const firstVisibleMsg = {
                     var currTabId = $mck_msg_inner.data('mck-id');
                     var isGroupTab = $mck_msg_inner.data('isgroup');
                     if (currTabId === groupId.toString() && isGroupTab) {
-                        $mck_group_menu_options.removeClass('vis').addClass('n-vis');
+                        kommunicateCommons.modifyClassList(
+                            { class: ['mck-group-menu-options'] },
+                            'n-vis',
+                            'vis',
+                            true
+                        );
                         _this.disableGroupTab();
                     }
                 }
             };
             _this.onAddedGroupMember = function (response, params) {
-                $mck_loading.removeClass('vis').addClass('n-vis');
+                kommunicateCommons.modifyClassList(
+                    { id: ['mck-contact-loading'] },
+                    'n-vis',
+                    'vis'
+                );
                 if (typeof response === 'object') {
                     if (response.status === 'error') {
                         alert('Unable to process your request. ' + response.errorMessage);
@@ -12162,7 +12187,11 @@ const firstVisibleMsg = {
                 }
             };
             _this.onRemovedGroupMember = function (response, params) {
-                $mck_loading.removeClass('vis').addClass('n-vis');
+                kommunicateCommons.modifyClassList(
+                    { id: ['mck-contact-loading'] },
+                    'n-vis',
+                    'vis'
+                );
                 if (typeof response === 'object') {
                     if (response.status === 'error') {
                         alert('Unable to process your request. ' + response.errorMessage);
@@ -12211,7 +12240,11 @@ const firstVisibleMsg = {
                     KommunicateUI.toggleVisibilityOfTextArea(assignee, groupUsers);
                 }
 
-                $mck_loading.removeClass('vis').addClass('n-vis');
+                kommunicateCommons.modifyClassList(
+                    { id: ['mck-contact-loading'] },
+                    'n-vis',
+                    'vis'
+                );
                 if (response.status === 'success') {
                     var groupFeed = response.data;
                     var conversationPxy = groupFeed.conversationPxy;
@@ -12264,7 +12297,11 @@ const firstVisibleMsg = {
                 }
             };
             _this.onUpdateGroupInfo = function (response, params) {
-                $mck_loading.removeClass('vis').addClass('n-vis');
+                kommunicateCommons.modifyClassList(
+                    { id: ['mck-contact-loading'] },
+                    'n-vis',
+                    'vis'
+                );
                 $mck_btn_group_update.attr('disabled', false).html('Update');
                 kommunicateCommons.setVisibility({ id: ['mck-group-update-panel'] }, false);
                 if (typeof response === 'object') {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -11324,10 +11324,20 @@ const firstVisibleMsg = {
                             typeof alUserService.MCK_USER_DETAIL_MAP[tabId] !== 'undefined' &&
                             userDetail.connected
                         ) {
-                            kommunicateCommons.classListChanger(this, 'vis', 'n-vis');
+                            var htmlId = mckContactUtils.formatContactId('' + tabId);
+                            kommunicateCommons.setVisibility(
+                                { class: ['.mck-user-ol-status.' + htmlId] },
+                                true,
+                                true
+                            );
                             $this.next().html('(' + MCK_LABELS['online'] + ')');
                         } else {
-                            kommunicateCommons.classListChanger(this, 'n-vis', 'vis');
+                            var htmlId = mckContactUtils.formatContactId('' + tabId);
+                            kommunicateCommons.setVisibility(
+                                { class: ['.mck-user-ol-status.' + htmlId] },
+                                false,
+                                true
+                            );
                             $this.next().html('(Offline)');
                         }
                     }
@@ -11341,14 +11351,18 @@ const firstVisibleMsg = {
                     kommunicateCommons.setVisibility({ id: ['mck-msg-form'] }, false);
                     $mck_tab_title.removeClass('mck-tab-title-w-status');
                     kommunicateCommons.setVisibility({ id: ['mck-tab-status'] }, false);
-                    $mck_typing_box.removeClass('vis').addClass('n-vis');
+                    kommunicateCommons.setVisibility(
+                        { class: ['mck-typing-box'] },
+                        false
+                    );
                     $mck_message_inner.data('blocked', true);
                     $mck_block_button
                         .html(MCK_LABELS['unblock.user'])
                         .attr('title', MCK_LABELS['unblock.user']);
                 } else {
                     $mck_msg_error.html('');
-                    $mck_msg_error.removeClass('vis').addClass('n-vis').removeClass('mck-no-mb');
+                    kommunicateCommons.setVisibility({ id: ['mck-msg-error'] }, false);
+                    $mck_msg_error.removeClass('mck-no-mb');
                     kommunicateCommons.setVisibility({ id: ['mck-msg-form'] }, true);
                     $mck_message_inner.data('blocked', false);
                     $mck_block_button
@@ -11734,10 +11748,9 @@ const firstVisibleMsg = {
                     .find('.mck-group-change-role-box');
                 var role = $applozic(this).parents('.mck-li-group-member').data('role');
                 $changeRoleBox.find('select').val(role);
-                kommunicateCommons.classListChanger(
-                    $changeRoleBox[0],
-                    'vis',
-                    'n-vis'
+                kommunicateCommons.setVisibility(
+                    { id: [$changeRoleBox.attr('id')] },
+                    true
                 );
                 kommunicateCommons.setVisibility({ id: ['mck-group-update-panel'] }, true);
             });
@@ -12746,10 +12759,10 @@ const firstVisibleMsg = {
                 }
                 kommunicateCommons.assignMessageTarget(messagePxy);
                 $mck_msg_sbmt.attr('disabled', true);
-                $mck_msg_error.removeClass('vis').addClass('n-vis');
+                kommunicateCommons.setVisibility({ id: ['mck-msg-error'] }, false);
                 $mck_msg_error.html('');
                 $mck_response_text.html('');
-                $mck_msg_response.removeClass('vis').addClass('n-vis');
+                kommunicateCommons.setVisibility({ id: ['mck-msg-response'] }, false);
                 mckMessageService.sendMessage(messagePxy);
                 $mck_loc_box.mckModal('hide');
             });
@@ -13897,7 +13910,10 @@ const firstVisibleMsg = {
                             }
                         } else {
                             $mck_tab_title.removeClass('mck-tab-title-w-typing');
-                            $mck_typing_box.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.setVisibility(
+                                { class: ['mck-typing-box'] },
+                                false
+                            );
                             typingService.hideTypingIndicator();
                             if ($mck_tab_title.hasClass('mck-tab-title-w-status')) {
                                 // $mck_tab_status.removeClass('n-vis').addClass('vis');
@@ -14204,7 +14220,10 @@ const firstVisibleMsg = {
                             MCK_BLOCKED_BY_MAP[contact.contactId] = true;
                             $mck_tab_title.removeClass('mck-tab-title-w-status');
                             $mck_tab_status.removeClass('vis').addClass('n-vis');
-                            $mck_typing_box.removeClass('vis').addClass('n-vis');
+                            kommunicateCommons.setVisibility(
+                                { class: ['mck-typing-box'] },
+                                false
+                            );
                         }
                     } else {
                         $applozic('#li-user-' + contact.htmlId + ' .mck-ol-status')

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -660,11 +660,12 @@ const firstVisibleMsg = {
                     !data?.groupFeeds.length && kmNavBar.hideAndShowTalkToHumanBtn();
                 }
             );
-            $applozic('#mck-msg-preview-visual-indicator').hasClass('vis')
-                ? $applozic('#mck-msg-preview-visual-indicator')
-                      .removeClass('vis')
-                      .addClass('n-vis')
-                : '';
+            if ($applozic('#mck-msg-preview-visual-indicator').hasClass('vis')) {
+                kommunicateCommons.setVisibility(
+                    { id: ['mck-msg-preview-visual-indicator'] },
+                    false
+                );
+            }
             var greetingMessageContainer = document.getElementById('chat-popup-widget-container');
             greetingMessageContainer &&
                 greetingMessageContainer.firstChild &&
@@ -2038,8 +2039,10 @@ const firstVisibleMsg = {
                         _this.setLeadCollectionLabels();
                         kmChatLoginModal.style.visibility = 'visible';
                         kmChatLoginModal.style.display = 'none';
-                        kmAnonymousChatLauncher.classList.remove('n-vis');
-                        kmAnonymousChatLauncher.classList.add('vis');
+                        kommunicateCommons.setVisibility(
+                            { id: ['km-anonymous-chat-launcher'] },
+                            true
+                        );
                         document
                             .getElementById('km-modal-close')
                             .addEventListener('click', _this.closeLeadCollectionWindow);
@@ -2215,8 +2218,10 @@ const firstVisibleMsg = {
                     kommunicateIframe.classList.remove('km-iframe-dimension-no-popup');
                 }
                 kmChatLoginModal.style.display = 'none';
-                kmAnonymousChatLauncher.classList.remove('n-vis');
-                kmAnonymousChatLauncher.classList.add('vis');
+                kommunicateCommons.setVisibility(
+                    { id: ['km-anonymous-chat-launcher'] },
+                    true
+                );
             };
 
             _this.onInitApp = function (data) {
@@ -5340,9 +5345,12 @@ const firstVisibleMsg = {
                             return;
                         }
                         if (FILE_META && KommunicateUI.isAttachmentV2(FILE_META[0].contentType)) {
-                            $applozic('.mck-timestamp-' + messagePxy.key)
-                                .removeClass('vis')
-                                .addClass('n-vis');
+                            kommunicateCommons.modifyClassList(
+                                { class: ['.mck-timestamp-' + messagePxy.key] },
+                                'n-vis',
+                                'vis',
+                                true
+                            );
                             FILE_META[0].contentType.indexOf('image/') != -1 &&
                                 KommunicateUI.displayProgressMeter(messagePxy.key);
                             KommunicateUI.updateAttachmentTemplate(messagePxy, messagePxy.key);
@@ -5535,12 +5543,24 @@ const firstVisibleMsg = {
                         var currentTabId = $mck_msg_inner.data('mck-id');
                         if (typeof data === 'object') {
                             KommunicateUI.deleteProgressMeter(messagePxy.key, true);
-                            $applozic('.km-attachment-download-icon-' + messagePxy.key)
-                                .removeClass('n-vis')
-                                .addClass('vis');
-                            $applozic('.km-attachment-cancel-icon-' + messagePxy.key)
-                                .removeClass('vis')
-                                .addClass('n-vis');
+                            kommunicateCommons.modifyClassList(
+                                {
+                                    class: [
+                                        '.km-attachment-download-icon-' + messagePxy.key,
+                                    ],
+                                },
+                                'vis',
+                                'n-vis',
+                                true
+                            );
+                            kommunicateCommons.modifyClassList(
+                                {
+                                    class: ['.km-attachment-cancel-icon-' + messagePxy.key],
+                                },
+                                'n-vis',
+                                'vis',
+                                true
+                            );
                             kommunicateCommons.modifyClassList(
                                 {
                                     class: ['km-attachment-progress-bar-wrapper-' + messagePxy.key],
@@ -5930,9 +5950,11 @@ const firstVisibleMsg = {
                                                     true,
                                                     append
                                                 );
-                                                $mck_tab_message_option
-                                                    .removeClass('n-vis')
-                                                    .addClass('vis');
+                                                kommunicateCommons.setVisibility(
+                                                    { class: ['.mck-tab-message-option'] },
+                                                    true,
+                                                    true
+                                                );
                                             }
                                         }
                                     }
@@ -6151,18 +6173,22 @@ const firstVisibleMsg = {
                                                             params.allowReload
                                                         );
                                                         if (group.type !== 6) {
-                                                            $mck_tab_message_option
-                                                                .removeClass('n-vis')
-                                                                .addClass('vis');
+                                                            kommunicateCommons.setVisibility(
+                                                                { class: ['.mck-tab-message-option'] },
+                                                                true,
+                                                                true
+                                                            );
                                                         }
                                                     } else if (
                                                         $applozic(
                                                             "#mck-message-cell .mck-message-inner div[name='message']"
                                                         ).length === 0
                                                     ) {
-                                                        $mck_tab_message_option
-                                                            .removeClass('vis')
-                                                            .addClass('n-vis');
+                                                        kommunicateCommons.setVisibility(
+                                                            { class: ['.mck-tab-message-option'] },
+                                                            false,
+                                                            true
+                                                        );
                                                         // $mck_no_messages.removeClass('n-vis').addClass('vis');
                                                         //  $mck_msg_inner.html('<div class="mck-no-data-text mck-text-muted">No messages yet!</div>');
                                                     }

--- a/webplugin/js/app/media/typing-area-dom-service.js
+++ b/webplugin/js/app/media/typing-area-dom-service.js
@@ -66,7 +66,10 @@ Kommunicate.typingAreaService = {
                 document
                     .querySelector('#mck-mic-btn-container')
                     .classList.add('mck-dropdown-toggle');
-                document.querySelector('#mck-mic-options-dropup').classList.remove('n-vis');
+                kommunicateCommons.setVisibility(
+                    { id: ['mck-mic-options-dropup'] },
+                    true
+                );
                 document
                     .querySelector('.mck-mic-animation-container svg#mck-mic-btn')
                     .classList.add('availableOptions');

--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -29,8 +29,17 @@ function ZendeskChatService() {
         });
 
         // Hide back button
-        document.getElementById('mck-contacts-content').classList.add('force-n-vis');
-        document.querySelector('.mck-back-btn-container').classList.add('force-n-vis');
+        kommunicateCommons.modifyClassList(
+            { id: ['mck-contacts-content'] },
+            'force-n-vis',
+            ''
+        );
+        kommunicateCommons.modifyClassList(
+            { class: ['.mck-back-btn-container'] },
+            'force-n-vis',
+            '',
+            true
+        );
     };
 
     _this.loadZopimSDK = function () {


### PR DESCRIPTION
## Summary
- clean up unused variables in `mck-sidebox-1.0.js`
- use `kommunicateCommons` helpers to toggle visibility for alert box and status indicators
- simplify role change UI toggle

## Testing
- `node --check webplugin/js/app/mck-sidebox-1.0.js`

------
https://chatgpt.com/codex/tasks/task_e_688289d7a71c832997afa2e7cec64205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in visibility toggling by standardizing show/hide controls across message forms, user status, group roles, and map service interactions.
  * Streamlined popup chat templates with dynamic action button generation for easier customization.
  * Enhanced hotel card display by introducing a reusable star rating component for clearer visual ratings.
  * Replaced direct DOM class manipulations with utility functions for more consistent UI updates in chat notifications, conversation settings, message visibility, and microphone options.
  * Removed unused variables and services to optimize performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->