### PR TITLE
Fix/textbox autobreak issue

### DIFF
--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -2252,6 +2252,10 @@ input[type=number]::-webkit-outer-spin-button {
   word-break: break-word;
 }
 
+#mck-text-box {
+  word-break: normal;
+}
+
 .mck-form-error-container {
   display: flex;
 }

--- a/webplugin/scss/components/_km-form-template.scss
+++ b/webplugin/scss/components/_km-form-template.scss
@@ -87,6 +87,10 @@
     word-break: break-word;
 }
 
+#mck-text-box {
+    word-break: normal;
+}
+
 .mck-form-error-container {
     display: flex;
     @include gap-supported(2px, 0 2px 0 0, '& svg');


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
Text should wrap at word boundaries only, keeping whole words on the same line and preventing mid‑word splits.
Example : "Statement" should stay on one line; no mid‑word breaks like “statem” / “ent”.
-

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
