### PR TITLE
Fix widget left position issue

### DIFF
--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -563,7 +563,14 @@ input[type=number]::-webkit-outer-spin-button {
   animation: km-reveal-animation-horizontal 0.3s ease-in-out 0.3s 1 forwards;
 }
 .chat-popup-widget-container--horizontal.align-left {
-  right: 60px;
+  right: 26px;
+}
+.chat-popup-widget-container--horizontal.align-left .chat-popup-widget-text {
+  padding: 20px 20px 20px 60px;
+}
+.chat-popup-widget-container--horizontal.align-left .chat-popup-widget-close-btn-container {
+  left: auto;
+  right: -8px;
 }
 .chat-popup-widget-container--horizontal .chat-popup-widget-text {
   padding: 20px 60px 20px 20px;
@@ -593,10 +600,15 @@ input[type=number]::-webkit-outer-spin-button {
   animation: km-reveal-animation-vertical 0.3s ease-in-out 0.3s 1 forwards;
 }
 .chat-popup-widget-container--vertical.align-left {
-  left: 20px;
+  left: 78px;
 }
 .chat-popup-widget-container--vertical.align-left #chat-popup-actionable-btn-container {
   right: unset;
+}
+.chat-popup-widget-container--vertical.align-left .chat-popup-widget-close-btn-container {
+  top: -4px;
+  right: -4px;
+  left: auto;
 }
 .chat-popup-widget-container--vertical .chat-popup-widget-text-wrapper {
   min-height: 75px;

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -73,7 +73,7 @@ var kmCustomIframe =
     'width:100vw;' +
     '} \n' +
     '.kommunicate-custom-iframe.chat-popup-widget-horizontal { ' +
-    '   width: 460px;' +
+    '   width: 400px;' +
     '   min-height: 80px;' +
     '   height: 90px;' +
     '} \n' +

--- a/webplugin/scss/components/_km-chat-popup.scss
+++ b/webplugin/scss/components/_km-chat-popup.scss
@@ -101,7 +101,16 @@ $popupClass: '.chat-popup-widget-container';
         }
 
         &.align-left {
-            right: 60px;
+            right: 26px;
+
+            .chat-popup-widget-text {
+                padding: 20px 20px 20px 60px;
+            }
+
+            .chat-popup-widget-close-btn-container {
+                left: auto;
+                right: -8px;
+            }
         }
         & .chat-popup-widget-text {
             padding: 20px 60px 20px 20px;
@@ -132,10 +141,16 @@ $popupClass: '.chat-popup-widget-container';
         }
 
         &.align-left {
-            left: 20px;
+            left: 78px;
 
             & #chat-popup-actionable-btn-container {
                 right: unset;
+            }
+
+            .chat-popup-widget-close-btn-container {
+                top: -4px;
+                right: -4px;
+                left: auto;
             }
         }
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
When we change widget position to left greeting message CSS break down. 
Before : 
<img width="467" height="238" alt="image" src="https://github.com/user-attachments/assets/7e2101ba-33b4-408e-b2c1-63d853a7c970" />


It shoudl be : 
<img width="463" height="166" alt="image" src="https://github.com/user-attachments/assets/e12e8788-ea60-46ba-b08d-2f19868ce091" />

-


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned chat widget alignment in horizontal and vertical layouts for improved screen placement
  * Optimized horizontal layout width for better compatibility with various screen sizes
  * Enhanced close button positioning and text spacing across layout variants for improved visual balance and accessibility
  * Refined overall widget spacing and alignment for a more polished appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->