### PR TITLE
Avoid auto open of widget when prechatlead is enabled

### DIFF
--- a/example/demo2.html
+++ b/example/demo2.html
@@ -14,7 +14,7 @@
                     // appId: '39187bcfc4dfd93e485509a19be3ed665',
                     appId: 'kommunicate-support',
                     popupWidget: true,
-                    layout: 'modern',
+                    layout: 'classic',
                     automaticChatOpenOnNavigation: true,
                     // appSettings: {
                     //     chatWidget: {
@@ -33,7 +33,7 @@
                     //     ],
                     // },
                     widgetSettings: {
-                        popup: false,
+                        // popup: false,
                         // primaryColor: '#fff000',
                         // Provide a `theme` map to override exposed CSS vars.
                         // Alias keys like `chatHeaderText` explain what each color controls.
@@ -63,18 +63,19 @@
                         },
                     ],
 
-                    //      "preLeadCollection": [{
-                    //         "field": "Name", // Name of the field you want to add
-                    //         "required": true, // Set 'true' to make it a mandatory field
-                    //         "placeholder": "Enter your name" // add whatever text you want to show in the placeholder
-                    //     },
-                    //     {
-                    //         "field": "Email",
-                    //         "type": "email",
-                    //         "required": true,
-                    //         "placeholder": "Enter your email"
-                    //     }
-                    // ]
+                    preLeadCollection: [
+                        {
+                            field: 'Name', // Name of the field you want to add
+                            required: true, // Set 'true' to make it a mandatory field
+                            placeholder: 'Enter your name', // add whatever text you want to show in the placeholder
+                        },
+                        {
+                            field: 'Email',
+                            type: 'email',
+                            required: true,
+                            placeholder: 'Enter your email',
+                        },
+                    ],
                 };
                 var s = document.createElement('script');
                 s.type = 'text/javascript';

--- a/example/demo2.html
+++ b/example/demo2.html
@@ -14,7 +14,7 @@
                     // appId: '39187bcfc4dfd93e485509a19be3ed665',
                     appId: 'kommunicate-support',
                     popupWidget: true,
-                    layout: 'classic',
+                    layout: 'modern',
                     automaticChatOpenOnNavigation: true,
                     // appSettings: {
                     //     chatWidget: {

