### PR TITLE
TDH-3462: Fix chatwidget error

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4127,7 +4127,7 @@ const firstVisibleMsg = {
                 }
                 console.log('[PRE-LEAD] loadChat completed, widget re-launched');
             }
-            if (typeof window !== 'undefined' && !window.loadChat) {
+            if (typeof window !== 'undefined' && typeof window.loadChat !== 'function') {
                 window.loadChat = loadChat;
             }
             /*  To trigger welcome event of a bot.

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2306,7 +2306,7 @@ const firstVisibleMsg = {
                                 chatNotificationMailSent: true,
                             };
                             PRE_CHAT_LEAD_COLLECTION_POPUP_ON = false;
-                            mckInit.initialize(options, window.loadChat);
+                            mckInit.initialize(options, mckInit.loadChatCallback);
                             return false;
                         }
                         var kmAnonymousChatLauncher = document.getElementById(
@@ -4127,8 +4127,8 @@ const firstVisibleMsg = {
                 }
                 console.log('[PRE-LEAD] loadChat completed, widget re-launched');
             }
-            if (typeof window !== 'undefined' && typeof window.loadChat !== 'function') {
-                window.loadChat = loadChat;
+            if (typeof mckInit !== 'undefined' && typeof mckInit.loadChatCallback !== 'function') {
+                mckInit.loadChatCallback = loadChat;
             }
             /*  To trigger welcome event of a bot.
                 defaultSettings: if there is any custome event is configured by the user
@@ -5505,7 +5505,7 @@ const firstVisibleMsg = {
                     var options = {
                         userId: userId,
                         applicationId: MCK_APP_ID,
-                        onInit: window.loadChat,
+                        onInit: mckInit.loadChatCallback,
                         baseUrl: MCK_BASE_URL,
                         locShare: IS_MCK_LOCSHARE,
                         metadata: metadata,
@@ -5532,7 +5532,7 @@ const firstVisibleMsg = {
                     });
                     kommunicateCommons.show($mck_loading);
                     KommunicateUI.skipPopupChatTemplate = true;
-                    mckInit.initialize(options, window.loadChat);
+                    mckInit.initialize(options, mckInit.loadChatCallback);
 
                     return false;
                 });

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2306,7 +2306,7 @@ const firstVisibleMsg = {
                                 chatNotificationMailSent: true,
                             };
                             PRE_CHAT_LEAD_COLLECTION_POPUP_ON = false;
-                            mckInit.initialize(options, loadChat);
+                            mckInit.initialize(options, window.loadChat);
                             return false;
                         }
                         var kmAnonymousChatLauncher = document.getElementById(
@@ -4127,6 +4127,9 @@ const firstVisibleMsg = {
                 }
                 console.log('[PRE-LEAD] loadChat completed, widget re-launched');
             }
+            if (typeof window !== 'undefined' && !window.loadChat) {
+                window.loadChat = loadChat;
+            }
             /*  To trigger welcome event of a bot.
                 defaultSettings: if there is any custome event is configured by the user
             */
@@ -5502,7 +5505,7 @@ const firstVisibleMsg = {
                     var options = {
                         userId: userId,
                         applicationId: MCK_APP_ID,
-                        onInit: loadChat,
+                        onInit: window.loadChat,
                         baseUrl: MCK_BASE_URL,
                         locShare: IS_MCK_LOCSHARE,
                         metadata: metadata,
@@ -5529,7 +5532,7 @@ const firstVisibleMsg = {
                     });
                     kommunicateCommons.show($mck_loading);
                     KommunicateUI.skipPopupChatTemplate = true;
-                    mckInit.initialize(options, loadChat);
+                    mckInit.initialize(options, window.loadChat);
 
                     return false;
                 });


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix ReferenceError: loadChat is not defined that crashes the widget during preview re‑init (layout/launcher changes) by ensuring the widget bundle calls a globally defined loadChat, and verify locally against the patched SDK bundle.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Ran dashboard locally.
Switched between Classic ↔ Modern layout and changed launcher while logged in.
Confirmed widget no longer disappears and no loadChat is not defined error.
Verified widget script loaded from http://localhost:3030/kommunicate-widget-3.0.min.js via DevTools Network.

### What new thing you came across while writing this code? 
-The dashboard does not call loadChat directly; the SDK calls it during pre‑lead re‑initialization, so the error is rooted in SDK scope, not dashboard config.

### In case you fixed a bug then please describe the root cause of it? 
-Root cause: in the SDK bundle, loadChat was referenced during pre‑lead re‑init from a different closure where it wasn’t in scope, causing ReferenceError on re‑initialization events. The fix is to expose loadChat on window and call window.loadChat.

### Screenshot
- NA

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made the chat widget triggerable from other scripts so it can be launched or relaunched externally.
  * Ensured consistent reinitialization so show/hide and widget state are reliably reset when reopened.
  * Preserved existing chat behavior while exposing a stable external entry point for launching the widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->