### PR TITLE
Fix powered-by visibility in modern layout

### DIFF
--- a/webplugin/css/app/mck-tab-visibility.css
+++ b/webplugin/css/app/mck-tab-visibility.css
@@ -211,11 +211,8 @@
 .layout-modern #mck-sidebox-content .mck-running-on {
   display: none !important;
 }
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.vis {
+.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
   display: block !important;
-}
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.n-vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.n-vis {
-  display: none !important;
 }
 .layout-modern #km-faq {
   display: none !important;

--- a/webplugin/css/app/mck-tab-visibility.css
+++ b/webplugin/css/app/mck-tab-visibility.css
@@ -208,12 +208,6 @@
 .layout-modern #mck-sidebox-content.active-tab-faqs .km-kb-container #km-faq {
   display: none !important;
 }
-.layout-modern #mck-sidebox-content .mck-running-on {
-  display: none !important;
-}
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
-  display: block !important;
-}
 .layout-modern #km-faq {
   display: none !important;
 }

--- a/webplugin/css/app/mck-tab-visibility.css
+++ b/webplugin/css/app/mck-tab-visibility.css
@@ -211,8 +211,11 @@
 .layout-modern #mck-sidebox-content .mck-running-on {
   display: none !important;
 }
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
+.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.vis {
   display: block !important;
+}
+.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.n-vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.n-vis {
+  display: none !important;
 }
 .layout-modern #km-faq {
   display: none !important;

--- a/webplugin/css/app/mck-tab-visibility.css
+++ b/webplugin/css/app/mck-tab-visibility.css
@@ -208,6 +208,13 @@
 .layout-modern #mck-sidebox-content.active-tab-faqs .km-kb-container #km-faq {
   display: none !important;
 }
+.layout-modern #mck-sidebox-content.km-poweredby-enabled.active-tab-conversations.active-subsection-conversation-individual .mck-running-on,
+.layout-modern #mck-sidebox-content.km-poweredby-enabled.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
+  display: block !important;
+}
+.layout-modern #mck-sidebox-content.km-poweredby-enabled:not(.active-tab-conversations.active-subsection-conversation-individual):not(.is-tab-conversations.is-subsection-conversation-individual) .mck-running-on {
+  display: none !important;
+}
 .layout-modern #km-faq {
   display: none !important;
 }

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -4882,12 +4882,6 @@ div#mck-rated:before {
 .layout-modern #mck-sidebox-content.active-tab-faqs .km-kb-container #km-faq {
   display: none !important;
 }
-.layout-modern #mck-sidebox-content .mck-running-on {
-  display: none !important;
-}
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
-  display: block !important;
-}
 .layout-modern #km-faq {
   display: none !important;
 }

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -4882,6 +4882,13 @@ div#mck-rated:before {
 .layout-modern #mck-sidebox-content.active-tab-faqs .km-kb-container #km-faq {
   display: none !important;
 }
+.layout-modern #mck-sidebox-content.km-poweredby-enabled.active-tab-conversations.active-subsection-conversation-individual .mck-running-on,
+.layout-modern #mck-sidebox-content.km-poweredby-enabled.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
+  display: block !important;
+}
+.layout-modern #mck-sidebox-content.km-poweredby-enabled:not(.active-tab-conversations.active-subsection-conversation-individual):not(.is-tab-conversations.is-subsection-conversation-individual) .mck-running-on {
+  display: none !important;
+}
 .layout-modern #km-faq {
   display: none !important;
 }

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -4885,8 +4885,11 @@ div#mck-rated:before {
 .layout-modern #mck-sidebox-content .mck-running-on {
   display: none !important;
 }
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
+.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.vis {
   display: block !important;
+}
+.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.n-vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.n-vis {
+  display: none !important;
 }
 .layout-modern #km-faq {
   display: none !important;

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -4885,11 +4885,8 @@ div#mck-rated:before {
 .layout-modern #mck-sidebox-content .mck-running-on {
   display: none !important;
 }
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.vis {
+.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on {
   display: block !important;
-}
-.layout-modern #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-running-on.n-vis, .layout-modern #mck-sidebox-content.is-tab-conversations.is-subsection-conversation-individual .mck-running-on.n-vis {
-  display: none !important;
 }
 .layout-modern #km-faq {
   display: none !important;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2827,6 +2827,9 @@ const firstVisibleMsg = {
                 });
                 // Showing powered by kommunicate for all, will be removed incase of white label enterprises.
                 var showPoweredBy = kommunicateCommons.showPoweredBy(data);
