### PR TITLE
Fix faq visibility issue in chat widget

### DIFF
--- a/webplugin/css/app/mck-tab-visibility.css
+++ b/webplugin/css/app/mck-tab-visibility.css
@@ -56,6 +56,9 @@
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options {
   display: flex !important;
 }
+#mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options.n-vis {
+  display: none !important;
+}
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-back-btn-container {
   display: inline-flex !important;
   width: auto !important;

--- a/webplugin/css/app/mck-tab-visibility.css
+++ b/webplugin/css/app/mck-tab-visibility.css
@@ -3,8 +3,7 @@
 #mck-sidebox-content:not(.active-tab-conversations) .mck-agent-status-indicator,
 #mck-sidebox-content:not(.active-tab-conversations) #mck-agent-status-text,
 #mck-sidebox-content:not(.active-tab-conversations) .mck-typing-box,
-#mck-sidebox-content:not(.active-tab-conversations) #mck-tab-status, #mck-sidebox-content:not(.active-tab-conversations) .mck-conversation, #km-widget-options,
-#mck-tab-conversation,
+#mck-sidebox-content:not(.active-tab-conversations) #mck-tab-status, #mck-sidebox-content:not(.active-tab-conversations) .mck-conversation, #mck-tab-conversation,
 #mck-tab-individual,
 #mck-contacts-content,
 #km-faqdiv,
@@ -54,10 +53,7 @@
   display: block !important;
 }
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options {
-  display: flex !important;
-}
-#mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options.n-vis {
-  display: none !important;
+  display: flex;
 }
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-back-btn-container {
   display: inline-flex !important;

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -49,8 +49,7 @@ $known-prefixes
 #mck-sidebox-content:not(.active-tab-conversations) .mck-agent-status-indicator,
 #mck-sidebox-content:not(.active-tab-conversations) #mck-agent-status-text,
 #mck-sidebox-content:not(.active-tab-conversations) .mck-typing-box,
-#mck-sidebox-content:not(.active-tab-conversations) #mck-tab-status, #mck-sidebox-content:not(.active-tab-conversations) .mck-conversation, #km-widget-options,
-#mck-tab-conversation,
+#mck-sidebox-content:not(.active-tab-conversations) #mck-tab-status, #mck-sidebox-content:not(.active-tab-conversations) .mck-conversation, #mck-tab-conversation,
 #mck-tab-individual,
 #mck-contacts-content,
 #km-faqdiv,
@@ -4762,10 +4761,7 @@ div#mck-rated:before {
   display: block !important;
 }
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options {
-  display: flex !important;
-}
-#mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options.n-vis {
-  display: none !important;
+  display: flex;
 }
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-back-btn-container {
   display: inline-flex !important;

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -4764,6 +4764,9 @@ div#mck-rated:before {
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options {
   display: flex !important;
 }
+#mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual #km-widget-options.n-vis {
+  display: none !important;
+}
 #mck-sidebox-content.active-tab-conversations.active-subsection-conversation-individual .mck-back-btn-container {
   display: inline-flex !important;
   width: auto !important;

