### PR TITLE
fix: handle clipboard item iteration

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -20,6 +20,17 @@ const CHARACTER_LIMIT = { ES: 256, CX: 500 };
 const WARNING_LENGTH = { ES: 199, CX: 450 };
 const TALK_TO_HUMAN = 'Talk to human';
 
+// DataTransferItemList in some browsers doesn't implement forEach.
+// This polyfill ensures paste handlers using `items.forEach` don't crash.
+if (
+    typeof window !== 'undefined' &&
+    window.DataTransferItemList &&
+    window.DataTransferItemList.prototype &&
+    !window.DataTransferItemList.prototype.forEach
+) {
+    window.DataTransferItemList.prototype.forEach = Array.prototype.forEach;
+}
+
 var userOverride = {
     voiceOutput: true,
 };


### PR DESCRIPTION
## Summary
- polyfill DataTransferItemList.forEach to prevent clipboard paste errors
- revert accidental library modification

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run prettify-commit`


------
https://chatgpt.com/codex/tasks/task_e_68a7f3260dc48329861bbd70c5f4f69f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross‑browser compatibility for paste events to prevent crashes in certain legacy or less common browsers.
  * Ensures smoother pasting of text, images, or files without errors during message composition.
  * Enhances stability for users who experienced failures when pasting content into the widget.
  * No visual or workflow changes; behavior remains unchanged in modern browsers.
  * Overall, users should notice more reliable paste handling and fewer unexpected interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->