### PR TITLE
fix: guard against duplicate icon sprite injection

### DIFF
--- a/webplugin/template/mck-icons.js
+++ b/webplugin/template/mck-icons.js
@@ -1,6 +1,10 @@
 (function () {
     var insert = function () {
+        if (document.getElementById('mck-icon-sprite')) {
+            return;
+        }
         var div = document.createElement('div');
+        div.id = 'mck-icon-sprite';
         div.style.display = 'none';
         div.innerHTML = `
 <svg xmlns="http://www.w3.org/2000/svg">
@@ -405,6 +409,9 @@
 `;
         document.body.insertBefore(div, document.body.firstChild);
     };
+    if (document.getElementById('mck-icon-sprite')) {
+        return;
+    }
     if (document.body) {
         insert();
     } else {


### PR DESCRIPTION
## Summary
- add stable `mck-icon-sprite` container for SVG symbols
- avoid reinserting sprite when already present

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2db80c5548329a375156f0eb7dde0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents duplicate icon sprites from being inserted when the script runs multiple times (e.g., re-initialization, SPA navigations, or hot reloads), ensuring consistent rendering and avoiding unnecessary DOM growth. Existing load timing is preserved.
- **Chores**
  - No changes to public APIs or behavior beyond idempotent insertion safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->