### PR TITLE
Improve default label handling

### DIFF
--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -1,6 +1,6 @@
 class KMLabel {
-    getLabels() {
-        return {
+    constructor() {
+        this.DEFAULT_LABELS = {
             'input.message': 'Type your message...',
             'conversations.title': 'Conversations',
             'start.new': 'Start New Conversation',
@@ -220,78 +220,78 @@ class KMLabel {
             },
         };
     }
+
+    getLabels() {
+        return { ...this.DEFAULT_LABELS };
+    }
+
     setLabels(MCK_LABELS = {}) {
-        $applozic('#mck-conversation-title')
-            .html(MCK_LABELS['conversations.title'])
-            .attr('title', MCK_LABELS['conversations.title']);
-        $applozic('#mck-msg-new, #mck-sidebox-search .mck-box-title')
-            .html(MCK_LABELS['start.new'])
-            .attr('title', MCK_LABELS['start.new']);
-        $applozic('#mck-contact-search-tab strong')
-            .html(MCK_LABELS['search.contacts'])
-            .attr('title', MCK_LABELS['search.contacts']);
-        $applozic('#mck-group-search-tab strong')
-            .html(MCK_LABELS['search.groups'])
-            .attr('title', MCK_LABELS['search.groups']);
-        $applozic(
-            '#mck-contact-search-input, #mck-group-search-input, #mck-group-member-search'
-        ).attr('placeholder', MCK_LABELS['search.placeholder']);
-        $applozic('#mck-loc-address').attr('placeholder', MCK_LABELS['location.placeholder']);
-        // $applozic('#mck-no-conversations').html(MCK_LABELS['empty.conversations']);
-        // $applozic('#mck-no-messages').html(MCK_LABELS['empty.messages']);
-        // $applozic('#mck-no-more-conversations').html(MCK_LABELS['no.more.conversations']);
-        // $applozic('#mck-no-more-messages').html(MCK_LABELS['no.more.messages']);
-        $applozic('#mck-no-search-contacts').html(MCK_LABELS['empty.contacts']);
-        $applozic('#mck-no-search-groups').html(MCK_LABELS['empty.groups']);
-        $applozic('#mck-new-group, #mck-group-create-tab .mck-box-title, #mck-btn-group-create')
-            .html(MCK_LABELS['create.group.title'])
-            .attr('title', MCK_LABELS['create.group.title']);
-        $applozic('#mck-gc-overlay-label').html(MCK_LABELS['add.group.icon']);
-        $applozic('#mck-msg-error').html(MCK_LABELS['group.deleted']);
-        $applozic('#mck-gc-title-label').html(MCK_LABELS['group.title']);
-        $applozic('#mck-gc-type-label').html(MCK_LABELS['group.type']);
-        $applozic('#mck-group-info-btn, #mck-group-info-tab .mck-box-title')
-            .html(MCK_LABELS['group.info.title'])
-            .attr('title', MCK_LABELS['group.info.title']);
-        $applozic('#mck-gi-overlay-label').html(MCK_LABELS['change.group.icon']);
-        $applozic('#mck-group-member-title')
-            .html(MCK_LABELS['members.title'])
-            .attr('title', MCK_LABELS['members.title']);
-        $applozic('#mck-group-add-member .blk-lg-9, #mck-gm-search-box .mck-box-title')
-            .html(MCK_LABELS['add.members.title'])
-            .attr('title', MCK_LABELS['add.members.title']);
-        $applozic('#mck-btn-group-update')
-            .html(MCK_LABELS['group.info.update'])
-            .attr('title', MCK_LABELS['group.info.update']);
-        $applozic('#mck-btn-leave-group, #mck-btn-group-exit')
-            .html(MCK_LABELS['exit.group'])
-            .attr('title', MCK_LABELS['exit.group']);
-        $applozic('#mck-typing-label').html(MCK_LABELS['typing']);
-        $applozic('#mck-btn-clear-messages')
-            .html(MCK_LABELS['clear.messages'])
-            .attr('title', MCK_LABELS['clear.messages']);
-        $applozic('#mck-block-button')
-            .html(MCK_LABELS['block.user'])
-            .attr('title', MCK_LABELS['block.user']);
-        $applozic('#mck-loc-box .mck-box-title, #mck-share-loc-label')
-            .html(MCK_LABELS['location.share.title'])
-            .attr('title', MCK_LABELS['location.share.title']);
-        $applozic('#mck-btn-loc').attr('title', MCK_LABELS['location.share.title']);
-        $applozic('#mck-file-up-label').html(MCK_LABELS['file.attachment']);
-        $applozic('#mck-file-up').attr('title', MCK_LABELS['file.attachment']);
-        $applozic('.mck-file-attach-label').attr('title', MCK_LABELS['file.attach.title']);
-        $applozic('#mck-my-loc')
-            .html(MCK_LABELS['my.location'])
-            .attr('title', MCK_LABELS['my.location']);
-        $applozic('#mck-btn-close-loc-box')
-            .html(MCK_LABELS['close'])
-            .attr('title', MCK_LABELS['close']);
-        $applozic('#mck-loc-submit').html(MCK_LABELS['send']).attr('title', MCK_LABELS['send']);
-        $applozic('#mck-msg-sbmt').attr('title', MCK_LABELS['send.message']);
-        $applozic('#mck-btn-smiley').attr('title', MCK_LABELS['smiley']);
-        $applozic('#mck-group-name-save').attr('title', MCK_LABELS['save']);
-        $applozic('#mck-btn-group-icon-save').attr('title', MCK_LABELS['save']);
-        $applozic('#mck-group-name-edit').attr('title', MCK_LABELS['edit']);
+        const htmlAndTitleMap = {
+            '#mck-conversation-title': 'conversations.title',
+            '#mck-msg-new, #mck-sidebox-search .mck-box-title': 'start.new',
+            '#mck-contact-search-tab strong': 'search.contacts',
+            '#mck-group-search-tab strong': 'search.groups',
+            '#mck-new-group, #mck-group-create-tab .mck-box-title, #mck-btn-group-create':
+                'create.group.title',
+            '#mck-group-info-btn, #mck-group-info-tab .mck-box-title': 'group.info.title',
+            '#mck-group-member-title': 'members.title',
+            '#mck-group-add-member .blk-lg-9, #mck-gm-search-box .mck-box-title':
+                'add.members.title',
+            '#mck-btn-group-update': 'group.info.update',
+            '#mck-btn-leave-group, #mck-btn-group-exit': 'exit.group',
+            '#mck-btn-clear-messages': 'clear.messages',
+            '#mck-block-button': 'block.user',
+            '#mck-loc-box .mck-box-title, #mck-share-loc-label': 'location.share.title',
+            '#mck-my-loc': 'my.location',
+            '#mck-btn-close-loc-box': 'close',
+            '#mck-loc-submit': 'send',
+        };
+
+        const htmlOnlyMap = {
+            '#mck-no-search-contacts': 'empty.contacts',
+            '#mck-no-search-groups': 'empty.groups',
+            '#mck-gc-overlay-label': 'add.group.icon',
+            '#mck-msg-error': 'group.deleted',
+            '#mck-gc-title-label': 'group.title',
+            '#mck-gc-type-label': 'group.type',
+            '#mck-gi-overlay-label': 'change.group.icon',
+            '#mck-typing-label': 'typing',
+            '#mck-file-up-label': 'file.attachment',
+        };
+
+        const titleOnlyMap = {
+            '#mck-btn-loc': 'location.share.title',
+            '#mck-file-up': 'file.attachment',
+            '.mck-file-attach-label': 'file.attach.title',
+            '#mck-msg-sbmt': 'send.message',
+            '#mck-btn-smiley': 'smiley',
+            '#mck-group-name-save': 'save',
+            '#mck-btn-group-icon-save': 'save',
+            '#mck-group-name-edit': 'edit',
+        };
+
+        const placeholderMap = {
+            '#mck-contact-search-input, #mck-group-search-input, #mck-group-member-search':
+                'search.placeholder',
+            '#mck-loc-address': 'location.placeholder',
+        };
+
+        Object.entries(htmlAndTitleMap).forEach(([selector, key]) => {
+            const text = MCK_LABELS[key];
+            $applozic(selector).html(text).attr('title', text);
+        });
+
+        Object.entries(htmlOnlyMap).forEach(([selector, key]) => {
+            $applozic(selector).html(MCK_LABELS[key]);
+        });
+
+        Object.entries(titleOnlyMap).forEach(([selector, key]) => {
+            $applozic(selector).attr('title', MCK_LABELS[key]);
+        });
+
+        Object.entries(placeholderMap).forEach(([selector, key]) => {
+            $applozic(selector).attr('placeholder', MCK_LABELS[key]);
+        });
         document.getElementById('mck-text-box').dataset.text = MCK_LABELS['input.message'];
         document.getElementById('mck-char-warning-text').innerHTML = MCK_LABELS['char.limit.warn'];
         document


### PR DESCRIPTION
## Summary
- refactor default-labels.js to cache defaults
- update label DOM manipulation using loops for readability

## Testing
- `npx prettier -w webplugin/js/app/labels/default-labels.js`

------
https://chatgpt.com/codex/tasks/task_e_6885d75110e083299e1e01c3b48d78a5