--- a/webplugin/js/app/conversation/mail-parser/dom-service.js
+++ b/webplugin/js/app/conversation/mail-parser/dom-service.js
@@ -1,10 +1,20 @@
 class EmailDOMService {
     static createEmailContainer(message, group) {
         const containerId = `km-email-${message.groupId}-${message.key}`;
-        const container = document.getElementById(containerId);
+        let container = document.getElementById(containerId);
 
         if (!container) {
-            throw new Error(`Email container not found: ${containerId}`);
+            const messageElem = document.querySelector(`[data-msgkey="${message.key}"]`);
+            const richTextContainer = messageElem
+                ? messageElem.querySelector('.km-msg-box-rich-text-container')
+                : null;
+            if (!richTextContainer) {
+                throw new Error(`Email container not found: ${containerId}`);
+            }
+            container = document.createElement('mck-email-rich-message');
+            container.id = containerId;
+            container.className = `km-mail-fixed-view ${containerId} mck-eml-container`;
+            richTextContainer.appendChild(container);
         }
 
         const shadowRoot = container.shadowRoot;

--- a/webplugin/js/app/conversation/mail-parser/dom-service.js
+++ b/webplugin/js/app/conversation/mail-parser/dom-service.js
@@ -11,13 +11,19 @@ class EmailDOMService {
             if (!richTextContainer) {
                 throw new Error(`Email container not found: ${containerId}`);
             }
-            container = document.createElement('mck-email-rich-message');
+            const supportsShadowDom =
+                typeof window !== 'undefined' &&
+                window.customElements &&
+                Element.prototype.attachShadow;
+            container = supportsShadowDom
+                ? document.createElement('mck-email-rich-message')
+                : document.createElement('div');
             container.id = containerId;
             container.className = `km-mail-fixed-view ${containerId} mck-eml-container`;
             richTextContainer.appendChild(container);
         }
 
-        const shadowRoot = container.shadowRoot;
+        const root = container.shadowRoot || container;
         const style = document.createElement('style');
         style.setAttribute('type', 'text/css');
         style.innerHTML = kmMailProcessor.getEmailRichMsgStyle();
@@ -32,7 +38,7 @@ class EmailDOMService {
             }`
         );
 
-        shadowRoot.append(style, mailElement);
+        root.append(style, mailElement);
         return mailElement;
     }
 
@@ -58,9 +64,11 @@ class EmailDOMService {
             const kmEmailRichMsg = document.getElementById(
                 'km-email-' + message.groupId + '-' + message.key
             );
-            const kmEmailMainContainer = kmEmailRichMsg.shadowRoot.querySelector(
-                '.km-email-rich-msg-container'
-            );
+            if (!kmEmailRichMsg) {
+                return;
+            }
+            const kmEmailRoot = kmEmailRichMsg.shadowRoot || kmEmailRichMsg;
+            const kmEmailMainContainer = kmEmailRoot.querySelector('.km-email-rich-msg-container');
 
             kmEmailMainContainer.innerHTML = emlToHtml ? message.emlContent : message.message;
 

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1483,6 +1483,8 @@ KommunicateUI = {
                 KommunicateConstants.CHAT_POPUP_TEMPLATE_CLASS[popupTemplateKey];
 
             kommunicateIframe.classList.add(popupTemplateClass.replace('-container-', ''));
+            kommunicateIframe.style.height = '';
+            kommunicateIframe.style.minHeight = '';
 
             popupTemplateKey === KommunicateConstants.CHAT_POPUP_TEMPLATE.HORIZONTAL &&
                 kommunicateCommons.modifyClassList(

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -31,6 +31,7 @@ KommunicateUI = {
     leadCollectionEnabledOnAwayMessage: false,
     welcomeMessageEnabled: false,
     leadCollectionEnabledOnWelcomeMessage: false,
+    skipPopupChatTemplate: false,
     anonymousUser: false,
     isCSATtriggeredByUser: false,
     isConvJustResolved: false,
@@ -1421,6 +1422,9 @@ KommunicateUI = {
         chatWidget,
         mckChatPopupNotificationTone
     ) {
+        if (KommunicateUI.skipPopupChatTemplate) {
+            return;
+        }
         console.log('displayPopupChatTemplate', {
             hasContent: Boolean(popupChatContent && popupChatContent.length),
             chatWidgetPopup: chatWidget && chatWidget.popup,

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1421,6 +1421,10 @@ KommunicateUI = {
         chatWidget,
         mckChatPopupNotificationTone
     ) {
+        console.log('displayPopupChatTemplate', {
+            hasContent: Boolean(popupChatContent && popupChatContent.length),
+            chatWidgetPopup: chatWidget && chatWidget.popup,
+        });
         var enableGreetingMessage =
             kommunicateCommons.isObject(chatWidget) &&
             chatWidget.hasOwnProperty('enableGreetingMessageInMobile')
@@ -1436,6 +1440,10 @@ KommunicateUI = {
             KommunicateConstants.CHAT_POPUP_TEMPLATE.HORIZONTAL;
         if (isPopupEnabled && delay > -1) {
             MCK_CHAT_POPUP_TEMPLATE_TIMER = setTimeout(function () {
+                console.log('calling togglePopupChatTemplate', {
+                    templateKey: popupTemplateKey,
+                    delay,
+                });
                 KommunicateUI.togglePopupChatTemplate(
                     popupTemplateKey,
                     true,
@@ -1457,7 +1465,12 @@ KommunicateUI = {
         var playPopupTone = appOptionSession.getPropertyDataFromSession(
             'playPopupNotificationTone'
         );
-        if (showTemplate && !kommunicateCommons.isWidgetOpen()) {
+        console.log('togglePopupChatTemplate called', {
+            templateKey: popupTemplateKey,
+            showTemplate,
+            widgetOpen: kommunicateCommons.isWidgetOpen(),
+        });
+        if (showTemplate) {
             if (playPopupTone == null || playPopupTone) {
                 mckChatPopupNotificationTone && mckChatPopupNotificationTone.play();
                 appOptionSession.setSessionData('playPopupNotificationTone', false);

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2317,8 +2317,6 @@ const firstVisibleMsg = {
                                 }
                             );
                         }
-                        PRE_CHAT_LEAD_COLLECTION_MODAL_AUTO_OPENED = true;
-
                         if (
                             $applozic('#km-form-chat-login .km-form-group input').hasClass('n-vis')
                         ) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2129,11 +2129,6 @@ const firstVisibleMsg = {
                             mckInit.initialize(options);
                             return false;
                         }
-                        Kommunicate.popupChatTemplate.getPopupChatTemplate(
-                            MCK_POPUP_WIDGET_CONTENT,
-                            WIDGET_SETTINGS,
-                            true
-                        );
                         var kmAnonymousChatLauncher = document.getElementById(
                             'km-anonymous-chat-launcher'
                         );
@@ -2182,6 +2177,11 @@ const firstVisibleMsg = {
                             kmChatLoginModal.setAttribute('aria-hidden', 'true');
                         }
                         kommunicateCommons.show(kmAnonymousChatLauncher);
+                        Kommunicate.popupChatTemplate.getPopupChatTemplate(
+                            MCK_POPUP_WIDGET_CONTENT,
+                            WIDGET_SETTINGS,
+                            true
+                        );
                         document
                             .getElementById('km-modal-close')
                             .addEventListener('click', _this.closeLeadCollectionWindow);
@@ -2241,6 +2241,12 @@ const firstVisibleMsg = {
                             WIDGET_SETTINGS,
                             mckChatPopupNotificationTone
                         );
+                        console.log('prechat displayPopupChatTemplate branch', {
+                            hasContent: Boolean(
+                                MCK_POPUP_WIDGET_CONTENT && MCK_POPUP_WIDGET_CONTENT.length
+                            ),
+                            widgetPopup: WIDGET_SETTINGS && WIDGET_SETTINGS.popup,
+                        });
                     } else {
                         _this.initialize(userPxy);
                     }
@@ -2513,12 +2519,14 @@ const firstVisibleMsg = {
                 ) {
                     PRE_CHAT_LEAD_COLLECTION_POPUP_ON &&
                         $applozic.fn.applozic('mckLaunchSideboxChat');
-                    !PRE_CHAT_LEAD_COLLECTION_POPUP_ON &&
-                        KommunicateUI.displayPopupChatTemplate(
-                            MCK_POPUP_WIDGET_CONTENT,
-                            WIDGET_SETTINGS,
-                            mckChatPopupNotificationTone
-                        );
+                    KommunicateUI.displayPopupChatTemplate(
+                        MCK_POPUP_WIDGET_CONTENT,
+                        WIDGET_SETTINGS,
+                        mckChatPopupNotificationTone
+                    );
+                    console.log('pre-lead init branch running before login', {
+                        popupContent: MCK_POPUP_WIDGET_CONTENT && MCK_POPUP_WIDGET_CONTENT.length,
+                    });
                 } else {
                     $applozic.fn.applozic('triggerMsgNotification');
                     !MCK_TRIGGER_MSG_NOTIFICATION_TIMEOUT &&

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2227,8 +2227,7 @@ const firstVisibleMsg = {
                                 }
                             );
                         }
-                        PRE_CHAT_LEAD_COLLECTION_MODAL_AUTO_OPENED = false;
-                        autoOpenPreChatLeadCollectionModal(kmAnonymousChatLauncher);
+                        PRE_CHAT_LEAD_COLLECTION_MODAL_AUTO_OPENED = true;
 
                         if (
                             $applozic('#km-form-chat-login .km-form-group input').hasClass('n-vis')


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Avoid auto open of widget when pre chat lead collection is enabled

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented premature pre-chat/modal auto-open by deferring display until the widget iframe is initialized.

* **Improvements**
  * Unified and delayed widget iframe setup for more consistent lead-collection flows.
  * Render email-rich message containers dynamically when missing to avoid hard failures.
  * Popup template display made less gated and more consistent; iframe sizing resets when showing popups.

* **New Features**
  * Configurable pre-lead fields enabled (Name, Email).
  * New feature flag to skip popup chat template.

* **Chores**
  * Added runtime debug logs to trace widget/modal and popup behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->