### PR TITLE
Change in Rich message(List) UI

### DIFF
--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -2966,19 +2966,18 @@ input[type=number]::-webkit-outer-spin-button {
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.km-faq-list--body_list li {
-  margin-bottom: 12px;
+  margin-bottom: 0px !important;
 }
 
 .km-faq-list--body_list li > a {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
   text-decoration: none;
   border: 1px solid rgba(114, 134, 211, 0.2);
-  border-radius: 20px;
-  padding: 16px 18px;
+  margin-bottom: 0px;
+  padding: 8px;
   color: #1c2043;
   background: linear-gradient(180deg, #ffffff 0%, #f9fbff 100%);
   box-shadow: 0 10px 24px rgba(71, 92, 168, 0.12);
@@ -3021,7 +3020,7 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 .km-faq-list--body_img {
-  padding: 10px 0px 10px 12px;
+  padding: 0;
   /*width: 70px;*/
   height: 50px;
   border-radius: 4px;
@@ -3047,7 +3046,7 @@ input[type=number]::-webkit-outer-spin-button {
   font-size: 18px;
   bottom: 2px;
   left: 12px;
-  margin: 0;
+  margin: 0px !important;
   padding: 12px 16px !important;
   text-align: left;
   word-wrap: break-word;

--- a/webplugin/scss/components/_km-faq-card.scss
+++ b/webplugin/scss/components/_km-faq-card.scss
@@ -20,18 +20,18 @@
     list-style: none;
     margin: 0;
     padding: 0;
-}
-.km-faq-list--body_list li {
-    margin-bottom: 12px;
+    margin-bottom: 0px !important ;
 }
 
 .km-faq-list--body_list li > a {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
     text-decoration: none;
     border: 1px solid rgba(114, 134, 211, 0.2);
-    border-radius: 20px;
-    padding: 16px 18px;
+    margin-bottom: 0px;
+    padding: 8px;
     color: #1c2043;
     background: linear-gradient(180deg, #ffffff 0%, #f9fbff 100%);
     box-shadow: 0 10px 24px rgba(71, 92, 168, 0.12);
@@ -75,7 +75,7 @@
 }
 
 .km-faq-list--body_img {
-    padding: 10px 0px 10px 12px;
+    padding: 0;
     /*width: 70px;*/
     height: 50px;
     border-radius: 4px;
@@ -98,7 +98,7 @@
     font-size: 18px;
     bottom: 2px;
     left: 12px;
-    margin: 0;
+    margin: 0px !important;
     padding: $msg-box-padding !important;
     text-align: left;
     word-wrap: break-word;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Changed the list rich message UI.
Old : 
<img width="625" height="736" alt="Screenshot 2026-02-02 at 6 44 41 PM" src="https://github.com/user-attachments/assets/4b9fd02e-ec76-4f7a-9be8-9e30ccfec6e6" />

Updated : 
<img width="600" height="615" alt="Screenshot 2026-02-02 at 6 44 57 PM" src="https://github.com/user-attachments/assets/f5af4b4d-6525-4a6e-837f-5070e7b0c648" />

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Reorganized FAQ list item layout to display horizontally instead of vertically
* Adjusted spacing and padding throughout FAQ items for a more compact appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->