### PR TITLE
  fixed greeting message is not visible

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1082,6 +1082,10 @@ const firstVisibleMsg = {
                     typeof Kommunicate.setDefaultIframeConfigForClosedChat === 'function' &&
                         Kommunicate.setDefaultIframeConfigForClosedChat();
                 }
+                // In lazy init mode, schedule the greeting popup immediately after
+                // the launcher and popup markup are added, so it can appear even
+                // before the first explicit widget open.
+                showPopupChatTemplateOnce();
             } else {
                 mckInit.initializeApp(appOptions, false);
                 mckNotificationService.init();


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- cause :
] project uses lazy user creation:
CREATE_USER_ON_WIDGET_OPEN = appOptions.preCreateUser === false;
In this mode, _this.init only calls mckInit.appendLauncher() and waits for the first widget open to run mckInit.initializeApp(...).
Our greeting logic (showPopupChatTemplateOnce() → KommunicateUI.displayPopupChatTemplate(...)) was only called inside the initializeApp/login flow, so:
No greeting popup  until after you click the widget.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
