### PR TITLE
Fix icons path in Kommunicate sidebox

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -222,7 +222,19 @@ function ApplozicSidebox() {
             }
         };
 
-        var script = String(scriptData) + 'detectBrowserAndMakeUiVisible();';
+        var updateIconsSvgPath = function updateIconsSvgPath() {
+            var icons = document.querySelectorAll('use[href^="icons.svg"]');
+            for (var i = 0; i < icons.length; i++) {
+                var href = icons[i].getAttribute('href');
+                var iconId = href.split('#')[1];
+                icons[i].setAttribute('href', window.MCK_STATICPATH + '/build/icons.svg#' + iconId);
+            }
+        };
+
+        var script =
+            String(scriptData) +
+            String(updateIconsSvgPath) +
+            'detectBrowserAndMakeUiVisible();updateIconsSvgPath();';
         var tag = document.createElement('script');
         tag.innerHTML = script;
         return tag;


### PR DESCRIPTION
## Summary
- fix SVG icon references by prepending plugin path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886f7a86eb88329aaf6966deff55bc1