+                var sideboxContent = document.getElementById('mck-sidebox-content');
+                sideboxContent &&
+                    sideboxContent.classList.toggle('km-poweredby-enabled', !!showPoweredBy);
                 if (showPoweredBy) {
                     var kommunicateIframe = parent.document.getElementById(
                         'kommunicate-widget-iframe'

--- a/webplugin/scss/components/_km-tab-visibility-layouts.scss
+++ b/webplugin/scss/components/_km-tab-visibility-layouts.scss
@@ -29,18 +29,6 @@
         display: none !important;
     }
 
-    // #mck-sidebox-content {
-    //     .mck-running-on {
-    //         display: none !important;
-    //     }
-
-    //     &.active-tab-conversations.active-subsection-conversation-individual,
-    //     &.is-tab-conversations.is-subsection-conversation-individual {
-    //         .mck-running-on {
-    //             display: block !important;
-    //         }
-    //     }
-    // }
     #km-faq {
         display: none !important;
     }

--- a/webplugin/scss/components/_km-tab-visibility-layouts.scss
+++ b/webplugin/scss/components/_km-tab-visibility-layouts.scss
@@ -36,8 +36,11 @@
 
         &.active-tab-conversations.active-subsection-conversation-individual,
         &.is-tab-conversations.is-subsection-conversation-individual {
-            .mck-running-on {
+            .mck-running-on.vis {
                 display: block !important;
+            }
+            .mck-running-on.n-vis {
+                display: none !important;
             }
         }
     }

--- a/webplugin/scss/components/_km-tab-visibility-layouts.scss
+++ b/webplugin/scss/components/_km-tab-visibility-layouts.scss
@@ -36,11 +36,8 @@
 
         &.active-tab-conversations.active-subsection-conversation-individual,
         &.is-tab-conversations.is-subsection-conversation-individual {
-            .mck-running-on.vis {
+            .mck-running-on {
                 display: block !important;
-            }
-            .mck-running-on.n-vis {
-                display: none !important;
             }
         }
     }

--- a/webplugin/scss/components/_km-tab-visibility-layouts.scss
+++ b/webplugin/scss/components/_km-tab-visibility-layouts.scss
@@ -29,6 +29,18 @@
         display: none !important;
     }
 
+    #mck-sidebox-content.km-poweredby-enabled.active-tab-conversations.active-subsection-conversation-individual,
+    #mck-sidebox-content.km-poweredby-enabled.is-tab-conversations.is-subsection-conversation-individual {
+        .mck-running-on {
+            display: block !important;
+        }
+    }
+
+    #mck-sidebox-content.km-poweredby-enabled:not(.active-tab-conversations.active-subsection-conversation-individual):not(.is-tab-conversations.is-subsection-conversation-individual) {
+        .mck-running-on {
+            display: none !important;
+        }
+    }
     #km-faq {
         display: none !important;
     }

--- a/webplugin/scss/components/_km-tab-visibility-layouts.scss
+++ b/webplugin/scss/components/_km-tab-visibility-layouts.scss
@@ -29,18 +29,18 @@
         display: none !important;
     }
 
-    #mck-sidebox-content {
-        .mck-running-on {
-            display: none !important;
-        }
+    // #mck-sidebox-content {
+    //     .mck-running-on {
+    //         display: none !important;
+    //     }
 
-        &.active-tab-conversations.active-subsection-conversation-individual,
-        &.is-tab-conversations.is-subsection-conversation-individual {
-            .mck-running-on {
-                display: block !important;
-            }
-        }
-    }
+    //     &.active-tab-conversations.active-subsection-conversation-individual,
+    //     &.is-tab-conversations.is-subsection-conversation-individual {
+    //         .mck-running-on {
+    //             display: block !important;
+    //         }
+    //     }
+    // }
     #km-faq {
         display: none !important;
     }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-When Kommunicate branding is disabled, the powered‑by label should be hidden in both classic and modern layouts.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * The running indicator’s visibility in the modern layout is now conditional: it appears only when the "Powered by" branding is enabled and when specific conversation tabs/subsections are active; otherwise it’s hidden.
* **UX**
  * The "Powered by" badge display now follows the product setting more consistently, so its presence can change how the running indicator is shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->