### PR TITLE
TDH-3306: Default preCreateUser to false

### DIFF
--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -395,6 +395,11 @@ function ApplozicSidebox() {
             if (options.labels && options.labels['lead.collection']?.heading) {
                 options['headingFromWidget'] = true;
             }
+            var userIdFromKommunicateSettings = options.userId;
+            var hasUserIdFromKommunicateSettings =
+                userIdFromKommunicateSettings != null &&
+                (typeof userIdFromKommunicateSettings !== 'string' ||
+                    userIdFromKommunicateSettings.trim().length > 0);
             var widgetSettingsFromApi = data.chatWidget || {};
             var localWidgetSettings =
                 options.widgetSettings && typeof options.widgetSettings === 'object'
@@ -591,11 +596,8 @@ function ApplozicSidebox() {
                     ? options.staticTopIcon
                     : widgetSettings && widgetSettings.staticTopIcon;
             options.preCreateUser =
-                options.preCreateUser != null
-                    ? options.preCreateUser
-                    : widgetSettings && widgetSettings.preCreateUser != null
-                    ? widgetSettings.preCreateUser
-                    : false;
+                hasUserIdFromKommunicateSettings ||
+                (widgetSettings && widgetSettings.preCreateUser);
 
             options.primaryCTA = isSettingEnable('primaryCTA');
             options.talkToHuman = isSettingEnable('talkToHuman');

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -395,11 +395,6 @@ function ApplozicSidebox() {
             if (options.labels && options.labels['lead.collection']?.heading) {
                 options['headingFromWidget'] = true;
             }
-            var userIdFromKommunicateSettings = options.userId;
-            var hasUserIdFromKommunicateSettings =
-                userIdFromKommunicateSettings != null &&
-                (typeof userIdFromKommunicateSettings !== 'string' ||
-                    userIdFromKommunicateSettings.trim().length > 0);
             var widgetSettingsFromApi = data.chatWidget || {};
             var localWidgetSettings =
                 options.widgetSettings && typeof options.widgetSettings === 'object'
@@ -596,8 +591,11 @@ function ApplozicSidebox() {
                     ? options.staticTopIcon
                     : widgetSettings && widgetSettings.staticTopIcon;
             options.preCreateUser =
-                hasUserIdFromKommunicateSettings ||
-                (widgetSettings && widgetSettings.preCreateUser);
+                options.preCreateUser != null
+                    ? options.preCreateUser
+                    : widgetSettings && widgetSettings.preCreateUser != null
+                    ? widgetSettings.preCreateUser
+                    : false;
 
             options.primaryCTA = isSettingEnable('primaryCTA');
             options.talkToHuman = isSettingEnable('talkToHuman');

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -62,7 +62,7 @@ const firstVisibleMsg = {
         olStatus: false,
         unreadCountOnchatLauncher: true,
         openConversationOnNewMessage: false, // default value
-        preCreateUser: true,
+        preCreateUser: false,
         //      awsS3Server :false,
         groupUserCount: false,
         desktopNotification: true,


### PR DESCRIPTION
## Summary
- default preCreateUser to false in sidebox defaults
- respect widgetSettings.preCreateUser unless overridden via kommunicateSettings

## Testing
- not run (config-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Automatic user pre-creation during widget initialization is now disabled by default.
  * Initialization now follows an explicit cascade: use an explicit setting if provided, otherwise fall back to widget configuration, otherwise default to disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->