### PR TITLE
Refactor visibility toggles

### DIFF
--- a/webplugin/js/app/components/answer-feedback-service.js
+++ b/webplugin/js/app/components/answer-feedback-service.js
@@ -196,21 +196,17 @@ class AnswerFeedback {
 
             this.putIconInsideSticker(stickySticker, iconToAdd);
 
-            kommunicateCommons.modifyClassList(
+            kommunicateCommons.hide(
                 {
                     class: [feedbackContainerSelector],
                 },
-                'n-vis',
-                'vis',
                 true
             );
 
-            kommunicateCommons.modifyClassList(
+            kommunicateCommons.show(
                 {
                     class: [stickyStickerSelector],
                 },
-                'vis',
-                'n-vis',
                 true
             );
 
@@ -221,21 +217,17 @@ class AnswerFeedback {
         notHelpfulButton.addEventListener('click', setFeedback.bind(null, 0));
 
         stickySticker.addEventListener('click', (e) => {
-            kommunicateCommons.modifyClassList(
+            kommunicateCommons.show(
                 {
                     class: [feedbackContainerSelector],
                 },
-                'vis',
-                'n-vis',
                 true
             );
 
-            kommunicateCommons.modifyClassList(
+            kommunicateCommons.hide(
                 {
                     class: [stickyStickerSelector],
                 },
-                'n-vis',
-                'vis',
                 true
             );
 

--- a/webplugin/js/app/components/rating-service.js
+++ b/webplugin/js/app/components/rating-service.js
@@ -12,20 +12,12 @@ class RatingService {
         }
     }
     starCsatHtmlEnable = () => {
-        kommunicateCommons.modifyClassList(
-            {
-                class: ['mck-smilies-inner'],
-            },
-            'n-vis',
-            'vis'
-        );
-        kommunicateCommons.modifyClassList(
-            {
-                class: ['star-rating'],
-            },
-            'vis',
-            'n-vis'
-        );
+        kommunicateCommons.hide({
+            class: ['mck-smilies-inner'],
+        });
+        kommunicateCommons.show({
+            class: ['star-rating'],
+        });
         kommunicateCommons.modifyClassList(
             {
                 class: ['mck-ratings-smilies'],

--- a/webplugin/js/app/events/applozic-event-handler.js
+++ b/webplugin/js/app/events/applozic-event-handler.js
@@ -19,10 +19,8 @@ Kommunicate.KmEventHandler = {
         } else if (
             document.getElementById('launcher-agent-img-container').classList.contains('vis')
         ) {
-            kommunicateCommons.modifyClassList(
+            kommunicateCommons.hide(
                 { class: ['#mck-sidebox-launcher #launcher-svg-container'] },
-                'n-vis',
-                'vis',
                 true
             );
         }

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -853,13 +853,9 @@ KommunicateUI = {
         if (isCSATenabled || triggeredByBot) {
             document.getElementById('mck-submit-comment').disabled = false;
             kommunicateCommons.modifyClassList({ class: ['mck-rating-box'] }, '', 'selected');
-            kommunicateCommons.modifyClassList(
-                {
-                    class: ['mck-box-form'],
-                },
-                'n-vis',
-                'vis'
-            );
+            kommunicateCommons.hide({
+                class: ['mck-box-form'],
+            });
             kommunicateCommons.modifyClassList(
                 {
                     id: ['mck-sidebox-ft'],
@@ -867,13 +863,9 @@ KommunicateUI = {
                 'km-mid-conv-csat'
             );
 
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['csat-1', 'csat-2', 'mck-feedback-text-wrapper'],
-                },
-                'vis',
-                'n-vis'
-            );
+            kommunicateCommons.show({
+                id: ['csat-1', 'csat-2', 'mck-feedback-text-wrapper'],
+            });
             KommunicateUI.isConvJustResolved = false;
             KommunicateUI.updateScroll(messageBody);
         } else if (
@@ -890,13 +882,9 @@ KommunicateUI = {
                 },
                 'km-mid-conv-csat'
             );
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['mck-conversation-status-box'],
-                },
-                'vis',
-                'n-vis'
-            );
+            kommunicateCommons.show({
+                id: ['mck-conversation-status-box'],
+            });
             kommunicateCommons.modifyClassList(
                 {
                     class: ['mck-box-form'],
@@ -1000,24 +988,16 @@ KommunicateUI = {
                       KommunicateConstants.FEEDBACK_API_STATUS.RATED
                 : kommunicate._globals.collectFeedback;
             if (!isCSATenabled) {
-                kommunicateCommons.modifyClassList(
-                    {
-                        id: ['mck-conversation-status-box'],
-                    },
-                    'n-vis',
-                    'vis'
-                );
+                kommunicateCommons.hide({
+                    id: ['mck-conversation-status-box'],
+                });
             }
 
             document.getElementById('mck-submit-comment').disabled = false;
             kommunicateCommons.modifyClassList({ class: ['mck-rating-box'] }, '', 'selected');
-            kommunicateCommons.modifyClassList(
-                {
-                    class: ['mck-box-form'],
-                },
-                'n-vis',
-                'vis'
-            );
+            kommunicateCommons.hide({
+                class: ['mck-box-form'],
+            });
             kommunicateCommons.modifyClassList(
                 {
                     class: ['mck-csat-text-1'],
@@ -1149,13 +1129,9 @@ KommunicateUI = {
                 },
                 'km-mid-conv-csat'
             );
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['mck-conversation-status-box'],
-                },
-                'vis',
-                'n-vis'
-            );
+            kommunicateCommons.show({
+                id: ['mck-conversation-status-box'],
+            });
             kommunicateCommons.modifyClassList(
                 {
                     class: ['mck-box-form'],

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -804,11 +804,9 @@ const firstVisibleMsg = {
             mckNotificationService.init();
             mckMapLayout.init();
             !MCK_ATTACHMENT &&
-                kommunicateCommons.modifyClassList(
-                    { id: ['mck-attachfile-box', 'mck-file-up'] },
-                    'n-vis',
-                    'vis'
-                );
+                kommunicateCommons.hide({
+                    id: ['mck-attachfile-box', 'mck-file-up'],
+                });
             !IS_CAPTURE_PHOTO &&
                 kommunicateCommons.modifyClassList(
                     { id: ['mck-attach-img-box', 'mck-img-file-up'] },
@@ -829,11 +827,9 @@ const firstVisibleMsg = {
                 window.frameElement.getAttribute('data-protocol') == 'file:' &&
                 !window.top.hasOwnProperty('cordova')
             ) {
-                kommunicateCommons.modifyClassList(
-                    { id: ['km-local-file-system-warning'] },
-                    'vis',
-                    'n-vis'
-                );
+                kommunicateCommons.show({
+                    id: ['km-local-file-system-warning'],
+                });
             }
             document.addEventListener('keydown', function (e) {
                 document.body.classList.add('accesibility');
@@ -2313,19 +2309,15 @@ const firstVisibleMsg = {
                 mckInit.tabFocused();
                 w.addEventListener('online', function () {
                     console.log('online');
-                    kommunicateCommons.modifyClassList(
-                        { id: ['km-internet-disconnect-msg'] },
-                        'n-vis',
-                        'vis'
-                    );
+                    kommunicateCommons.hide({
+                        id: ['km-internet-disconnect-msg'],
+                    });
                     window.Applozic.ALSocket.reconnect();
                 });
                 w.addEventListener('offline', function () {
-                    kommunicateCommons.modifyClassList(
-                        { id: ['km-internet-disconnect-msg'] },
-                        'vis',
-                        'n-vis'
-                    );
+                    kommunicateCommons.show({
+                        id: ['km-internet-disconnect-msg'],
+                    });
                     console.log('offline');
                 });
                 if ($mckChatLauncherIcon.length > 0 && MCK_TOTAL_UNREAD_COUNT > 0) {


### PR DESCRIPTION
## Summary
- use `kommunicateCommons.show` and `hide` for element visibility

## Testing
- `npx prettier -w webplugin/js/app/components/answer-feedback-service.js webplugin/js/app/components/rating-service.js webplugin/js/app/events/applozic-event-handler.js webplugin/js/app/kommunicate-ui.js webplugin/js/app/mck-sidebox-1.0.js`

------
https://chatgpt.com/codex/tasks/task_e_68862c725f408329ae5f18296bdbea4d