### PR TITLE
TDH-3284-Remove unused data from metadata

### DIFF
--- a/webplugin/js/app/kommunicate-client.js
+++ b/webplugin/js/app/kommunicate-client.js
@@ -110,18 +110,9 @@ Kommunicate.client = {
             chatContext = $applozic.extend(chatContext, currentLanguage);
 
             CURRENT_GROUP_DATA.isWaitingQueue = false; // for showing the loader in screen
+
             var groupMetadata = {
-                CREATE_GROUP_MESSAGE: '',
-                REMOVE_MEMBER_MESSAGE: '',
-                ADD_MEMBER_MESSAGE: '',
-                JOIN_MEMBER_MESSAGE: '',
-                GROUP_NAME_CHANGE_MESSAGE: '',
-                GROUP_ICON_CHANGE_MESSAGE: '',
-                GROUP_LEFT_MESSAGE: '',
                 CONVERSATION_STATUS: -1,
-                DELETED_GROUP_MESSAGE: '',
-                GROUP_USER_ROLE_UPDATED_MESSAGE: '',
-                GROUP_META_DATA_UPDATED_MESSAGE: '',
                 KM_CONVERSATION_TITLE: conversationDetail.groupName,
                 //ALERT: "false",
                 HIDE: 'true',


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- In the Group Create API, These metadata fields are sent with empty values in every request. For support groups, this metadata is not used anywhere. The backend currently removes this data before storing it in the database but still returns it in the response.


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up unused metadata field initializations in conversation creation to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->