### PR TITLE
fix: avoid message box focus on touch devices

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -840,7 +840,8 @@ KommunicateUI = {
         }
     },
     activateTypingField: function () {
-        !kommunicateCommons.checkIfDeviceIsHandheld() && $applozic('#mck-text-box').focus();
+        var isTouchDevice = kommunicateCommons.isTouchDevice();
+        !isTouchDevice && $applozic('#mck-text-box').focus();
     },
     setAvailabilityStatus: function (status) {
         kommunicateCommons.show('.mck-agent-image-container');
@@ -1333,7 +1334,7 @@ KommunicateUI = {
         var isPopupEnabled =
             kommunicateCommons.isObject(chatWidget) &&
             chatWidget.popup &&
-            (kommunicateCommons.checkIfDeviceIsHandheld() ? enableGreetingMessage : true);
+            (kommunicateCommons.isTouchDevice() ? enableGreetingMessage : true);
         var delay = popupChatContent && popupChatContent.length ? popupChatContent[0].delay : -1;
         var popupTemplateKey =
             (popupChatContent && popupChatContent.length && popupChatContent[0].templateKey) ||

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -622,7 +622,7 @@ $applozic.extend(true, Kommunicate, {
         Kommunicate.updateChatContext(chatContext);
     },
     setDefaultIframeConfigForOpenChat: function (isPopupEnabled) {
-        !kommunicateCommons.checkIfDeviceIsHandheld() &&
+        !kommunicateCommons.isTouchDevice() &&
             kommunicateCommons.modifyClassList({ id: ['mck-sidebox'] }, 'popup-enabled', '');
         var kommunicateIframe = parent.document.getElementById('kommunicate-widget-iframe');
         var kommunicateIframeDocument = kommunicateIframe.contentDocument;

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -247,6 +247,15 @@ function KommunicateCommons() {
         return check;
     };
 
+    _this.isTouchDevice = function () {
+        return (
+            _this.checkIfDeviceIsHandheld() ||
+            (typeof window !== 'undefined' &&
+                window.matchMedia &&
+                window.matchMedia('(pointer:coarse)').matches)
+        );
+    };
+
     _this.removeHtmlTag = function (html) {
         var temporalDivElement = document.createElement('div');
         temporalDivElement.innerHTML = html;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -630,8 +630,7 @@ const firstVisibleMsg = {
         var CONNECT_SOCKET_ON_WIDGET_CLICK = appOptions.connectSocketOnWidgetClick || false;
         var SUBSCRIBE_TO_EVENTS_BACKUP = [];
         var DEFAULT_ENCRYPTED_APP_VERSION = 111; // Update it to 112 to enable encryption for socket messages.
-        kommunicateCommons.checkIfDeviceIsHandheld() &&
-            (MCK_MAINTAIN_ACTIVE_CONVERSATION_STATE = false);
+        kommunicateCommons.isTouchDevice() && (MCK_MAINTAIN_ACTIVE_CONVERSATION_STATE = false);
 
         _this.toggleMediaOptions = function () {
             var mckTypingBox = document.getElementById('mck-text-box');
@@ -2499,7 +2498,7 @@ const firstVisibleMsg = {
             };
 
             _this.configurePopupWidget = function () {
-                !kommunicateCommons.checkIfDeviceIsHandheld() &&
+                !kommunicateCommons.isTouchDevice() &&
                     kommunicateCommons.modifyClassList(
                         { id: ['mck-sidebox'] },
                         'popup-enabled',
@@ -2601,12 +2600,12 @@ const firstVisibleMsg = {
                 var parentHtmlTag = parent && parent.document.getElementsByTagName('html')[0];
 
                 sideboxLauncher.addEventListener('click', function () {
-                    kommunicateCommons.checkIfDeviceIsHandheld() &&
+                    kommunicateCommons.isTouchDevice() &&
                         (parentBody && parentBody.classList.add('mck-restrict-scroll'),
                         parentHtmlTag && parentHtmlTag.classList.add('mck-restrict-scroll'));
                 });
                 sideboxCloseButton.addEventListener('click', function () {
-                    kommunicateCommons.checkIfDeviceIsHandheld() &&
+                    kommunicateCommons.isTouchDevice() &&
                         (parentBody && parentBody.classList.remove('mck-restrict-scroll'),
                         parentHtmlTag && parentHtmlTag.classList.remove('mck-restrict-scroll'));
                 });

--- a/webplugin/js/app/media/typing-area-dom-service.js
+++ b/webplugin/js/app/media/typing-area-dom-service.js
@@ -3,8 +3,11 @@ var appOption = appOptionSession.getPropertyDataFromSession('appOptions') || app
 Kommunicate.typingAreaService = {
     populateText: function (text) {
         $applozic('#mck-text-box').text(text);
-        $applozic('#mck-text-box').focus();
-        this.setCursorAtTheEndOfInputString();
+        var isTouchDevice = kommunicateCommons.isTouchDevice();
+        if (!isTouchDevice) {
+            $applozic('#mck-text-box').focus();
+            this.setCursorAtTheEndOfInputString();
+        }
     },
     setCursorAtTheEndOfInputString: function (el) {
         el = el || document.getElementById('mck-text-box');


### PR DESCRIPTION
## Summary
- consolidate handheld detection by letting `isTouchDevice` reuse `checkIfDeviceIsHandheld`
- replace scattered `checkIfDeviceIsHandheld` calls with unified `isTouchDevice` across UI and sidebox modules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b98207e6008329ab3a554fe62cd01c