--- a/webplugin/knowledgebase/kb.js
+++ b/webplugin/knowledgebase/kb.js
@@ -41,15 +41,16 @@
                     success: function (data) {
                         response.status = 'success';
                         response.data = data.data || [];
-                        var hasArticles = response.data.some(function (category) {
-                            return category && Number(category.articleCount) > 0;
-                        });
-                        if (!hasArticles) {
-                            hideFAQBtn();
-                        }
 
                         if (options.success) {
-                            response.data.length === 0 && hideFAQBtn();
+                            var shouldHideFAQ =
+                                response.data.length === 0 ||
+                                !response.data.some(function (category) {
+                                    return category && Number(category.articleCount) > 0;
+                                });
+                            if (shouldHideFAQ) {
+                                hideFAQBtn();
+                            }
                             options.success(response);
                         }
                         return;

--- a/webplugin/knowledgebase/kb.js
+++ b/webplugin/knowledgebase/kb.js
@@ -41,6 +41,13 @@
                     success: function (data) {
                         response.status = 'success';
                         response.data = data.data || [];
+                        var hasArticles = response.data.some(function (category) {
+                            return category && Number(category.articleCount) > 0;
+                        });
+                        if (!hasArticles) {
+                            hideFAQBtn();
+                        }
+
                         if (options.success) {
                             response.data.length === 0 && hideFAQBtn();
                             options.success(response);
@@ -60,6 +67,7 @@
         };
 
         KommunicateKB.getArticles = function (options) {
+            console.log('getArticles called with categoryName: ' + options.data.categoryName);
             try {
                 var articles = [];
                 KommunicateKB.getFaqs({

--- a/webplugin/knowledgebase/kb.js
+++ b/webplugin/knowledgebase/kb.js
@@ -67,7 +67,6 @@
         };
 
         KommunicateKB.getArticles = function (options) {
-            console.log('getArticles called with categoryName: ' + options.data.categoryName);
             try {
                 var articles = [];
                 KommunicateKB.getFaqs({

--- a/webplugin/scss/components/_km-tab-visibility-base.scss
+++ b/webplugin/scss/components/_km-tab-visibility-base.scss
@@ -14,7 +14,6 @@
     @extend %km-hidden;
 }
 
-#km-widget-options,
 #mck-tab-conversation,
 #mck-tab-individual,
 #mck-contacts-content,

--- a/webplugin/scss/components/_km-tab-visibility-conversations.scss
+++ b/webplugin/scss/components/_km-tab-visibility-conversations.scss
@@ -72,6 +72,9 @@
     #km-widget-options {
         display: flex !important;
     }
+    #km-widget-options.n-vis {
+        display: none !important;
+    }
     #km-faq {
         @extend %km-hidden;
     }

--- a/webplugin/scss/components/_km-tab-visibility-conversations.scss
+++ b/webplugin/scss/components/_km-tab-visibility-conversations.scss
@@ -70,10 +70,7 @@
 
 %km-conversation-individual {
     #km-widget-options {
-        display: flex !important;
-    }
-    #km-widget-options.n-vis {
-        display: none !important;
+        display: flex;
     }
     #km-faq {
         @extend %km-hidden;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?

#### The FAQ tab should be displayed in the chat widget only when there is at least 1 published FAQ article.
- Currently, the FAQ tab is visible even when:
  - The category is empty
  - The category contains only draft articles
- Expected behaviour: The FAQ tab should not be shown unless there is at least 1 published article.

#### When CSAT is disabled, the three-dot icon should not be visible.
- Currently, when CSAT is disabled, the three-dot icon is still visible and a blank div is rendered.
<img width="2549" height="1440" alt="image" src="https://github.com/user-attachments/assets/a8be3f9f-b036-481d-851c-371720784ea8" />

- Expected behaviour:
  - When CSAT is disabled, the icon should not be displayed in the modern layout.
  - In the classic layout, if both CSAT is disabled and the FAQ is empty, the icon should not be displayed.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
- Tested with the following scenarios for FAQ visibility:
  - 0 categories created
  - Empty category (no articles)
  - Category with all draft articles
  - Category with some draft and some published articles
  - Category with at least 1 published article
- Verified that the FAQ tab is shown only when at least 1 published article exists.

- Tested with the following scenarios for CSAT option visibility:
  - Disabled CSAT and verified in modern layout
  - Disabled CSAT and verified in classic layout with empty FAQ

### What new thing you came across while writing this code? 
- FAQ tab visibility was previously dependent on category existence instead of published article count.
- The three-dot container hide CSS was not working because the required CSS was missing/overridden.

### In case you fixed a bug then please describe the root cause of it? 
- FAQ tab was getting displayed even when there were no published FAQ articles because it was only checking category presence.
- Missing CSS was causing the three-dot container to remain visible even when CSAT was disabled.

### Screenshot
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FAQ button now hides automatically when the knowledge base is empty or when no categories contain articles.

* **UI Changes**
  * Widget options visibility relaxed so options are no longer forcibly hidden in inactive tabs and can display in more tab/subsection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
