### PR TITLE
fix: tighten url extraction and event overrides

### DIFF
--- a/webplugin/js/app/km-widget-custom-events.js
+++ b/webplugin/js/app/km-widget-custom-events.js
@@ -29,14 +29,13 @@ var kmWidgetEvents = {
         // Any other analytics tool related code can be add here no need to paste it in every function
         if (kommunicateCommons.isObject(eventObject)) {
             var data = Object.assign({}, eventObject.data);
-            if (customLabel) {
+            if (customLabel !== undefined) {
                 data.eventLabel = customLabel;
             }
-            if (customValue) {
+            if (customValue !== undefined) {
                 data.eventValue = customValue;
             }
-            kmWidgetEvents.gaTrackingId() &&
-                kmWidgetEvents.sendEventToGoogleAnalytics({ data: data });
+            kmWidgetEvents.sendEventToGoogleAnalytics({ data: data });
             if (eventObject.eventFunction !== null) {
                 // checks if there is any errors in user provided function
                 try {

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -176,7 +176,10 @@ $applozic.extend(true, Kommunicate, {
         return {
             ...conversationDetail,
             WELCOME_MESSAGE: conversationDetail.WELCOME_MESSAGE ?? settings.WELCOME_MESSAGE,
-            defaultAssignee: conversationDetail.assignee ?? settings.defaultAssignee,
+            defaultAssignee:
+                conversationDetail.defaultAssignee ??
+                conversationDetail.assignee ??
+                settings.defaultAssignee,
             agentIds: conversationDetail.agentIds ?? settings.defaultAgentIds,
             botIds: conversationDetail.botIds ?? settings.defaultBotIds,
             skipRouting: conversationDetail.skipRouting ?? settings.skipRouting,

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -138,15 +138,38 @@ function KommunicateCommons() {
     };
 
     _this.setMessagePxyRecipient = function (messagePxy) {
-        var $mck_msg_inner = $applozic('#mck-message-cell .mck-message-inner');
-        var $mck_msg_to = $applozic('#mck-msg-to');
-        if (!$mck_msg_inner.length || !$mck_msg_to.length) {
+        if (typeof window.$applozic !== 'function') {
             return;
         }
-        if ($mck_msg_inner.data('isgroup') === true) {
-            messagePxy.groupId = $mck_msg_to.val();
+
+        var $ = window.$applozic;
+        var $mck_msg_inner = $('#mck-message-cell .mck-message-inner');
+        var $mck_msg_to = $('#mck-msg-to');
+
+        if (!$mck_msg_inner || !$mck_msg_inner.length || !$mck_msg_to || !$mck_msg_to.length) {
+            return;
+        }
+
+        var isgroupVal =
+            typeof $mck_msg_inner.data === 'function' ? $mck_msg_inner.data('isgroup') : undefined;
+        var isGroup = false;
+        if (typeof isgroupVal !== 'undefined') {
+            var normalized = String(isgroupVal).toLowerCase();
+            isGroup =
+                normalized === 'true' ||
+                normalized === '1' ||
+                isgroupVal === true ||
+                isgroupVal === 1;
+        }
+
+        if (isGroup) {
+            if (typeof $mck_msg_to.val === 'function') {
+                messagePxy.groupId = $mck_msg_to.val();
+            }
         } else {
-            messagePxy.to = $mck_msg_to.val();
+            if (typeof $mck_msg_to.val === 'function') {
+                messagePxy.to = $mck_msg_to.val();
+            }
         }
     };
 
@@ -158,7 +181,7 @@ function KommunicateCommons() {
     };
     _this.isMessageContainsUrl = function (message) {
         if (!message) return false;
-        var extractedUrl = message.match(/((https?|ftp):\/\/[^\s]+)/i);
+        var extractedUrl = message.match(/(https?:\/\/[^\s]+)/i);
         return extractedUrl && KommunicateUtils.isURL(extractedUrl[0]) ? extractedUrl[0] : false;
     };
     _this.getTimeOrDate = function (createdAtTime) {


### PR DESCRIPTION
## Summary
- ensure GA custom label/value overrides handle falsy values and always delegate to GA sender
- respect conversationDetail.defaultAssignee over assignee and fallback to settings
- harden message recipient parsing and restrict URL detection to http(s)

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689da04259d08329bb57a298ee766fdf