### PR TITLE
Replace Chatbot powered by with AI Agent powered by Kommunicate

### DIFF
--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -1651,10 +1651,10 @@
                 </div>
             </div>
             <div class="mck-running-on n-vis notranslate">
-                Chatbot powered by
+                AI Agent powered by
                 <!-- <svg focusable="false" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="10" height="15" style="vertical-align: middle;"><path fill="#513DD8" fill-rule="nonzero" d="M7.69879975.54941587L5.81596948 6.3447902l3.87961917.47635733c.13377998.01642612.19891133.17720919.10092463.28401145l-7.24573967 7.4456573c-.05838132.06073652-.1713319.01291556-.14228864-.0853757l1.54838036-5.83643965-3.71239422-.45582469C.11069114 8.15675014.0455598 7.99596707.1435465 7.8891648L7.55445767.48076424c.06043478-.07746063.17133188-.01291553.14434208.06865163z"/></svg> by -->
                 <a class="mck-powered-by" href="https://www.kommunicate.io" target="_blank">
-                    <span class="n-vis">Kommunicate AI Chatbot</span> Kommunicate.io
+                    <span class="n-vis">Kommunicate AI Agent</span> Kommunicate
                 </a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace "Chatbot powered by" banner text with "AI Agent powered by" and update link label to Kommunicate

## Testing
- `npx prettier --write webplugin/template/mck-sidebox.html`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5b753e10c832988fc225c15333070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebox footer attribution from “Chatbot powered by” to “AI Agent powered by.”
  * Refreshed public-facing branding: link text changed from “Kommunicate AI Chatbot” to “Kommunicate AI Agent,” and displayed domain updated from “Kommunicate.io” to “Kommunicate.”
  * No changes to layout or link destination; only visible text updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->