### PR TITLE
 hided sentry in kommunicate.app  if sentry is not enabled

### DIFF
--- a/webplugin/controller.js
+++ b/webplugin/controller.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const util = require('util');
 const config = require('./../server/config/config-env');
 const { pluginVersionData } = require('./development.js');
+const { getThirdPartyIntegrationContext } = require('./third-party-integration');
 
 exports.getPlugin = async (req, res) => {
     const MCK_PLUGIN_VERSION = req.params.version;
@@ -24,12 +25,7 @@ const generatePluginFile = async (req, res) => {
     const MCK_CONTEXTPATH = config.urls.hostUrl;
     const MCK_STATICPATH = MCK_CONTEXTPATH + '/plugin';
     const PLUGIN_SETTING = config.pluginProperties;
-    const THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration || {};
-    const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
-    const MCK_THIRD_PARTY_INTEGRATION =
-        sentry && sentry.enabled === false
-            ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
-            : THIRD_PARTY_INTEGRATION;
+    const { MCK_THIRD_PARTY_INTEGRATION } = getThirdPartyIntegrationContext(config);
     const MCK_PLUGIN_VERSION = req.params.version;
     PLUGIN_SETTING.kommunicateApiUrl =
         PLUGIN_SETTING.kommunicateApiUrl || config.urls.kommunicateBaseUrl;

--- a/webplugin/controller.js
+++ b/webplugin/controller.js
@@ -24,7 +24,12 @@ const generatePluginFile = async (req, res) => {
     const MCK_CONTEXTPATH = config.urls.hostUrl;
     const MCK_STATICPATH = MCK_CONTEXTPATH + '/plugin';
     const PLUGIN_SETTING = config.pluginProperties;
-    const MCK_THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration;
+    const THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration || {};
+    const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
+    const MCK_THIRD_PARTY_INTEGRATION =
+        sentry && sentry.enabled === false
+            ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
+            : THIRD_PARTY_INTEGRATION;
     const MCK_PLUGIN_VERSION = req.params.version;
     PLUGIN_SETTING.kommunicateApiUrl =
         PLUGIN_SETTING.kommunicateApiUrl || config.urls.kommunicateBaseUrl;

--- a/webplugin/development.js
+++ b/webplugin/development.js
@@ -26,7 +26,12 @@ const TERSER_CONFIG = require('./terser.config');
 const MCK_CONTEXT_PATH = config.urls.hostUrl;
 const MCK_STATIC_PATH = MCK_CONTEXT_PATH + '/plugin';
 const PLUGIN_SETTING = config.pluginProperties;
-const MCK_THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration;
+const THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration || {};
+const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
+const MCK_THIRD_PARTY_INTEGRATION =
+    sentry && sentry.enabled === false
+        ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
+        : THIRD_PARTY_INTEGRATION;
 
 const pluginVersions = ['v1', 'v2', 'v3'];
 

--- a/webplugin/development.js
+++ b/webplugin/development.js
@@ -23,15 +23,11 @@ const legacyThirdPartyDir = path.join(legacyResourcesDir, 'third-party-scripts')
 const legacyPluginLibDir = path.join(buildDir, 'plugin', 'lib', 'js');
 const config = require('../server/config/config-env');
 const TERSER_CONFIG = require('./terser.config');
+const { getThirdPartyIntegrationContext } = require('./third-party-integration');
 const MCK_CONTEXT_PATH = config.urls.hostUrl;
 const MCK_STATIC_PATH = MCK_CONTEXT_PATH + '/plugin';
 const PLUGIN_SETTING = config.pluginProperties;
-const THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration || {};
-const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
-const MCK_THIRD_PARTY_INTEGRATION =
-    sentry && sentry.enabled === false
-        ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
-        : THIRD_PARTY_INTEGRATION;
+const { MCK_THIRD_PARTY_INTEGRATION } = getThirdPartyIntegrationContext(config);
 
 const pluginVersions = ['v1', 'v2', 'v3'];
 

--- a/webplugin/gulpfile.js
+++ b/webplugin/gulpfile.js
@@ -39,7 +39,12 @@ const TERSER_CONFIG = require('./terser.config');
 const MCK_CONTEXT_PATH = config.urls.hostUrl;
 const MCK_STATIC_PATH = MCK_CONTEXT_PATH + '/plugin';
 const PLUGIN_SETTING = config.pluginProperties;
-const MCK_THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration;
+const THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration || {};
+const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
+const MCK_THIRD_PARTY_INTEGRATION =
+    sentry && sentry.enabled === false
+        ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
+        : THIRD_PARTY_INTEGRATION;
 const pluginVersions = ['v1', 'v2', 'v3'];
 
 PLUGIN_SETTING.kommunicateApiUrl =
@@ -51,17 +56,20 @@ PLUGIN_SETTING.dashboardUrl = PLUGIN_SETTING.dashboardUrl || config.urls.dashboa
 const BUILD_URL = MCK_STATIC_PATH + '/build';
 
 let env = config.getEnvId() !== 'development';
-const SENTRY_ENABLED = MCK_THIRD_PARTY_INTEGRATION.sentry.enabled;
+const sentryCfg = THIRD_PARTY_INTEGRATION.sentry || null;
+const SENTRY_ENABLED = !!(sentryCfg && sentryCfg.enabled);
 
-const cli = new SentryCli(null, {
-    authToken: MCK_THIRD_PARTY_INTEGRATION.sentry.AUTH_TOKEN,
-    org: MCK_THIRD_PARTY_INTEGRATION.sentry.ORG,
-    project: MCK_THIRD_PARTY_INTEGRATION.sentry.PROJECT,
-    sourcemaps: {
-        rewrite: true,
-        ignore_file: ['node_modules'],
-    },
-});
+const cli = SENTRY_ENABLED
+    ? new SentryCli(null, {
+          authToken: sentryCfg.AUTH_TOKEN,
+          org: sentryCfg.ORG,
+          project: sentryCfg.PROJECT,
+          sourcemaps: {
+              rewrite: true,
+              ignore_file: ['node_modules'],
+          },
+      })
+    : null;
 
 let pathToResource = !env
     ? `${BUILD_URL}/${version}/resources`
@@ -101,7 +109,7 @@ const generateResourceFolder = () => {
 };
 
 const generateThirdPartyJSFiles = () => {
-    console.log('sentry.enabled: ' + MCK_THIRD_PARTY_INTEGRATION.sentry.enabled);
+    console.log('sentry.enabled: ' + SENTRY_ENABLED);
 
     let inputScripts = THIRD_PARTY_SCRIPTS;
 

--- a/webplugin/gulpfile.js
+++ b/webplugin/gulpfile.js
@@ -35,16 +35,12 @@ const legacyThirdPartyDir = path.join(legacyResourcesDir, 'third-party-scripts')
 const legacyPluginLibDir = path.join(buildDir, 'plugin', 'lib', 'js');
 const config = require('../server/config/config-env');
 const TERSER_CONFIG = require('./terser.config');
+const { getThirdPartyIntegrationContext } = require('./third-party-integration');
 
 const MCK_CONTEXT_PATH = config.urls.hostUrl;
 const MCK_STATIC_PATH = MCK_CONTEXT_PATH + '/plugin';
 const PLUGIN_SETTING = config.pluginProperties;
-const THIRD_PARTY_INTEGRATION = config.thirdPartyIntegration || {};
-const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
-const MCK_THIRD_PARTY_INTEGRATION =
-    sentry && sentry.enabled === false
-        ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
-        : THIRD_PARTY_INTEGRATION;
+const { MCK_THIRD_PARTY_INTEGRATION, sentryCfg } = getThirdPartyIntegrationContext(config);
 const pluginVersions = ['v1', 'v2', 'v3'];
 
 PLUGIN_SETTING.kommunicateApiUrl =
@@ -56,7 +52,6 @@ PLUGIN_SETTING.dashboardUrl = PLUGIN_SETTING.dashboardUrl || config.urls.dashboa
 const BUILD_URL = MCK_STATIC_PATH + '/build';
 
 let env = config.getEnvId() !== 'development';
-const sentryCfg = THIRD_PARTY_INTEGRATION.sentry || null;
 const SENTRY_ENABLED = !!(sentryCfg && sentryCfg.enabled);
 
 const cli = SENTRY_ENABLED

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -1,6 +1,8 @@
 var $original;
 var oModal = '';
-var sentryConfig = MCK_THIRD_PARTY_INTEGRATION.sentry;
+var sentryConfig = (MCK_THIRD_PARTY_INTEGRATION && MCK_THIRD_PARTY_INTEGRATION.sentry) || {
+    enabled: false,
+};
 var MCK_COOKIE_DOMAIN;
 if (typeof jQuery !== 'undefined') {
     $original = jQuery.noConflict(true);

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -627,7 +627,8 @@ function injectJquery() {
     }
 
     function loadKommunicateWithSentry() {
-        if (!shouldLoadSentryScript()) {
+        var sentryEnabled = shouldLoadSentryScript();
+        if (!sentryEnabled) {
             addKommunicatePluginToIframe();
             return Promise.resolve();
         }
@@ -635,7 +636,7 @@ function injectJquery() {
         return scriptLoader({
             _document: addableDocument, // kommunicate iframe document
             url: THIRD_PARTY_SCRIPTS.sentry.js, // kommunicate modified version of sentry
-            enabled: MCK_THIRD_PARTY_INTEGRATION.sentry.enabled,
+            enabled: sentryEnabled,
             ignoreIfError: true, // ignore if error occurs while loading sentry script load km plugin script
         })
             .then(addKommunicatePluginToIframe)

--- a/webplugin/third-party-integration.js
+++ b/webplugin/third-party-integration.js
@@ -1,0 +1,18 @@
+const getThirdPartyIntegrationContext = (config) => {
+    const THIRD_PARTY_INTEGRATION = (config && config.thirdPartyIntegration) || {};
+    const { sentry, ...MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY } = THIRD_PARTY_INTEGRATION;
+    const MCK_THIRD_PARTY_INTEGRATION =
+        sentry && sentry.enabled === false
+            ? MCK_THIRD_PARTY_INTEGRATION_WITHOUT_SENTRY
+            : THIRD_PARTY_INTEGRATION;
+
+    return {
+        THIRD_PARTY_INTEGRATION,
+        MCK_THIRD_PARTY_INTEGRATION,
+        sentryCfg: sentry || null,
+    };
+};
+
+module.exports = {
+    getThirdPartyIntegrationContext,
+};


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- hiding  sentry  details in kommunicate.app  if sentry is  disabled.
- this is for all env .
  it will be visible only if  sentry is enabled .

<img width="1437" height="162" alt="image" src="https://github.com/user-attachments/assets/9f5051b3-f1fa-432a-a0ca-16777e4e323a" />




NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime errors from missing or undefined third‑party configuration entries.
  * Ensured the app gracefully skips Sentry when it’s explicitly disabled, avoiding related failures.
  * Added safer defaults and null‑safety checks for integration settings to improve stability.
  * Improved error handling during third‑party service loading so main plugin initialization continues reliably.

* **Chores**
  * Centralized third‑party integration lookup to standardize initialization and reduce edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->