### PR TITLE
Fix duplicate mic button ID for voice web

### DIFF
--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -1334,7 +1334,7 @@
                         <svg
                             focusable="false"
                             aria-hidden="true"
-                            id="mck-mic-btn"
+                            id="mck-mic-btn-voice-web"
                             width="24"
                             height="24"
                             viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- rename voice web mic button id to `mck-mic-btn-voice-web` to avoid collision with recorder button

## Testing
- `rg -n 'id="mck-mic-btn"' webplugin/template/mck-sidebox.html`
- `rg -n 'mck-mic-btn-voice-web' -g '!node_modules/**'`
- `rg -n '#mck-mic-btn-voice-web' -g '!node_modules/**'`
- `rg -n 'svg#mck-mic-btn' -g '!node_modules/**'`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a80b1a94a08329b5334082d574d276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal identifier for the microphone button in the side panel component to align with naming conventions. This change does not alter appearance or behavior and requires no action from users. Ensures consistency across UI elements and prepares for future enhancements without impacting current functionality. No downtime expected today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->