### PR TITLE
Revert "fixed spinner"

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -3550,7 +3550,6 @@ ul.mck-intent-menu > li:hover {
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 2;
 }
 
 .mck-sidebox-search .mck-loading {

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -556,7 +556,7 @@
                         </div>
                     </div>
 
-                    <div id="mck-contact-loading" class="mck-loading n-vis">
+                    <div id="mck-contact-loading" class="mck-loading">
                         <svg
                             focusable="false"
                             aria-hidden="true"
@@ -1795,7 +1795,7 @@
                                 height="50"
                             >
                                 <circle
-                                    class="mck-spinner-path"
+                                    class="path"
                                     cx="50"
                                     cy="50"
                                     r="20"
@@ -2162,7 +2162,7 @@
                             height="50"
                         >
                             <circle
-                                class="mck-spinner-path"
+                                class="path"
                                 cx="50"
                                 cy="50"
                                 r="20"


### PR DESCRIPTION
Reverts Kommunicate-io/Kommunicate-Web-SDK#1387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Loading indicator in the side panel is now visible by default during contact fetches.
  - Adjusted hover behavior in the intent menu to follow normal stacking, reducing unintended overlap with nearby elements.

- Style
  - Unified spinner visuals across the app for consistency, including contact loading, feedback submission, and add member flows.
  - Minor visual refinements to loading indicators for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->