### PR TITLE
fixed  List,cards and ListTemplate mesagging display issue

### DIFF
--- a/webplugin/scss/components/_km-carousel-template.scss
+++ b/webplugin/scss/components/_km-carousel-template.scss
@@ -33,11 +33,10 @@
         font-stretch: normal;
         line-height: normal;
         letter-spacing: 0.6px;
-        text-overflow: ellipsis;
+
         overflow: hidden;
-        white-space: nowrap;
+        white-space: wrap;
         max-width: 220px;
-        text-overflow: ellipsis;
     }
     &-sub-title {
         font-size: $heading-secondary;
@@ -75,7 +74,7 @@
         text-overflow: ellipsis;
 
         &-wrapper {
-            height: 44px;
+            min-height: 44px;
         }
 
         &:before {

--- a/webplugin/scss/components/_km-carousel-template.scss
+++ b/webplugin/scss/components/_km-carousel-template.scss
@@ -35,7 +35,7 @@
         letter-spacing: 0.6px;
 
         overflow: hidden;
-        white-space: wrap;
+        white-space: normal;
         max-width: 220px;
     }
     &-sub-title {
@@ -44,8 +44,8 @@
         letter-spacing: 0.5px;
         margin-top: 4px;
         font-weight: 400;
-        overflow: hidden;
-        white-space: wrap;
+
+        white-space: normal;
         padding-right: 20px;
     }
 
@@ -68,8 +68,6 @@
         letter-spacing: 0.5px;
         height: auto;
         white-space: pre-line;
-        text-overflow: ellipsis;
-
         &-wrapper {
             min-height: 44px;
         }

--- a/webplugin/scss/components/_km-carousel-template.scss
+++ b/webplugin/scss/components/_km-carousel-template.scss
@@ -45,9 +45,7 @@
         margin-top: 4px;
         font-weight: 400;
         overflow: hidden;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
+        white-space: wrap;
         padding-right: 20px;
     }
 
@@ -63,7 +61,6 @@
         overflow: hidden;
         position: relative;
         line-height: 14.4px;
-        max-height: 43.2px;
         margin-right: 12px;
         padding-right: 12px;
         margin-top: 4px;

--- a/webplugin/scss/components/_km-faq-card.scss
+++ b/webplugin/scss/components/_km-faq-card.scss
@@ -36,12 +36,11 @@
 .km-faq-list--body_que-ans {
     padding: 10px 12px;
     /*width: calc(100% - 106px);*/
-    max-height: auto;
     overflow: hidden;
     transition: all 0.3s ease-in-out;
 }
 .km-faq-list--body_que-ans * {
-    white-space: wrap;
+    white-space: normal;
 }
 .km-faq-list--body_list li > a:hover {
     background-color: #efefef;
@@ -56,7 +55,7 @@
     .km-faq-list--body_ans {
         color: $text-primary-color;
         font-size: $heading-secondary;
-        white-space: wrap;
+        white-space: normal;
         overflow: hidden;
     }
 

--- a/webplugin/scss/components/_km-faq-card.scss
+++ b/webplugin/scss/components/_km-faq-card.scss
@@ -36,16 +36,12 @@
 .km-faq-list--body_que-ans {
     padding: 10px 12px;
     /*width: calc(100% - 106px);*/
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-height: 51px;
+    max-height: auto;
     overflow: hidden;
     transition: all 0.3s ease-in-out;
 }
 .km-faq-list--body_que-ans * {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    white-space: wrap;
 }
 .km-faq-list--body_list li > a:hover {
     background-color: #efefef;
@@ -60,8 +56,7 @@
     .km-faq-list--body_ans {
         color: $text-primary-color;
         font-size: $heading-secondary;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: wrap;
         overflow: hidden;
     }
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- description was not completely visible on chat widget for list template and cards because of ellipsis property and no wrap.


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.



### Screenshot
- 
<img width="561" height="875" alt="image" src="https://github.com/user-attachments/assets/46ddc563-e2f1-4121-bcb2-574428a3895f" />
<img width="608" height="790" alt="image" src="https://github.com/user-attachments/assets/1b561011-e112-41c5-8eed-99d186fee139" />
<img width="573" height="857" alt="image" src="https://github.com/user-attachments/assets/08249336-0f36-4c4c-90b6-63db699764ac" />
<img width="565" height="840" alt="image" src="https://github.com/user-attachments/assets/6a959763-96c1-4811-a51e-9e08a9a100e1" />


NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Carousel titles and subtitles now wrap instead of truncating; ellipses removed while respecting width limits.
  - Carousel descriptions no longer clipped; content can expand vertically for improved readability.
  - FAQ questions and answers wrap across multiple lines; single-line truncation removed so full text is visible.
  - Improves text legibility across components, especially for longer content and smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->