### PR TITLE
CSAT placeholder and other improvements

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -4387,6 +4387,7 @@ ul.mck-intent-menu > li:hover {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding: 0 16px;
 }
 .km-header-container {
     display: flex;
@@ -5715,7 +5716,38 @@ div#mck-waiting-queue {
     ) !important;
 }
 .km-faq-and-close-btn-container {
+    display: flex;
+    align-items: center;
     justify-content: flex-end;
+    gap: 6px;
+}
+.km-faq-and-close-btn-container .km-kb-container {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.km-faq-and-close-btn-container .km-widget-options-button {
+    margin-right: 0;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+}
+.km-faq-and-close-btn-container .mck-close-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.km-faq-and-close-btn-container #km-chat-widget-close-button {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
 }
 
 .mck-cont-msg-date {

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -3435,6 +3435,10 @@ div#mck-rated:before {
   width: 20px;
 }
 
+.mck-title {
+  padding: 0 16px;
+}
+
 .mck-sidebox .mck-tab-title,
 .mck-sidebox .mck-tab-title-w-status,
 .mck-sidebox .mck-tab-title-w-typing,
@@ -3504,6 +3508,41 @@ div#mck-rated:before {
 .mck-search-tab-box,
 .mck-search-box-top {
   background-color: rgba(241, 241, 241, 0.6);
+}
+
+.km-faq-and-close-btn-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.km-faq-and-close-btn-container .km-kb-container {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.km-faq-and-close-btn-container .km-widget-options-button {
+  margin-right: 0;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+.km-faq-and-close-btn-container .mck-close-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.km-faq-and-close-btn-container #km-chat-widget-close-button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
 }
 
 .mck-gm-search-box .mck-box-top .blk-lg-3 {

--- a/webplugin/js/app/kommunicate.custom.theme.js
+++ b/webplugin/js/app/kommunicate.custom.theme.js
@@ -223,6 +223,10 @@ function KmCustomTheme() {
                 });
             }
         });
+        if (isClassicLayout() && !hasThemeValue(overrides['--km-on-primary'])) {
+            console.log('overriding --km-on-primary for classic layout');
+            overrides['--km-on-primary'] = '#ffffff';
+        }
         return overrides;
     }
 
@@ -238,9 +242,7 @@ function KmCustomTheme() {
             additionalVars || {},
             customVars
         );
-        if (isClassicLayout() && !hasThemeValue(mergedVars['--km-on-primary'])) {
-            mergedVars['--km-on-primary'] = '#ffffff';
-        }
+
         Object.keys(mergedVars).forEach(function (name) {
             var value = mergedVars[name];
             if (value != null) {
@@ -281,7 +283,6 @@ function KmCustomTheme() {
     }
 
     _this.changeColorTheme = function () {
-        // #0A090C
         var primaryColor =
             (WIDGET_SETTINGS && WIDGET_SETTINGS.primaryColor) || DEFAULT_BACKGROUND_COLOR;
         if (!primaryColor) {

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -138,6 +138,16 @@ class KMLabel {
                 node.setAttribute('placeholder', value);
             });
         };
+        var setPlaceholderAndAriaLabelForSelector = function (selector, path) {
+            var value = resolveLabel(path);
+            if (value === null || typeof value === 'undefined') {
+                return;
+            }
+            getNodes(selector).forEach(function (node) {
+                node.setAttribute('placeholder', value);
+                node.setAttribute('aria-label', value);
+            });
+        };
 
         [
             { selector: '#mck-conversation-title', path: 'conversations.title' },
@@ -215,6 +225,10 @@ class KMLabel {
             'search.placeholder'
         );
         setPlaceholderForSelector('#mck-loc-address', 'location.placeholder');
+        setPlaceholderAndAriaLabelForSelector(
+            '#mck-feedback-comment',
+            'csat.rating.CONVERSATION_REVIEW_PLACEHOLDER'
+        );
         document.getElementById('mck-text-box').dataset.text = MCK_LABELS['input.message'];
         document.getElementById('mck-char-warning-text').innerHTML = MCK_LABELS['char.limit.warn'];
         document

--- a/webplugin/scss/components/_km-widget-header.scss
+++ b/webplugin/scss/components/_km-widget-header.scss
@@ -23,6 +23,10 @@
     }
 }
 
+.mck-title {
+    padding: 0 16px;
+}
+
 .mck-sidebox .mck-tab-title,
 .mck-sidebox .mck-tab-title-w-status,
 .mck-sidebox .mck-tab-title-w-typing,
@@ -91,6 +95,45 @@
 .mck-search-tab-box,
 .mck-search-box-top {
     background-color: rgba(241, 241, 241, 0.6);
+}
+
+.km-faq-and-close-btn-container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+
+    .km-kb-container {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .km-widget-options-button {
+        margin-right: 0;
+        padding: 0;
+        width: 32px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;
+    }
+
+    .mck-close-btn {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    #km-chat-widget-close-button {
+        width: 32px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;
+    }
 }
 
 .mck-gm-search-box .mck-box-top .blk-lg-3 {

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -904,8 +904,6 @@
                             cols="34"
                             maxlength="90"
                             id="mck-feedback-comment"
-                            placeholder="(optional)"
-                            aria-label="(optional)"
                             tabindex="0"
                             rows="4"
                         ></textarea>


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- CSAT placeholder
- Classic layout override on primary color is not set
- Correcting icon spacing on header part
Prev
<img width="846" height="128" alt="Screenshot 2025-12-31 at 6 45 29 PM" src="https://github.com/user-attachments/assets/1e830cae-5790-4d7a-86ad-d573eccb6084" />




Now
<img width="929" height="160" alt="Screenshot 2025-12-31 at 6 45 34 PM" src="https://github.com/user-attachments/assets/ba4b4406-2b41-40c6-b960-5a57bbb2e165" />

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved classic-layout color handling to ensure consistent contrast.

* **Accessibility**
  * Feedback comment field now sets both placeholder text and ARIA label for better screen-reader support.

* **Style / UI Improvements**
  * Refined header and FAQ/close-button layout and spacing; increased hover hit area for intent list items.

* **Chores**
  * Removed legacy fallback logic and minor cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->