### PR TITLE
Changed the ancor link color to blue

### DIFF
--- a/webplugin/scss/abstracts/_variables.scss
+++ b/webplugin/scss/abstracts/_variables.scss
@@ -11,7 +11,7 @@ $km-danger-color: #d64242;
 $disable-input-color: #fafafa;
 $outline-color: #7761f9;
 $popup-boxShadow-color: #04444d26;
-$ancor-link-primary-color:#0000ed
+$ancor-link-primary-color:#0000ed;
 
 //border
 $form-btn-radius: 4px;

--- a/webplugin/scss/abstracts/_variables.scss
+++ b/webplugin/scss/abstracts/_variables.scss
@@ -11,6 +11,7 @@ $km-danger-color: #d64242;
 $disable-input-color: #fafafa;
 $outline-color: #7761f9;
 $popup-boxShadow-color: #04444d26;
+$ancor-link-primary-color:#0000ed
 
 //border
 $form-btn-radius: 4px;

--- a/webplugin/scss/components/_km-message-area.scss
+++ b/webplugin/scss/components/_km-message-area.scss
@@ -124,6 +124,7 @@
         }
 
         a {
+            color: $ancor-link-primary-color;
             text-decoration: none;
             &:hover {
                 color: rgb(218, 85, 47);

--- a/webplugin/scss/components/_km-message-area.scss
+++ b/webplugin/scss/components/_km-message-area.scss
@@ -124,7 +124,6 @@
         }
 
         a {
-            color: $text-primary-color;
             text-decoration: none;
             &:hover {
                 color: rgb(218, 85, 47);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Changed the ancor link color to blue
Before :

<img width="496" height="745" alt="Screenshot 2025-08-18 at 1 31 18 PM" src="https://github.com/user-attachments/assets/1024f5fe-e522-49bb-b32e-d4457e088fcf" />

After :

<img width="480" height="745" alt="Screenshot 2025-08-18 at 1 31 45 PM" src="https://github.com/user-attachments/assets/187ffeb9-31fa-4827-b9a1-57d1cc933de9" />


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated anchor link color in left-side message bubbles to use the app’s primary link color, improving readability and visual consistency; right-side message links unchanged.

* **Chores**
  * Added a theme variable for the primary link color to standardize link styling across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->