### PR TITLE
refactor search tab toggle and cleanup

### DIFF
--- a/webplugin/js/app/km-nav-bar.js
+++ b/webplugin/js/app/km-nav-bar.js
@@ -35,16 +35,9 @@ function KmNavBar(mckMsgLayout) {
             if (talkToHumanButton) {
                 talkToHumanButton.disabled = false;
             }
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['km-talk-to-human'],
-                    class: ['km-option-talk-to-human'],
-                },
-                'n-vis',
-                'vis'
-            );
+            kommunicateCommons.show('#km-talk-to-human', '.km-option-talk-to-human');
         } else if (HEADER_CTA.TALK_TO_HUMAN === appOptions.primaryCTA) {
-            kommunicateCommons.modifyClassList({ id: ['km-talk-to-human'] }, 'vis', 'n-vis');
+            kommunicateCommons.hide('#km-talk-to-human');
         }
     };
 }

--- a/webplugin/js/app/km-rich-text-event-handler.js
+++ b/webplugin/js/app/km-rich-text-event-handler.js
@@ -182,27 +182,13 @@ Kommunicate.attachmentEventHandler = {
 
         if (stopSending) {
             KommunicateUI.updateAttachmentStopUploadStatus(msgKey, true);
-            kommunicateCommons.modifyClassList(
-                {
-                    class: [
-                        'km-attachment-progress-bar-success-' + msgKey,
-                        'km-attachment-progress-bar-wrapper-' + msgKey,
-                    ],
-                },
-                'n-vis',
-                'vis'
+            kommunicateCommons.hide(
+                '.km-attachment-progress-bar-success-' + msgKey,
+                '.km-attachment-progress-bar-wrapper-' + msgKey
             );
-            kommunicateCommons.modifyClassList(
-                { class: ['mck-timestamp-' + msgKey] },
-                'vis',
-                'n-vis'
-            );
-            $applozic('.km-attachment-cancel-icon-' + msgKey)
-                .removeClass('vis')
-                .addClass('n-vis');
-            $applozic('.km-attachment-upload-icon-' + msgKey)
-                .removeClass('n-vis')
-                .addClass('vis');
+            kommunicateCommons.show('.mck-timestamp-' + msgKey);
+            kommunicateCommons.hide('.km-attachment-cancel-icon-' + msgKey);
+            kommunicateCommons.show('.km-attachment-upload-icon-' + msgKey);
             deliveryStatusDiv[0].querySelector('.mck-sending-failed').style.display = 'block';
         } else {
             var fileName = attachmentDiv[0].dataset.filename;
@@ -238,18 +224,12 @@ Kommunicate.attachmentEventHandler = {
                     optns: optns,
                 };
                 $applozic.fn.applozic('submitMessage', params);
-                $applozic('.km-attachment-cancel-icon-' + msgKey)
-                    .removeClass('vis')
-                    .addClass('n-vis');
-                $applozic('.km-attachment-upload-icon-' + msgKey)
-                    .removeClass('vis')
-                    .addClass('n-vis');
-                deliveryStatusDiv[0].querySelector('.mck-sending-failed').style.display = 'none';
-                kommunicateCommons.modifyClassList(
-                    { class: ['mck-timestamp-' + msgKey] },
-                    'n-vis',
-                    'vis'
+                kommunicateCommons.hide(
+                    '.km-attachment-cancel-icon-' + msgKey,
+                    '.km-attachment-upload-icon-' + msgKey
                 );
+                deliveryStatusDiv[0].querySelector('.mck-sending-failed').style.display = 'none';
+                kommunicateCommons.hide('.mck-timestamp-' + msgKey);
             } else if (thumbnailUrl && groupId && msgKey && file) {
                 messagePxy = {
                     contentType: 1,
@@ -273,11 +253,7 @@ Kommunicate.attachmentEventHandler = {
                 };
                 KommunicateUI.updateAttachmentStopUploadStatus(msgKey, false);
                 $applozic.fn.applozic('uploadAttachemnt', params);
-                kommunicateCommons.modifyClassList(
-                    { class: ['mck-timestamp-' + msgKey] },
-                    'vis',
-                    'n-vis'
-                );
+                kommunicateCommons.show('.mck-timestamp-' + msgKey);
                 deliveryStatusDiv[0].querySelector('.mck-sending-failed').style.display = 'none';
                 delete KM_PENDING_ATTACHMENT_FILE[msgKey];
             }

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -449,16 +449,15 @@ KommunicateUtils = {
         );
     },
     isURL: function (str) {
-        var pattern = new RegExp(
-            '^(https?:\\/\\/)?' + // protocol
-                '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-                '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-                '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-                '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-                '(\\#[-a-z\\d_]*)?$',
-            'i'
-        ); // fragment locator
-        return pattern.test(str);
+        try {
+            var url = new URL(str);
+            return url.protocol === 'http:' || url.protocol === 'https:';
+        } catch (e) {
+            return false;
+        }
+    },
+    getBooleanOption: function (value, defaultValue) {
+        return typeof value === 'boolean' ? value : defaultValue;
     },
     formatParams: function (params) {
         return (

--- a/webplugin/js/app/km-widget-custom-events.js
+++ b/webplugin/js/app/km-widget-custom-events.js
@@ -16,8 +16,8 @@ var kmWidgetEvents = {
         try {
             if (kmWidgetEvents.gaTrackingId() && typeof window.top.gtag !== 'undefined') {
                 window.top.gtag('event', eventObject.data.eventAction, {
-                    category: eventObject.data.eventCategory,
-                    label: eventObject.data.eventLabel,
+                    event_category: eventObject.data.eventCategory,
+                    event_label: eventObject.data.eventLabel,
                     value: eventObject.data.eventValue || '',
                 });
             }
@@ -28,17 +28,19 @@ var kmWidgetEvents = {
     eventTracking: function (eventObject, customLabel, customValue) {
         // Any other analytics tool related code can be add here no need to paste it in every function
         if (kommunicateCommons.isObject(eventObject)) {
+            var data = Object.assign({}, eventObject.data);
             if (customLabel) {
-                eventObject.data.eventLabel = customLabel;
+                data.eventLabel = customLabel;
             }
             if (customValue) {
-                eventObject.data.eventValue = customValue;
+                data.eventValue = customValue;
             }
-            kmWidgetEvents.gaTrackingId() && kmWidgetEvents.sendEventToGoogleAnalytics(eventObject);
+            kmWidgetEvents.gaTrackingId() &&
+                kmWidgetEvents.sendEventToGoogleAnalytics({ data: data });
             if (eventObject.eventFunction !== null) {
                 // checks if there is any errors in user provided function
                 try {
-                    eventObject.eventFunction(eventObject.data);
+                    eventObject.eventFunction(data);
                 } catch (error) {
                     console.error(error);
                 }

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -885,7 +885,7 @@ KommunicateUI = {
     loadQuickReplies: function (quickReplies) {
         var intentList = document.getElementById('mck-intent-options');
         if (quickReplies.length > 0 && intentList && intentList.childElementCount < 1) {
-            kommunicateCommons.modifyClassList({ id: ['mck-quick-replies-box'] }, 'vis', 'n-vis');
+            kommunicateCommons.show('#mck-quick-replies-box');
             for (var i = 0; i < quickReplies.length; i++) {
                 var li = document.createElement('li');
                 li.innerText = quickReplies[i];
@@ -1560,27 +1560,15 @@ KommunicateUI = {
                     ) {
                         waitingQueueNumber.innerHTML =
                             '#' + parseInt(WAITING_QUEUE.indexOf(parseInt(groupId)) + 1);
-                        kommunicateCommons.modifyClassList(
-                            {
-                                id: ['mck-waiting-queue'],
-                            },
-                            'vis',
-                            'n-vis'
+                        kommunicateCommons.show('#mck-waiting-queue');
+                        kommunicateCommons.hide(
+                            '.mck-agent-image-container',
+                            '.mck-agent-status-text'
                         );
-                        kommunicateCommons.modifyClassList(
-                            {
-                                class: ['mck-agent-image-container', 'mck-agent-status-text'],
-                            },
-                            'n-vis',
-                            'vis'
-                        );
-                        kommunicateCommons.modifyClassList(
-                            {
-                                class: ['km-option-talk-to-human'],
-                                id: ['km-talk-to-human', 'km-restart-conversation'],
-                            },
-                            'n-vis',
-                            'vis'
+                        kommunicateCommons.hide(
+                            '.km-option-talk-to-human',
+                            '#km-talk-to-human',
+                            '#km-restart-conversation'
                         );
                         CURRENT_GROUP_DATA.isWaitingQueue = true;
                         headerTabTitle.innerHTML =
@@ -1592,24 +1580,14 @@ KommunicateUI = {
                             KommunicateUI.updateScroll(messageBody);
                         }
                     } else {
-                        kommunicateCommons.modifyClassList(
-                            {
-                                id: ['mck-waiting-queue'],
-                            },
-                            'n-vis',
-                            'vis'
-                        );
+                        kommunicateCommons.hide('#mck-waiting-queue');
 
                         headerTabTitle = document.getElementById('mck-tab-title');
                         headerTabTitle.innerHTML = headerTabTitle.getAttribute('title');
 
-                        var updateClasses = {
-                            class: ['mck-agent-image-container', 'mck-agent-status-text'],
-                        };
-
-                        KommunicateUI.isFAQPrimaryCTA() && (updateClasses.id = ['km-faq']);
-
-                        kommunicateCommons.modifyClassList(updateClasses, 'vis', 'n-vis');
+                        var selectors = ['.mck-agent-image-container', '.mck-agent-status-text'];
+                        KommunicateUI.isFAQPrimaryCTA() && selectors.push('#km-faq');
+                        kommunicateCommons.show.apply(kommunicateCommons, selectors);
                     }
                 }
             },

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -169,26 +169,22 @@ $applozic.extend(true, Kommunicate, {
         }
     },
     updateConversationDetail: function (conversationDetail) {
-        var kommunicateSettings = appOptionSession.getPropertyDataFromSession('settings');
-        if (typeof kommunicateSettings === 'undefined' || kommunicateSettings === null) {
+        var settings = appOptionSession.getPropertyDataFromSession('settings') || {};
+        if (!Object.keys(settings).length) {
             return conversationDetail;
         }
-        // Update welcome message only if some value for it is coming in conversationDetails parameter or kommunicateSettings.
-        conversationDetail.WELCOME_MESSAGE =
-            conversationDetail.WELCOME_MESSAGE || kommunicateSettings.WELCOME_MESSAGE;
-        conversationDetail.defaultAssignee =
-            conversationDetail.assignee || kommunicateSettings.defaultAssignee;
-        conversationDetail.agentIds =
-            conversationDetail.agentIds || kommunicateSettings.defaultAgentIds;
-        conversationDetail.botIds = conversationDetail.botIds || kommunicateSettings.defaultBotIds;
-        conversationDetail.skipRouting =
-            conversationDetail.skipRouting || kommunicateSettings.skipRouting;
-        conversationDetail.skipBotEvent =
-            conversationDetail.skipBotEvent || kommunicateSettings.skipBotEvent;
-        conversationDetail.customWelcomeEvent =
-            conversationDetail.customWelcomeEvent || kommunicateSettings.customWelcomeEvent;
-        conversationDetail.teamId = conversationDetail.teamId || kommunicateSettings.teamId;
-        return conversationDetail;
+        return {
+            ...conversationDetail,
+            WELCOME_MESSAGE: conversationDetail.WELCOME_MESSAGE ?? settings.WELCOME_MESSAGE,
+            defaultAssignee: conversationDetail.assignee ?? settings.defaultAssignee,
+            agentIds: conversationDetail.agentIds ?? settings.defaultAgentIds,
+            botIds: conversationDetail.botIds ?? settings.defaultBotIds,
+            skipRouting: conversationDetail.skipRouting ?? settings.skipRouting,
+            skipBotEvent: conversationDetail.skipBotEvent ?? settings.skipBotEvent,
+            customWelcomeEvent:
+                conversationDetail.customWelcomeEvent ?? settings.customWelcomeEvent,
+            teamId: conversationDetail.teamId ?? settings.teamId,
+        };
     },
     openConversationList: function () {
         kommunicateCommons.setWidgetStateOpen(true);

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -117,22 +117,24 @@ function KommunicateCommons() {
         });
     };
 
-    function changeVisibility(element, addClass, removeClass) {
-        var elems = typeof element === 'string' ? document.querySelectorAll(element) : element;
-        if (!elems) return elems;
-        (elems instanceof Element ? [elems] : Array.from(elems)).forEach(function (el) {
-            el.classList.remove(removeClass);
-            el.classList.add(addClass);
+    function changeVisibility(elements, addClass, removeClass) {
+        (Array.isArray(elements) ? elements : [elements]).forEach(function (element) {
+            var elems = typeof element === 'string' ? document.querySelectorAll(element) : element;
+            if (!elems) return;
+            (elems instanceof Element ? [elems] : Array.from(elems)).forEach(function (el) {
+                if (!el || !el.classList) return;
+                el.classList.remove(removeClass);
+                el.classList.add(addClass);
+            });
         });
-        return elems;
     }
 
-    _this.show = function (element) {
-        return changeVisibility(element, 'vis', 'n-vis');
+    _this.show = function () {
+        changeVisibility(Array.from(arguments), 'vis', 'n-vis');
     };
 
-    _this.hide = function (element) {
-        return changeVisibility(element, 'n-vis', 'vis');
+    _this.hide = function () {
+        changeVisibility(Array.from(arguments), 'n-vis', 'vis');
     };
 
     _this.setMessagePxyRecipient = function (messagePxy) {
@@ -154,67 +156,37 @@ function KommunicateCommons() {
         if (!object) return false;
         return typeof object == 'object' && object.constructor == Object;
     };
-    _this.isUrlValid = function (url) {
-        if (!url) return false;
-        return /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
-            url
-        );
-    };
     _this.isMessageContainsUrl = function (message) {
-        var urlReg = new RegExp(
-            '([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?([^ ])+'
-        );
-        var extractedUrl = message ? message.match(urlReg) : '';
-        return message && extractedUrl
-            ? this.isUrlValid(extractedUrl[0])
-                ? extractedUrl[0]
-                : false
-            : false;
+        if (!message) return false;
+        var extractedUrl = message.match(/((https?|ftp):\/\/[^\s]+)/i);
+        return extractedUrl && KommunicateUtils.isURL(extractedUrl[0]) ? extractedUrl[0] : false;
     };
     _this.getTimeOrDate = function (createdAtTime) {
-        var timeStampLabels = MCK_LABELS['time.stamp'];
+        var labels = MCK_LABELS['time.stamp'];
+        var secondsPast = Math.max(0, (Date.now() - new Date(createdAtTime).getTime()) / 1000);
+        var seconds = Math.floor(secondsPast);
+        if (seconds < 60) {
+            return seconds + ' ' + (seconds <= 1 ? labels['sec.ago'] : labels['secs.ago']);
+        }
+        var minutes = Math.floor(seconds / 60);
+        if (minutes < 60) {
+            return minutes + ' ' + (minutes <= 1 ? labels['min.ago'] : labels['mins.ago']);
+        }
+        var hours = Math.floor(minutes / 60);
+        if (hours <= 48) {
+            return hours + ' ' + (hours <= 1 ? labels['hr.ago'] : labels['hrs.ago']);
+        }
         var timeStamp = new Date(createdAtTime);
-        var currentTime = new Date(),
-            secondsPast = Math.max(0, (currentTime.getTime() - timeStamp.getTime()) / 1000);
-        if (secondsPast < 60) {
-            return (
-                parseInt(secondsPast) +
-                ' ' +
-                (parseInt(secondsPast) <= 1
-                    ? timeStampLabels['sec.ago']
-                    : timeStampLabels['secs.ago'])
-            );
-        }
-        if (secondsPast < 3600) {
-            return (
-                parseInt(secondsPast / 60) +
-                ' ' +
-                (parseInt(secondsPast / 60) <= 1
-                    ? timeStampLabels['min.ago']
-                    : timeStampLabels['mins.ago'])
-            );
-        }
-        if (secondsPast <= 172800) {
-            return (
-                parseInt(secondsPast / 3600) +
-                ' ' +
-                (parseInt(secondsPast / 3600) <= 1
-                    ? timeStampLabels['hr.ago']
-                    : timeStampLabels['hrs.ago'])
-            );
-        }
-        if (secondsPast > 172800) {
-            day = timeStamp.getDate();
-            month = timeStamp
-                .toDateString()
-                .match(/ [a-zA-Z]*/)[0]
-                .replace(' ', '');
-            year =
-                timeStamp.getFullYear() == currentTime.getFullYear()
-                    ? ''
-                    : ' ' + timeStamp.getFullYear();
-            return day + ' ' + month + year;
-        }
+        var day = timeStamp.getDate();
+        var month = timeStamp
+            .toDateString()
+            .match(/ [a-zA-Z]*/)[0]
+            .replace(' ', '');
+        var year =
+            timeStamp.getFullYear() == new Date().getFullYear()
+                ? ''
+                : ' ' + timeStamp.getFullYear();
+        return day + ' ' + month + year;
     };
 
     _this.setWidgetStateOpen = function (isWidgetOpen) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -337,21 +337,14 @@ const firstVisibleMsg = {
         var INIT_APP_DATA = {};
         var IS_PLUGIN_INITIALIZATION_PROCESS_COMPLETED = false;
         var PRE_CHAT_LEAD_COLLECTION_POPUP_ON = true;
-        var MCK_TOKEN;
-        var USER_ENCRYPTION_KEY;
         var AUTH_CODE;
         MCK_GROUP_MAP = [];
         var FILE_META = [];
         var USER_DEVICE_KEY;
-        var USER_COUNTRY_CODE;
-        var MCK_WEBSOCKET_URL;
-        var MCK_WEBSOCKET_PORT;
         var IS_LOGGED_IN = true;
         var MCK_CONTACT_MAP = [];
-        var MCK_TYPING_STATUS = 0;
         MCK_CLIENT_GROUP_MAP = [];
         var CONTACT_SYNCING = false;
-        var MCK_USER_TIMEZONEOFFSET;
         var MCK_BLOCKED_TO_MAP = [];
         var MCK_BLOCKED_BY_MAP = [];
         var MCK_IDLE_TIME_LIMIT = 90;
@@ -457,18 +450,18 @@ const firstVisibleMsg = {
             typeof appOptions.topicBox === 'boolean' ? appOptions.topicBox : false;
         var IS_MCK_OL_STATUS =
             typeof appOptions.olStatus === 'boolean' ? appOptions.olStatus : false;
-        var MESSAGE_BUBBLE_AVATOR_ENABLED =
-            typeof appOptions.messageBubbleAvator === 'boolean'
-                ? appOptions.messageBubbleAvator
-                : true;
-        var IS_OFFLINE_MESSAGE_ENABLED =
-            typeof appOptions.showOfflineMessage === 'boolean'
-                ? appOptions.showOfflineMessage
-                : false;
-        var IS_GROUP_SUBTITLE_HIDDEN =
-            typeof appOptions.hideGroupSubtitle === 'boolean'
-                ? appOptions.hideGroupSubtitle
-                : false;
+        var MESSAGE_BUBBLE_AVATOR_ENABLED = KommunicateUtils.getBooleanOption(
+            appOptions.messageBubbleAvator,
+            true
+        );
+        var IS_OFFLINE_MESSAGE_ENABLED = KommunicateUtils.getBooleanOption(
+            appOptions.showOfflineMessage,
+            false
+        );
+        var IS_GROUP_SUBTITLE_HIDDEN = KommunicateUtils.getBooleanOption(
+            appOptions.hideGroupSubtitle,
+            false
+        );
         var MCK_DEFAULT_MESSAGE_METADATA =
             typeof appOptions.defaultMessageMetaData === 'undefined'
                 ? {}
@@ -652,8 +645,7 @@ const firstVisibleMsg = {
         _this.churnCustomerWidgetChanges = function () {
             mckMessageService.openChatbox();
             kommunicateCommons.show('.mck-box-form-container');
-            kommunicateCommons.hide('#mck-contact-loading');
-            kommunicateCommons.hide('#mck-contacts-content');
+            kommunicateCommons.hide('#mck-contact-loading', '#mck-contacts-content');
         };
 
         _this.mckLaunchSideboxChat = function () {
@@ -709,25 +701,13 @@ const firstVisibleMsg = {
                 }
                 SOCKET_RECONNECT_FAIL_COUNT++;
                 SOCKET_RECONNECT_FAIL_COUNT > 2 &&
-                    kommunicateCommons.modifyClassList(
-                        { id: ['km-socket-disconnect-msg'] },
-                        '',
-                        'n-vis'
-                    );
+                    kommunicateCommons.show('#km-socket-disconnect-msg');
             },
             onConnect: function (resp) {
                 IS_SOCKET_CONNECTED = true;
                 console.debug('connected..');
-                kommunicateCommons.modifyClassList(
-                    { id: ['km-local-file-system-warning'] },
-                    'n-vis',
-                    'vis'
-                );
-                kommunicateCommons.modifyClassList(
-                    { id: ['km-socket-disconnect-msg'] },
-                    'n-vis',
-                    ''
-                );
+                kommunicateCommons.hide('#km-local-file-system-warning');
+                kommunicateCommons.hide('#km-socket-disconnect-msg');
                 SOCKET_RECONNECT_FAIL_COUNT = 0;
                 if (
                     Array.isArray(SUBSCRIBE_TO_EVENTS_BACKUP) &&
@@ -826,24 +806,9 @@ const firstVisibleMsg = {
             mckInit.initializeApp(appOptions, false);
             mckNotificationService.init();
             mckMapLayout.init();
-            !MCK_ATTACHMENT &&
-                kommunicateCommons.modifyClassList(
-                    { id: ['mck-attachfile-box', 'mck-file-up'] },
-                    'n-vis',
-                    'vis'
-                );
-            !IS_CAPTURE_PHOTO &&
-                kommunicateCommons.modifyClassList(
-                    { id: ['mck-attach-img-box', 'mck-img-file-up'] },
-                    'n-vis',
-                    ''
-                );
-            !IS_CAPTURE_VIDEO &&
-                kommunicateCommons.modifyClassList(
-                    { id: ['mck-attach-vid-box', 'mck-vid-file-up'] },
-                    'n-vis',
-                    ''
-                );
+            !MCK_ATTACHMENT && kommunicateCommons.hide('#mck-attachfile-box', '#mck-file-up');
+            !IS_CAPTURE_PHOTO && kommunicateCommons.hide('#mck-attach-img-box', '#mck-img-file-up');
+            !IS_CAPTURE_VIDEO && kommunicateCommons.hide('#mck-attach-vid-box', '#mck-vid-file-up');
             (VOICE_INPUT_ENABLED || VOICE_NOTE_ENABLED) &&
                 Kommunicate.typingAreaService.showMicIfRequiredWebAPISupported();
 
@@ -852,11 +817,7 @@ const firstVisibleMsg = {
                 window.frameElement.getAttribute('data-protocol') == 'file:' &&
                 !window.top.hasOwnProperty('cordova')
             ) {
-                kommunicateCommons.modifyClassList(
-                    { id: ['km-local-file-system-warning'] },
-                    'vis',
-                    'n-vis'
-                );
+                kommunicateCommons.show('#km-local-file-system-warning');
             }
             document.addEventListener('keydown', function (e) {
                 document.body.classList.add('accesibility');
@@ -1120,8 +1081,6 @@ const firstVisibleMsg = {
         };
         _this.reset = function (optns) {
             ALStorage.clearSessionStorageElements();
-            MCK_TOKEN = '';
-            USER_ENCRYPTION_KEY = '';
             AUTH_CODE = '';
             window.Applozic.ALApiService.AUTH_TOKEN = null;
             FILE_META = [];
@@ -1130,7 +1089,6 @@ const firstVisibleMsg = {
             MCK_CONTACT_MAP = [];
             USER_DEVICE_KEY = '';
             MCK_MODE = optns.mode;
-            USER_COUNTRY_CODE = '';
             MCK_BLOCKED_TO_MAP = [];
             MCK_BLOCKED_BY_MAP = [];
             CONTACT_SYNCING = false;
@@ -1216,8 +1174,10 @@ const firstVisibleMsg = {
                 typeof optns.desktopNotification === 'boolean' ? optns.desktopNotification : false;
             IS_MCK_OWN_CONTACTS =
                 typeof optns.loadOwnContacts === 'boolean' ? optns.loadOwnContacts : false;
-            MESSAGE_BUBBLE_AVATOR_ENABLED =
-                typeof optns.messageBubbleAvator === 'boolean' ? optns.messageBubbleAvator : true;
+            MESSAGE_BUBBLE_AVATOR_ENABLED = KommunicateUtils.getBooleanOption(
+                optns.messageBubbleAvator,
+                true
+            );
             IS_RESET_USER_STATUS =
                 typeof appOptions.resetUserStatus === 'boolean'
                     ? appOptions.resetUserStatus
@@ -1255,8 +1215,7 @@ const firstVisibleMsg = {
                     name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,
                     domain: MCK_COOKIE_DOMAIN,
                 });
-                kommunicateCommons.hide('#mck-sidebox');
-                kommunicateCommons.hide('#mck-sidebox-launcher');
+                kommunicateCommons.hide('#mck-sidebox', '#mck-sidebox-launcher');
                 parent.document.getElementById('kommunicate-widget-iframe') &&
                     (parent.document.getElementById('kommunicate-widget-iframe').style.display =
                         'none');
@@ -2076,8 +2035,7 @@ const firstVisibleMsg = {
                         _this.setLeadCollectionLabels();
                         kmChatLoginModal.style.visibility = 'visible';
                         kmChatLoginModal.style.display = 'none';
-                        kmAnonymousChatLauncher.classList.remove('n-vis');
-                        kmAnonymousChatLauncher.classList.add('vis');
+                        kommunicateCommons.show(kmAnonymousChatLauncher);
                         document
                             .getElementById('km-modal-close')
                             .addEventListener('click', _this.closeLeadCollectionWindow);
@@ -2115,8 +2073,7 @@ const firstVisibleMsg = {
                                     }
                                     kmChatLoginModal.style.display = 'block';
                                     !POPUP_WIDGET &&
-                                        (kmAnonymousChatLauncher.classList.remove('vis'),
-                                        kmAnonymousChatLauncher.classList.add('n-vis'));
+                                        kommunicateCommons.hide(kmAnonymousChatLauncher);
                                     mckInit.clearMsgTriggerAndChatPopuTimeouts();
                                 }
                             );
@@ -2250,8 +2207,7 @@ const firstVisibleMsg = {
                     Kommunicate.setDefaultIframeConfigForClosedChat();
                 }
                 kmChatLoginModal.style.display = 'none';
-                kmAnonymousChatLauncher.classList.remove('n-vis');
-                kmAnonymousChatLauncher.classList.add('vis');
+                kommunicateCommons.show(kmAnonymousChatLauncher);
             };
 
             _this.onInitApp = function (data) {
@@ -2268,14 +2224,9 @@ const firstVisibleMsg = {
                         kommunicateCommons.show(this);
                     }
                 });
-                MCK_TOKEN = data.token;
                 MCK_USER_ID = data.userId;
-                USER_COUNTRY_CODE = data.countryCode;
                 USER_DEVICE_KEY = data.deviceKey;
-                MCK_WEBSOCKET_URL = data.websocketUrl;
-                MCK_WEBSOCKET_PORT = data.websocketPort;
                 MCK_IDLE_TIME_LIMIT = data.websocketIdleTimeLimit;
-                MCK_USER_TIMEZONEOFFSET = data.timeZoneOffset;
                 MCK_FILE_URL = data.fileBaseUrl;
                 IS_MCK_USER_DEACTIVATED = data.deactivated;
                 // For trial plan connect to socket only when someone opens the chat or have some existing chat thread
@@ -2294,7 +2245,6 @@ const firstVisibleMsg = {
                     data.encryptionKey,
                     data.userEncryptionKey
                 );
-                USER_ENCRYPTION_KEY = data.userEncryptionKey;
                 if (!EMOJI_LIBRARY) {
                     // EMOJI_LIBRARY = false ->hide emoticon from chat widget
                     //Below code might be required once emoticons are added
@@ -2355,11 +2305,7 @@ const firstVisibleMsg = {
                 mckInit.tabFocused();
                 w.addEventListener('online', function () {
                     console.log('online');
-                    kommunicateCommons.modifyClassList(
-                        { id: ['km-internet-disconnect-msg'] },
-                        'n-vis',
-                        'vis'
-                    );
+                    kommunicateCommons.hide('#km-internet-disconnect-msg');
                     if (!IS_SOCKET_CONNECTED) {
                         console.log('Attempting socket reconnection');
 
@@ -2387,11 +2333,7 @@ const firstVisibleMsg = {
                     }
                 });
                 w.addEventListener('offline', function () {
-                    kommunicateCommons.modifyClassList(
-                        { id: ['km-internet-disconnect-msg'] },
-                        'vis',
-                        'n-vis'
-                    );
+                    kommunicateCommons.show('#km-internet-disconnect-msg');
                     console.log('offline');
                 });
                 if ($mckChatLauncherIcon.length > 0 && MCK_TOTAL_UNREAD_COUNT > 0) {
@@ -2593,11 +2535,7 @@ const firstVisibleMsg = {
                     kommunicateCommons.setWidgetStateOpen(true);
                     kommunicateIframe.classList.remove('km-iframe-closed');
                     kommunicateIframe.classList.add('kommunicate-iframe-enable-media-query');
-                    kommunicateCommons.modifyClassList(
-                        { id: ['applozic-badge-count'] },
-                        'n-vis',
-                        ''
-                    );
+                    kommunicateCommons.hide('#applozic-badge-count');
                     kommunicateIframe.style.width = '';
                     POPUP_WIDGET
                         ? (kommunicateIframe.classList.add('km-iframe-dimension-with-popup'),
@@ -2612,16 +2550,8 @@ const firstVisibleMsg = {
                     mckMessageService.closeSideBox();
                     popUpcloseButton.style.display = 'none';
                     Kommunicate.setDefaultIframeConfigForClosedChat();
-                    kommunicateCommons.modifyClassList(
-                        { id: ['applozic-badge-count'] },
-                        '',
-                        'n-vis'
-                    );
-                    kommunicateCommons.modifyClassList(
-                        { id: ['km-widget-options'], class: ['km-header-cta'] },
-                        'n-vis',
-                        ''
-                    );
+                    kommunicateCommons.show('#applozic-badge-count');
+                    kommunicateCommons.hide('#km-widget-options', '.km-header-cta');
                     KommunicateUI.flushFaqsEvents();
                     firstVisibleMsg.reset();
                 }
@@ -2634,20 +2564,9 @@ const firstVisibleMsg = {
                         .addEventListener('click', function () {
                             mckVoice.stopRecording(true);
 
-                            kommunicateCommons.modifyClassList(
-                                { id: ['mck-voice-interface'] },
-                                'n-vis',
-                                'vis'
-                            );
+                            kommunicateCommons.hide('#mck-voice-interface');
 
-                            kommunicateCommons.modifyClassList(
-                                {
-                                    id: ['mck-sidebox-ft'],
-                                    class: ['mck-box-body'],
-                                },
-                                'vis',
-                                'n-vis'
-                            );
+                            kommunicateCommons.show('#mck-sidebox-ft', '.mck-box-body');
 
                             document.querySelector('.mck-box-top').classList.remove('n-vis');
                             window.Kommunicate.openConversation(CURRENT_GROUP_DATA.tabId);
@@ -2996,7 +2915,7 @@ const firstVisibleMsg = {
                 sendFeedbackComment.addEventListener('click', function () {
                     const isAnyRatingSelected = document.querySelector('.mck-rating-box.selected');
                     if (!isAnyRatingSelected) {
-                        ratingErrorMsgContainer.classList.remove('n-vis');
+                        kommunicateCommons.show(ratingErrorMsgContainer);
                         return;
                     }
                     kmWidgetEvents.eventTracking(eventMapping.onSubmitRatingClick);
@@ -3028,25 +2947,17 @@ const firstVisibleMsg = {
                 });
                 for (var i = 0; i < ratingStars.length; i++) {
                     ratingStars[i].addEventListener('click', function (e) {
-                        kommunicateCommons.modifyClassList({ id: ['csat-2'] }, '', 'n-vis');
-                        kommunicateCommons.modifyClassList(
-                            { id: ['mck-rate-conversation'] },
-                            'n-vis',
-                            ''
-                        );
+                        kommunicateCommons.show('#csat-2');
+                        kommunicateCommons.hide('#mck-rate-conversation');
                         kommunicateCommons.modifyClassList(
                             { class: ['mck-rating-box'] },
                             '',
                             'selected'
                         );
-                        kommunicateCommons.modifyClassList(
-                            { class: ['mck-feedback-text-wrapper'] },
-                            '',
-                            'n-vis'
-                        );
+                        kommunicateCommons.show('.mck-feedback-text-wrapper');
                         e.currentTarget.classList.add('selected');
                         !ratingErrorMsgContainer.classList.contains('n-vis') &&
-                            ratingErrorMsgContainer.classList.add('n-vis');
+                            kommunicateCommons.hide(ratingErrorMsgContainer);
                         if (appOptions?.appSettings?.chatWidget?.csatRatingBase == 5) {
                             if (e.currentTarget.classList[2] == 'selected') {
                                 var ratingValue = parseInt(e.currentTarget.dataset.rating);
@@ -3160,7 +3071,7 @@ const firstVisibleMsg = {
                 $applozic('#mck-sidebox-launcher').remove();
                 $applozic('body').append(_this.getLauncherHtml());
                 mckNotificationService.init();
-                document.querySelector('#mck-sidebox-launcher').classList.remove('n-vis');
+                kommunicateCommons.show('#mck-sidebox-launcher');
             };
             _this.tabFocused = function () {
                 var hidden = 'hidden';
@@ -3445,11 +3356,7 @@ const firstVisibleMsg = {
                     _this.changeConversationAssignee();
                 } else {
                     appOptions.restartConversationByUser &&
-                        kommunicateCommons.modifyClassList(
-                            { id: ['km-widget-options'] },
-                            '',
-                            'n-vis'
-                        );
+                        kommunicateCommons.show('#km-widget-options');
                     kommunicateCommons.modifyClassList(
                         {
                             id: ['mck-sidebox-ft'],
@@ -3465,48 +3372,29 @@ const firstVisibleMsg = {
                 }
             };
             _this.showSendButton = function () {
-                kommunicateCommons.modifyClassList({ id: ['send-button-wrapper'] }, 'vis', 'n-vis');
-                kommunicateCommons.modifyClassList(
-                    {
-                        id: [
-                            'mck-file-up',
-                            'mck-btn-loc',
-                            'mck-btn-smiley-box',
-                            'mck-img-file-up',
-                            'mck-vid-file-up',
-                        ],
-                    },
-                    'n-vis',
-                    'vis'
+                kommunicateCommons.show('#send-button-wrapper');
+                kommunicateCommons.hide(
+                    '#mck-file-up',
+                    '#mck-btn-loc',
+                    '#mck-btn-smiley-box',
+                    '#mck-img-file-up',
+                    '#mck-vid-file-up'
                 );
-                IS_MCK_LOCSHARE
-                    ? ''
-                    : kommunicateCommons.modifyClassList({ id: ['mck-file-up2'] }, 'n-vis', 'vis');
+                !IS_MCK_LOCSHARE && kommunicateCommons.hide('#mck-file-up2');
 
-                !IS_CAPTURE_PHOTO &&
-                    kommunicateCommons.modifyClassList({ id: ['mck-img-file-up'] }, 'n-vis', '');
-                !IS_CAPTURE_VIDEO &&
-                    kommunicateCommons.modifyClassList({ id: ['mck-vid-file-up'] }, 'n-vis', '');
+                !IS_CAPTURE_PHOTO && kommunicateCommons.hide('#mck-img-file-up');
+                !IS_CAPTURE_VIDEO && kommunicateCommons.hide('#mck-vid-file-up');
             };
 
             _this.hideSendButton = function () {
-                kommunicateCommons.modifyClassList({ id: ['send-button-wrapper'] }, 'n-vis', 'vis');
-                MCK_ATTACHMENT &&
-                    kommunicateCommons.modifyClassList({ id: ['mck-file-up'] }, 'vis', 'n-vis');
+                kommunicateCommons.hide('#send-button-wrapper');
+                MCK_ATTACHMENT && kommunicateCommons.show('#mck-file-up');
                 !IS_MCK_LOCSHARE
-                    ? kommunicateCommons.modifyClassList({ id: ['mck-file-up2'] }, 'vis', 'n-vis')
-                    : kommunicateCommons.modifyClassList({ id: ['mck-btn-loc'] }, 'vis', 'n-vis');
-                IS_CAPTURE_PHOTO &&
-                    kommunicateCommons.modifyClassList({ id: ['mck-img-file-up'] }, '', 'n-vis');
-                IS_CAPTURE_VIDEO &&
-                    kommunicateCommons.modifyClassList({ id: ['mck-vid-file-up'] }, '', 'n-vis');
-                !EMOJI_LIBRARY
-                    ? ''
-                    : kommunicateCommons.modifyClassList(
-                          { id: ['mck-btn-smiley-box'] },
-                          'vis',
-                          'n-vis'
-                      );
+                    ? kommunicateCommons.show('#mck-file-up2')
+                    : kommunicateCommons.show('#mck-btn-loc');
+                IS_CAPTURE_PHOTO && kommunicateCommons.show('#mck-img-file-up');
+                IS_CAPTURE_VIDEO && kommunicateCommons.show('#mck-vid-file-up');
+                EMOJI_LIBRARY && kommunicateCommons.show('#mck-btn-smiley-box');
             };
             _this.toggleMediaOptions = function (el) {
                 var text = '';
@@ -3889,14 +3777,16 @@ const firstVisibleMsg = {
                     mckInit.clearMsgTriggerAndChatPopuTimeouts();
                 });
                 $applozic(d).on('click', '#mck-sidebox-launcher', function () {
-                    document.getElementById('launcher-agent-img-container').classList.add('n-vis');
-                    document.getElementById('launcher-agent-img-container').classList.remove('vis');
+                    kommunicateCommons.hide(
+                        document.getElementById('launcher-agent-img-container')
+                    );
                     if (typeof CUSTOM_CHAT_LAUNCHER !== 'undefined') {
-                        document
-                            .getElementById('mck-sidebox-launcher')
-                            .childNodes[0].childNodes[0].classList.remove('n-vis');
+                        kommunicateCommons.show(
+                            document.getElementById('mck-sidebox-launcher').childNodes[0]
+                                .childNodes[0]
+                        );
                     } else {
-                        document.getElementById('launcher-svg-container').classList.remove('n-vis');
+                        kommunicateCommons.show('#launcher-svg-container');
                     }
                 });
                 $applozic(d).on('click', '#talk-to-human-link', function () {
@@ -4144,7 +4034,7 @@ const firstVisibleMsg = {
                                     ')';
                             }
                             document.getElementById('mck-char-count').innerHTML = remtxt;
-                            warningBox.classList.remove('n-vis');
+                            kommunicateCommons.show(warningBox);
                             if (!warningBox.classList.contains('mck-warning-slide-up')) {
                                 warningBox.classList.add('mck-warning-slide-up');
                                 warningBox.classList.remove('mck-warning-slide-down');
@@ -4158,7 +4048,7 @@ const firstVisibleMsg = {
                                 warningBox.classList.add('mck-warning-slide-down');
                                 warningBox.classList.remove('mck-warning-slide-up');
                                 setTimeout(function () {
-                                    warningBox.classList.add('n-vis');
+                                    kommunicateCommons.hide(warningBox);
                                 }, 700);
                             }
                         }
@@ -4550,14 +4440,7 @@ const firstVisibleMsg = {
                     e.preventDefault();
                     mckMessageService.stopBusinessHoursTimer();
                     kommunicateCommons.hide($mck_business_hours_box);
-                    kommunicateCommons.modifyClassList(
-                        {
-                            id: ['km-widget-options'],
-                            class: ['km-header-cta'],
-                        },
-                        'n-vis',
-                        ''
-                    );
+                    kommunicateCommons.hide('#km-widget-options', '.km-header-cta');
                     CURRENT_GROUP_DATA.isWaitingQueue = false;
                     firstVisibleMsg.reset();
                     genAiService.enableTextArea(true);
@@ -4580,11 +4463,7 @@ const firstVisibleMsg = {
                     KommunicateUI.hideLeadCollectionTemplate();
                     KommunicateUI.showClosedConversationBanner(false);
                     !MCK_ATTACHMENT &&
-                        kommunicateCommons.modifyClassList(
-                            { id: ['mck-attachfile-box', 'mck-file-up'] },
-                            'n-vis',
-                            'vis'
-                        );
+                        kommunicateCommons.hide('#mck-attachfile-box', '#mck-file-up');
                     mckMessageLayout.loadTab({
                         tabId: '',
                         isGroup: false,
@@ -5030,8 +4909,7 @@ const firstVisibleMsg = {
                 });
                 $mck_form_field.on('click', function () {
                     $applozic(this).val('');
-                    kommunicateCommons.hide('#mck-msg-error');
-                    kommunicateCommons.hide('#mck-msg-response');
+                    kommunicateCommons.hide('#mck-msg-error', '#mck-msg-response');
                 });
                 $applozic(d).bind('click', function (e) {
                     kommunicateCommons.hide('.mck-context-menu');
@@ -5199,9 +5077,11 @@ const firstVisibleMsg = {
                             .html(MCK_LABELS['user.delete'])
                             .removeClass('n-vis')
                             .addClass('vis');
-                        kommunicateCommons.hide('#mck-tab-status');
-                        kommunicateCommons.hide('#mck-msg-form');
-                        kommunicateCommons.hide('#li-mck-block-user');
+                        kommunicateCommons.hide(
+                            '#mck-tab-status',
+                            '#mck-msg-form',
+                            '#li-mck-block-user'
+                        );
                         return;
                     }
                 }
@@ -5582,12 +5462,8 @@ const firstVisibleMsg = {
                                 '.km-attachment-download-icon-' + messagePxy.key
                             );
                             kommunicateCommons.hide('.km-attachment-cancel-icon-' + messagePxy.key);
-                            kommunicateCommons.modifyClassList(
-                                {
-                                    class: ['km-attachment-progress-bar-wrapper-' + messagePxy.key],
-                                },
-                                'n-vis',
-                                'vis'
+                            kommunicateCommons.hide(
+                                '.km-attachment-progress-bar-wrapper-' + messagePxy.key
                             );
                             var messageKey = data.messageKey;
                             if (currentTabId && currentTabId.toString() === optns.tabId) {
@@ -6834,12 +6710,7 @@ const firstVisibleMsg = {
                                               );
                                     });
                                 }
-                                kommunicateCommons.modifyClassList(
-                                    {
-                                        class: ['mck-box-form-container'],
-                                    },
-                                    'n-vis'
-                                );
+                                kommunicateCommons.hide('.mck-box-form-container');
                                 const assignee =
                                     groupPxy.metadata && groupPxy.metadata.CONVERSATION_ASSIGNEE;
                                 const groupUsers = groupPxy.groupUsers;
@@ -7151,7 +7022,7 @@ const firstVisibleMsg = {
                 var ctaData = KommunicateConstants.HEADER_PRIMARY_CTA;
 
                 if (data.currentCTA) {
-                    kommunicateCommons.modifyClassList({ id: ['km-faq'] }, 'n-vis');
+                    kommunicateCommons.hide('#km-faq');
                     // kommunicateCommons.modifyClassList({ id: ['km-header-cta'] }, '', 'n-vis');
 
                     switch (true) {
@@ -7169,7 +7040,7 @@ const firstVisibleMsg = {
                 var isIterable = true;
                 var restartConversationBtn = document.getElementById(id);
                 if (restartConversationBtn && restartConversationBtn.classList.contains('n-vis')) {
-                    kommunicateCommons.modifyClassList({ id: [id] }, '', 'n-vis');
+                    kommunicateCommons.show('#' + id);
                 }
 
                 CURRENT_GROUP_DATA.groupMembers &&
@@ -7189,14 +7060,14 @@ const firstVisibleMsg = {
                     CURRENT_GROUP_DATA.conversationAssignee &&
                     CURRENT_GROUP_DATA.initialBot.userId
                 ) {
-                    kommunicateCommons.modifyClassList({ id: [id] }, '', 'n-vis');
+                    kommunicateCommons.show('#' + id);
                     restartConversationBtn &&
                         restartConversationBtn.addEventListener(
                             'click',
                             mckMessageService.restartConversation
                         );
                 } else {
-                    kommunicateCommons.modifyClassList({ id: [id] }, 'n-vis', '');
+                    kommunicateCommons.hide('#' + id);
                 }
             };
 
@@ -7217,7 +7088,7 @@ const firstVisibleMsg = {
                 */
                 if (CSAT_ENABLED && !isConvRated && HEADER_CTA.CSAT_RATING !== primaryCTA) {
                     enableDropdown = true;
-                    kommunicateCommons.modifyClassList({ id: ['km-csat-trigger'] }, '', 'n-vis');
+                    kommunicateCommons.show('#km-csat-trigger');
                 }
                 if (appOptions.restartConversationByUser) {
                     var restartConversationBtn = document.getElementById('km-restart-conversation');
@@ -7240,22 +7111,14 @@ const firstVisibleMsg = {
                         CURRENT_GROUP_DATA.conversationAssignee ==
                             CURRENT_GROUP_DATA.initialBot.userId
                     ) {
-                        kommunicateCommons.modifyClassList(
-                            { id: ['km-restart-conversation'] },
-                            '',
-                            'n-vis'
-                        );
+                        kommunicateCommons.show('#km-restart-conversation');
                         restartConversationBtn &&
                             restartConversationBtn.addEventListener(
                                 'click',
                                 mckMessageService.restartConversation
                             );
                     } else {
-                        kommunicateCommons.modifyClassList(
-                            { id: ['km-restart-conversation'] },
-                            'n-vis',
-                            ''
-                        );
+                        kommunicateCommons.hide('#km-restart-conversation');
                     }
 
                     if (HEADER_CTA.RESTART_CONVERSATION !== primaryCTA) {
@@ -7268,11 +7131,7 @@ const firstVisibleMsg = {
                 if (VOICE_OUTPUT_ENABLED && HEADER_CTA.TTS !== primaryCTA) {
                     enableDropdown = true;
                     KommunicateUI.toggleVoiceOutputOverride(userOverride.voiceOutput);
-                    kommunicateCommons.modifyClassList(
-                        { id: ['user-overide-voice-output'] },
-                        '',
-                        'n-vis'
-                    );
+                    kommunicateCommons.show('#user-overide-voice-output');
                 }
 
                 if (
@@ -7281,11 +7140,7 @@ const firstVisibleMsg = {
                     !convTransferred
                 ) {
                     enableDropdown = true;
-                    kommunicateCommons.modifyClassList(
-                        { class: ['km-option-talk-to-human'] },
-                        '',
-                        'n-vis'
-                    );
+                    kommunicateCommons.show('.km-option-talk-to-human');
                 }
                 // hasArticles initially will be undefined and after the faq load it will be boolean
                 if (
@@ -7294,18 +7149,14 @@ const firstVisibleMsg = {
                         kommunicate._globals.hasArticles === true)
                 ) {
                     enableDropdown = true;
-                    kommunicateCommons.modifyClassList({ class: ['km-option-faq'] }, '', 'n-vis');
+                    kommunicateCommons.show('.km-option-faq');
                 }
 
-                var addClass = enableDropdown ? 'vis' : 'n-vis';
-                var removeClass = enableDropdown ? 'n-vis' : 'vis';
-
-                // For toggling display of three dot button (Dropdown btn)
-                kommunicateCommons.modifyClassList(
-                    { id: ['km-widget-options'] },
-                    addClass,
-                    removeClass
-                );
+                if (enableDropdown) {
+                    kommunicateCommons.show('#km-widget-options');
+                } else {
+                    kommunicateCommons.hide('#km-widget-options');
+                }
             };
 
             // _this.openConversation = function () {
@@ -7410,17 +7261,17 @@ const firstVisibleMsg = {
                 $mck_msg_inner.html('');
                 $mck_msg_error.removeClass('mck-no-mb');
                 kommunicateCommons.show('#mck-contacts-content');
-                kommunicateCommons.hide('.mck-box-ft .mck-box-form-container');
-                kommunicateCommons.hide('#mck-sidebox-ft');
-                kommunicateCommons.modifyClassList({ id: ['mck-voice-web'] }, 'n-vis');
+                kommunicateCommons.hide('.mck-box-ft .mck-box-form-container', '#mck-sidebox-ft');
+                kommunicateCommons.hide('#mck-voice-web');
                 // render quick replies
                 QUICK_REPLIES && KommunicateUI.loadQuickReplies(QUICK_REPLIES);
-                kommunicateCommons.hide('#mck-sidebox-search');
-                kommunicateCommons.hide('#mck-group-info-tab');
+                kommunicateCommons.hide('#mck-sidebox-search', '#mck-group-info-tab');
                 kommunicateCommons.show('#mck-sidebox-content');
-                kommunicateCommons.hide('#mck-product-box');
-                kommunicateCommons.hide($mck_conversation_header);
-                kommunicateCommons.hide('#mck-contact-loading');
+                kommunicateCommons.hide(
+                    '#mck-product-box',
+                    $mck_conversation_header,
+                    '#mck-contact-loading'
+                );
                 $mck_msg_inner.removeClass('mck-group-inner');
                 kommunicateCommons.hide('#mck-tab-status');
                 $mck_tab_title.removeClass('mck-tab-title-w-status');
@@ -7431,7 +7282,7 @@ const firstVisibleMsg = {
                 $mck_msg_inner.data('datetime', '');
                 kommunicateCommons.hide('#mck-char-warning');
                 kommunicateCommons.modifyClassList({ class: ['mck-rating-box'] }, '', 'selected');
-                kommunicateCommons.modifyClassList({ id: ['km-faq'] }, 'n-vis', '');
+                kommunicateCommons.hide('#km-faq');
                 if (params.tabId) {
                     $mck_msg_to.val(params.tabId);
                     $mck_msg_inner.data('mck-id', params.tabId);
@@ -7446,13 +7297,7 @@ const firstVisibleMsg = {
                     appOptions.voiceChat && mckVoice.showMic(appOptions);
                     kommunicateCommons.show('#mck-btn-clear-messages');
                     kommunicateCommons.hide('.mck-group-menu-options');
-                    kommunicateCommons.modifyClassList(
-                        {
-                            id: ['mck-waiting-queue'],
-                        },
-                        'n-vis',
-                        'vis'
-                    );
+                    kommunicateCommons.hide('#mck-waiting-queue');
                     if (params.isGroup) {
                         $mck_msg_inner.addClass('mck-group-inner');
                         kommunicateCommons.hide('#li-mck-block-user');
@@ -7500,8 +7345,7 @@ const firstVisibleMsg = {
                         document.querySelector('#mck-msg-error').classList.add('mck-no-mb');
                         kommunicateCommons.hide('#mck-msg-form');
                     }
-                    kommunicateCommons.hide('#mck-tab-conversation');
-                    kommunicateCommons.hide('#mck-search-tabview-box');
+                    kommunicateCommons.hide('#mck-tab-conversation', '#mck-search-tabview-box');
                     kommunicateCommons.show('#mck-tab-individual');
 
                     // kommunicateCommons.hide("#km-faq");
@@ -7543,8 +7387,7 @@ const firstVisibleMsg = {
                     $mck_msg_inner.data('mck-topicid', '');
                     kommunicateCommons.hide('#mck-price-widget');
                     $mck_msg_inner.removeClass('mck-msg-w-panel');
-                    kommunicateCommons.hide('#mck-tab-option-panel');
-                    kommunicateCommons.hide('#mck-btn-clear-messages');
+                    kommunicateCommons.hide('#mck-tab-option-panel', '#mck-btn-clear-messages');
                     $mck_msg_to.val('');
 
                     var mckMessageArray = ALStorage.getLatestMessageArray();
@@ -9188,47 +9031,39 @@ const firstVisibleMsg = {
 
             _this.getImageForMessagePreview = function (message) {
                 if (typeof message.fileMeta === 'object') {
-                    if (message.fileMeta.contentType.indexOf('image') !== -1) {
+                    var meta = message.fileMeta;
+                    var size = alFileService.getFilePreviewSize(meta.size);
+                    if (meta.contentType.indexOf('image') !== -1) {
                         return (
                             '<span>photo</span> <img src="' +
                             MCK_FILE_URL +
                             FILE_PREVIEW_URL +
-                            message.fileMeta.blobKey +
+                            meta.blobKey +
                             '" class="mck-image-reply move-right"/>'
                         );
-                    } else if (message.fileMeta.contentType.indexOf('audio') !== -1) {
-                        return (
-                            '<span>audio</span><span class="mck-file-detail move-right"><span class="mck-file-name"><span class="mck-icon-attachment"></span>&nbsp;' +
-                            message.fileMeta.name +
-                            '</span>&nbsp;<span class="file-size">' +
-                            alFileService.getFilePreviewSize(message.fileMeta.size) +
-                            '</span></span>'
-                        );
-                    } else {
-                        return (
-                            '<span class="mck-file-detail move-right"><span class="mck-file-name"><span class="mck-icon-attachment"></span>&nbsp;' +
-                            message.fileMeta.name +
-                            '</span>&nbsp;<span class="file-size">' +
-                            alFileService.getFilePreviewSize(message.fileMeta.size) +
-                            '</span></span>'
-                        );
                     }
-                    return '';
+                    var fileDetail =
+                        '<span class="mck-file-detail move-right"><span class="mck-file-name"><span class="mck-icon-attachment"></span>&nbsp;' +
+                        meta.name +
+                        '</span>&nbsp;<span class="file-size">' +
+                        size +
+                        '</span></span>';
+                    return meta.contentType.indexOf('audio') !== -1
+                        ? '<span>audio</span>' + fileDetail
+                        : fileDetail;
                 }
                 if (message.contentType === 2) {
                     var geoLoc = $applozic.parseJSON(message.message);
+                    var coords = geoLoc.lat + ',' + geoLoc.lon;
                     return (
                         '<span>location</span><img src="https://maps.googleapis.com/maps/api/staticmap?zoom=17&size=200x150&center=' +
-                        geoLoc.lat +
-                        ',' +
-                        geoLoc.lon +
+                        coords +
                         '&maptype=roadmap&markers=color:red|' +
-                        geoLoc.lat +
-                        ',' +
-                        geoLoc.lon +
+                        coords +
                         '" class="mck-image-reply move-right"/>'
                     );
                 }
+                return '';
             };
 
             _this.getImageForReplyMessage = function (message) {
@@ -10176,23 +10011,34 @@ const firstVisibleMsg = {
                     $textMessage.html('');
                 }
             };
-            _this.addContactsToContactSearchList = function () {
-                kommunicateCommons.hide('#mck-no-search-contacts');
-                kommunicateCommons.hide('#mck-no-search-groups');
-                if (!$mck_contact_search_tab.hasClass('active')) {
+            _this.openSearchView = function () {
+                kommunicateCommons.hide(
+                    '#mck-contacts-content',
+                    '#mck-sidebox-content',
+                    '#mck-group-info-tab'
+                );
+                kommunicateCommons.show('#mck-sidebox-search', '#mck-search-loading');
+            };
+            _this.switchSearchTab = function (showGroup) {
+                var activeTab = showGroup ? $mck_group_search_tab : $mck_contact_search_tab;
+                if (!activeTab.hasClass('active')) {
                     $mck_search_tab_link.removeClass('active');
-                    $mck_contact_search_tab.addClass('active');
+                    activeTab.addClass('active');
                 }
-                kommunicateCommons.hide('#mck-group-search-list');
-                kommunicateCommons.show('#mck-contact-search-list');
-                kommunicateCommons.hide('#mck-group-search-input-box');
-                kommunicateCommons.show('#mck-contact-search-input-box');
+                var hideSelectors = showGroup
+                        ? ['#mck-contact-search-list', '#mck-contact-search-input-box']
+                        : ['#mck-group-search-list', '#mck-group-search-input-box'],
+                    showSelectors = showGroup
+                        ? ['#mck-group-search-list', '#mck-group-search-input-box']
+                        : ['#mck-contact-search-list', '#mck-contact-search-input-box'];
+                kommunicateCommons.hide.apply(kommunicateCommons, hideSelectors);
+                kommunicateCommons.show.apply(kommunicateCommons, showSelectors);
+            };
+            _this.addContactsToContactSearchList = function () {
+                kommunicateCommons.hide('#mck-no-search-contacts', '#mck-no-search-groups');
+                _this.switchSearchTab(false);
                 $mck_contact_search_list.html('');
-                kommunicateCommons.hide('#mck-contacts-content');
-                kommunicateCommons.hide('#mck-sidebox-content');
-                kommunicateCommons.hide('#mck-group-info-tab');
-                kommunicateCommons.show('#mck-sidebox-search');
-                kommunicateCommons.show('#mck-search-loading');
+                _this.openSearchView();
                 if (MCK_CONTACT_ARRAY.length !== 0) {
                     mckMessageLayout.addContactsToSearchList();
                 } else if (!IS_MCK_OWN_CONTACTS) {
@@ -10206,22 +10052,10 @@ const firstVisibleMsg = {
             _this.addGroupsToGroupSearchList = function () {
                 var groupsArray = [],
                     groupIdArray = [];
-                kommunicateCommons.hide('#mck-no-search-contacts');
-                kommunicateCommons.hide('#mck-no-search-groups');
-                if (!$mck_group_search_tab.hasClass('active')) {
-                    $mck_search_tab_link.removeClass('active');
-                    $mck_group_search_tab.addClass('active');
-                }
-                kommunicateCommons.hide('#mck-contact-search-list');
-                kommunicateCommons.show('#mck-group-search-list');
-                kommunicateCommons.hide('#mck-contact-search-input-box');
-                kommunicateCommons.show('#mck-group-search-input-box');
+                kommunicateCommons.hide('#mck-no-search-contacts', '#mck-no-search-groups');
+                _this.switchSearchTab(true);
                 $mck_group_search_list.html('');
-                kommunicateCommons.hide('#mck-contacts-content');
-                kommunicateCommons.hide('#mck-sidebox-content');
-                kommunicateCommons.hide('#mck-group-info-tab');
-                kommunicateCommons.show('#mck-sidebox-search');
-                kommunicateCommons.show('#mck-search-loading');
+                _this.openSearchView();
                 if (MCK_GROUP_ARRAY.length > 0) {
                     $applozic.each(MCK_GROUP_ARRAY, function (i, group) {
                         groupIdArray.push(group.contactId);
@@ -10759,11 +10593,7 @@ const firstVisibleMsg = {
                     mckUtils.badgeCountOnLaucher(MCK_ENABLE_BADGE_COUNT, MCK_TOTAL_UNREAD_COUNT);
                 }
                 if (kommunicateCommons.isWidgetOpen()) {
-                    kommunicateCommons.modifyClassList(
-                        { id: ['applozic-badge-count'] },
-                        'n-vis',
-                        ''
-                    );
+                    kommunicateCommons.hide('#applozic-badge-count');
                 }
             };
             _this.incrementUnreadCount = function (tabId) {
@@ -11318,8 +11148,7 @@ const firstVisibleMsg = {
                     document.querySelector('#mck-msg-error').classList.add('mck-no-mb');
                     kommunicateCommons.hide('#mck-msg-form');
                     $mck_tab_title.removeClass('mck-tab-title-w-status');
-                    kommunicateCommons.hide('#mck-tab-status');
-                    kommunicateCommons.hide('.mck-typing-box');
+                    kommunicateCommons.hide('#mck-tab-status', '.mck-typing-box');
                     $mck_message_inner.data('blocked', true);
                     $mck_block_button
                         .html(MCK_LABELS['unblock.user'])
@@ -11909,8 +11738,10 @@ const firstVisibleMsg = {
                             $mck_tab_title.removeClass('mck-tab-title-w-status');
                             kommunicateCommons.hide('#mck-tab-status');
                         }
-                        kommunicateCommons.hide('.mck-group-menu-options');
-                        kommunicateCommons.hide('.mck-tab-message-option');
+                        kommunicateCommons.hide(
+                            '.mck-group-menu-options',
+                            '.mck-tab-message-option'
+                        );
                         kommunicateCommons.hide('#mck-tab-option-panel');
                         if (typeof OPEN_GROUP_SUBSCRIBER_MAP[group.contactId] === 'undefined') {
                             window.Applozic.ALSocket.subscribeToOpenGroup(group);
@@ -12435,11 +12266,13 @@ const firstVisibleMsg = {
                     .appendTo('#mck-group-member-search-list');
             };
             _this.loadCreateGroupTab = function () {
-                kommunicateCommons.hide('#mck-contacts-content');
-                kommunicateCommons.hide('#mck-sidebox-content');
-                kommunicateCommons.hide('#mck-sidebox-search');
-                kommunicateCommons.hide('#mck-group-info-tab');
-                kommunicateCommons.hide('#mck-group-create-icon-loading');
+                kommunicateCommons.hide(
+                    '#mck-contacts-content',
+                    '#mck-sidebox-content',
+                    '#mck-sidebox-search',
+                    '#mck-group-info-tab',
+                    '#mck-group-create-icon-loading'
+                );
                 $mck_group_create_icon.data('iconurl', '');
                 $mck_group_create_title.html('');
                 $mck_group_create_overlay_box.removeClass('n-vis');
@@ -12451,11 +12284,13 @@ const firstVisibleMsg = {
                     $mck_group_title.attr('contenteditable', false);
                     kommunicateCommons.hide('#mck-group-name-save');
                     kommunicateCommons.show('#mck-group-name-edit');
-                    kommunicateCommons.hide('#mck-contacts-content');
-                    kommunicateCommons.hide('#mck-sidebox-search');
-                    kommunicateCommons.hide('#mck-group-update-panel');
-                    kommunicateCommons.hide('#mck-btn-group-icon-save');
-                    kommunicateCommons.hide('#mck-group-info-icon-loading');
+                    kommunicateCommons.hide(
+                        '#mck-contacts-content',
+                        '#mck-sidebox-search',
+                        '#mck-group-update-panel',
+                        '#mck-btn-group-icon-save',
+                        '#mck-group-info-icon-loading'
+                    );
                     $mck_group_info_tab.data('mck-id', params.groupId);
                     $mck_group_info_icon.data('iconurl', '');
                     if (params.conversationId) {
@@ -13309,13 +13144,7 @@ const firstVisibleMsg = {
                 kommunicateCommons.hide('.km-attachment-cancel-icon-' + messageKey);
                 kommunicateCommons.show('.mck-timestamp-' + messageKey);
                 kommunicateCommons.show('.malicious-error-' + messageKey);
-                kommunicateCommons.modifyClassList(
-                    {
-                        class: ['km-attachment-progress-bar-wrapper-' + messageKey],
-                    },
-                    'n-vis',
-                    'vis'
-                );
+                kommunicateCommons.hide('.km-attachment-progress-bar-wrapper-' + messageKey);
             };
         }
 
@@ -13549,11 +13378,7 @@ const firstVisibleMsg = {
                 }
 
                 $mck_msg_preview_visual_indicator_text.html(htmlPayload);
-                kommunicateCommons.modifyClassList(
-                    { id: ['mck-msg-preview-visual-indicator'] },
-                    'vis',
-                    'n-vis'
-                );
+                kommunicateCommons.show('#mck-msg-preview-visual-indicator');
             };
 
             _this.formatMessageForNotification = function (msg) {
@@ -13648,11 +13473,7 @@ const firstVisibleMsg = {
                         kommunicateIframe.classList.remove('km-iframe-dimension-with-popup');
                         document.getElementById('km-popup-close-button').style.display = 'none';
                         _this.hideMessagePreview();
-                        kommunicateCommons.modifyClassList(
-                            { id: ['applozic-badge-count'] },
-                            '',
-                            'n-vis'
-                        );
+                        kommunicateCommons.show('#applozic-badge-count');
                     }
                 );
                 $applozic(d).on(
@@ -14069,8 +13890,7 @@ const firstVisibleMsg = {
                         } else {
                             MCK_BLOCKED_BY_MAP[contact.contactId] = true;
                             $mck_tab_title.removeClass('mck-tab-title-w-status');
-                            kommunicateCommons.hide('#mck-tab-status');
-                            kommunicateCommons.hide('.mck-typing-box');
+                            kommunicateCommons.hide('#mck-tab-status', '.mck-typing-box');
                         }
                     } else {
                         kommunicateCommons.hide('#li-user-' + contact.htmlId + ' .mck-ol-status');

--- a/webplugin/js/app/media/typing-area-dom-service.js
+++ b/webplugin/js/app/media/typing-area-dom-service.js
@@ -76,22 +76,18 @@ Kommunicate.typingAreaService = {
         }
     },
     hideMicButton: function () {
-        kommunicateCommons.modifyClassList({ id: ['mck-mic-animation-container'] }, 'n-vis', 'vis');
+        kommunicateCommons.hide('#mck-mic-animation-container');
     },
     showMicButton: function () {
         if (appOption && (appOption.voiceInput || appOption.voiceNote)) {
-            kommunicateCommons.modifyClassList(
-                { id: ['mck-mic-animation-container'] },
-                'vis',
-                'n-vis'
-            );
+            kommunicateCommons.show('#mck-mic-animation-container');
         }
     },
     hideMiceRecordingAnimation: function () {
-        kommunicateCommons.modifyClassList({ id: ['mck-animation-outer'] }, 'n-vis', 'vis');
+        kommunicateCommons.hide('#mck-animation-outer');
     },
     showMicRcordingAnimation: function () {
-        kommunicateCommons.modifyClassList({ id: ['mck-animation-outer'] }, 'vis', 'n-vis');
+        kommunicateCommons.show('#mck-animation-outer');
     },
     showRecorder: function () {
         document.querySelector('#mck-textbox-container').classList.add('n-vis');

--- a/webplugin/js/app/voice/mck-voice.js
+++ b/webplugin/js/app/voice/mck-voice.js
@@ -155,10 +155,7 @@ class MckVoice {
                 }
 
                 // Hide other rings
-                kommunicateCommons.modifyClassList(
-                    { class: ['voice-ring-2', 'voice-ring-3'] },
-                    'n-vis'
-                );
+                kommunicateCommons.hide('.voice-ring-2', '.voice-ring-3');
 
                 // Apply receding animation to the first ring
                 const ring1 = document.querySelector('.voice-ring-1');
@@ -251,10 +248,7 @@ class MckVoice {
                 document.getElementById('mck-voice-repeat-last-msg').classList.remove('mck-hidden');
 
                 // Hide other rings
-                kommunicateCommons.modifyClassList(
-                    { class: ['voice-ring-2', 'voice-ring-3'] },
-                    'n-vis'
-                );
+                kommunicateCommons.hide('.voice-ring-2', '.voice-ring-3');
 
                 // Apply receding animation to the first ring
                 const ring1 = document.querySelector('.voice-ring-1');
@@ -277,20 +271,10 @@ class MckVoice {
     addEventListeners() {
         const self = this;
         document.querySelector('.mck-voice-web').addEventListener('click', () => {
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['mck-sidebox-ft'],
-                    class: ['mck-box-body', 'mck-box-top'],
-                },
-                'n-vis'
-            );
+            kommunicateCommons.hide('#mck-sidebox-ft', '.mck-box-body', '.mck-box-top');
 
-            kommunicateCommons.modifyClassList({ id: ['mck-voice-interface'] }, 'vis', 'n-vis');
-            kommunicateCommons.modifyClassList(
-                { class: ['voice-ring-2', 'voice-ring-3'] },
-                '',
-                'n-vis'
-            );
+            kommunicateCommons.show('#mck-voice-interface');
+            kommunicateCommons.show('.voice-ring-2', '.voice-ring-3');
             kommunicateCommons.modifyClassList(
                 { class: ['voice-ring-1'] },
                 '',
@@ -310,14 +294,7 @@ class MckVoice {
         document.querySelector('#mck-voice-chat-btn').addEventListener('click', () => {
             this.stopRecording(true);
 
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['mck-sidebox-ft'],
-                    class: ['mck-box-body'],
-                },
-                'vis',
-                'n-vis'
-            );
+            kommunicateCommons.show('#mck-sidebox-ft', '.mck-box-body');
 
             document.querySelector('.mck-box-top').classList.remove('n-vis');
 
@@ -326,7 +303,7 @@ class MckVoice {
                 'mck-hidden'
             );
 
-            kommunicateCommons.modifyClassList({ id: ['mck-voice-interface'] }, 'n-vis', 'vis');
+            kommunicateCommons.hide('#mck-voice-interface');
         });
 
         document.querySelector('#mck-voice-speak-btn').addEventListener('click', () => {
@@ -336,11 +313,7 @@ class MckVoice {
                 'mck-hidden'
             );
 
-            kommunicateCommons.modifyClassList(
-                { class: ['voice-ring-2', 'voice-ring-3'] },
-                '',
-                'n-vis'
-            );
+            kommunicateCommons.show('.voice-ring-2', '.voice-ring-3');
             kommunicateCommons.modifyClassList(
                 { class: ['voice-ring-1'] },
                 '',


### PR DESCRIPTION
## Summary
- add `KommunicateUtils.getBooleanOption` for consistent option defaults
- remove unused globals and streamline search tab toggling in the sidebox
- replace remaining `modifyClassList` calls with `show/hide` in nav bar, send button logic, and other UI components
- harden visibility helpers and URL checks and simplify conversation detail merging
- convert leftover attachment icon toggles to `show/hide` and properly spread selector arrays when invoking visibility helpers
- fix widget event tracking to clone shared data and use correct gtag parameter keys

## Testing
- `node --check webplugin/js/app/km-rich-text-event-handler.js`
- `node --check webplugin/js/app/kommunicate-ui.js`
- `node --check webplugin/js/app/mck-sidebox-1.0.js`
- `node --check webplugin/js/app/km-widget-custom-events.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c7b49c1648329adac2930de65dde1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a dedicated search view with easy tab switching between contacts and groups.

- Refactor
  - Unified visibility handling across the widget (chat, attachments, quick replies, waiting queue, voice/mic UI) for smoother, more consistent interactions.
  - Improved disconnect indicator behavior for clearer status feedback.

- Bug Fixes
  - More accurate detection of clickable links in messages.
  - Clearer, more consistent timestamp display on messages.
  - Quick replies and “talk to human” controls now show/hide more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->