### PR TITLE
Fix form label text overflowing outside the container in widget UI.

### DIFF
--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -2248,6 +2248,8 @@ input[type=number]::-webkit-outer-spin-button {
   color: #6e6e6e;
   letter-spacing: 0.36px;
   margin-left: 0 !important;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .mck-form-error-container {

--- a/webplugin/scss/components/_km-form-template.scss
+++ b/webplugin/scss/components/_km-form-template.scss
@@ -83,6 +83,8 @@
     color: $text-tertiary-color;
     letter-spacing: 0.36px;
     margin-left: 0 !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .mck-form-error-container {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
Fix form label text overflowing outside the container in widget UI.
-

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
