### PR TITLE
Code refractoring

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1501,7 +1501,10 @@ const firstVisibleMsg = {
                 typeof optns.launchOnUnreadMessage === 'boolean'
                     ? optns.launchOnUnreadMessage
                     : false;
-            KM_ASK_USER_DETAILS = appOptions.askUserDetails;
+            KM_ASK_USER_DETAILS.length = 0;
+            if (Array.isArray(appOptions.askUserDetails)) {
+                Array.prototype.push.apply(KM_ASK_USER_DETAILS, appOptions.askUserDetails);
+            }
         };
         _this.logout = function () {
             if (typeof window.Applozic.ALSocket !== 'undefined') {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -1512,12 +1512,7 @@ const firstVisibleMsg = {
                 // Below function will clearMckMessageArray, clearAppHeaders, clearMckContactNameArray, removeEncryptionKey
                 ALStorage.clearSessionStorageElements();
                 $applozic.fn.applozic('reset', appOptions);
-                kmLocalStorage.deleteLocalStorage(
-                    KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
-                );
-                kmLocalStorage.deleteLocalStorage(
-                    KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION
-                );
+                _this.clearStoredAuthState();
                 kommunicateCommons.hide('#mck-sidebox', '#mck-sidebox-launcher');
                 parent.document.getElementById('kommunicate-widget-iframe') &&
                     (parent.document.getElementById('kommunicate-widget-iframe').style.display =
@@ -2168,39 +2163,6 @@ const firstVisibleMsg = {
                 }
             }
 
-            function ensureChatLoginModalExists() {
-                var existingModal = document.getElementById('km-chat-login-modal');
-                if (existingModal) {
-                    localizeChatLoginModal(existingModal);
-                    return existingModal;
-                }
-                return null;
-            }
-
-            function localizeChatLoginModal(modal) {
-                if (!modal || typeof MCK_LABELS === 'undefined') {
-                    return;
-                }
-                var closeBtn = modal.querySelector('#km-modal-close');
-                var closeLabel = MCK_LABELS['close'];
-                if (closeBtn && closeLabel) {
-                    closeBtn.setAttribute('aria-label', closeLabel);
-                }
-                var userIdLabel = modal.querySelector('#km-label-user-id');
-                var userIdText = MCK_LABELS['form.label.userId'];
-                if (userIdLabel && userIdText) {
-                    userIdLabel.textContent = userIdText;
-                }
-                var submitBtn = modal.querySelector('#km-submit-chat-login');
-                var submitText = (MCK_LABELS['lead.collection'] || {}).submit || '';
-                if (submitBtn && submitText) {
-                    if (!submitBtn.textContent) {
-                        submitBtn.textContent = submitText;
-                    }
-                    submitBtn.setAttribute('aria-label', submitText);
-                }
-            }
-
             function autoOpenPreChatLeadCollectionModal(launcher) {
                 if (!launcher || PRE_CHAT_LEAD_COLLECTION_MODAL_AUTO_OPENED) {
                     return;
@@ -2215,113 +2177,16 @@ const firstVisibleMsg = {
                 }, PRE_CHAT_LEAD_COLLECTION_AUTO_CLICK_DELAY);
             }
 
-            function ensureAuthFailureFormFields(config) {
-                config = config || {};
-                var showUserIdField = config.showUserIdField !== false;
-                if (isPreLeadCollectionEnabled()) {
-                    return;
-                }
+            function clearAuthErrorState() {
                 _this.resetPreChatLoginError && _this.resetPreChatLoginError();
-                var form = document.getElementById('km-form-chat-login');
-                if (!form) {
-                    return;
-                }
-                var askUserDetailsContainer = form.querySelector('.mck-askuserdetail-inputdiv');
-                if (!askUserDetailsContainer) {
-                    return;
-                }
-                var userIdInput = document.getElementById('km-userId');
-                if (userIdInput) {
-                    kommunicateCommons.show(userIdInput);
-                    userIdInput.setAttribute('type', 'text');
-                    if (showUserIdField) {
-                        userIdInput.setAttribute('required', 'true');
-                    } else {
-                        userIdInput.removeAttribute('required');
-                    }
-                    var userIdLabel = MCK_LABELS['form.label.userId'];
-                    userIdInput.setAttribute('placeholder', userIdLabel);
-                    userIdInput.setAttribute('aria-label', userIdLabel);
-                    var userIdLabelNode = document.getElementById('km-label-user-id');
-                    if (userIdLabelNode) {
-                        var requiredSvg =
-                            '<svg width="6" height="6" viewBox="0 0 6 6" focusable="false" aria-hidden="true">' +
-                            '<use xlink:href="#icon-69" href="#icon-69"></use>' +
-                            '</svg>';
-                        userIdLabelNode.textContent = userIdLabel;
-                        userIdLabelNode.classList.remove('sr-only');
-                        userIdLabelNode.classList.add('km-form-label', 'km-tertiary-title');
-                        if (userIdInput.hasAttribute('required')) {
-                            userIdLabelNode.innerHTML = userIdLabel + ' ' + requiredSvg;
-                        }
-                        if (
-                            !userIdLabelNode.parentElement.classList.contains(
-                                'km-form-label-container'
-                            )
-                        ) {
-                            var labelContainer = document.createElement('div');
-                            labelContainer.className = 'km-form-label-container';
-                            userIdLabelNode.parentElement.insertBefore(
-                                labelContainer,
-                                userIdLabelNode
-                            );
-                            labelContainer.appendChild(userIdLabelNode);
-                        }
-                        var userIdContainer =
-                            typeof userIdInput.closest === 'function'
-                                ? userIdInput.closest('.km-form-group')
-                                : null;
-                        var userIdTarget = userIdContainer;
-                        if (!showUserIdField) {
-                            kommunicateCommons.hide(userIdTarget);
-                            userIdLabelNode.classList.add('sr-only');
-                        } else {
-                            kommunicateCommons.show(userIdTarget);
-                            userIdLabelNode.classList.remove('sr-only');
-                        }
-                    }
-                }
-                var submitBtn = document.getElementById('km-submit-chat-login');
-                if (submitBtn) {
-                    var submitLabel =
-                        _this.getLeadCollectionLabel && _this.getLeadCollectionLabel('submit', '');
-                    submitBtn.innerHTML = submitLabel;
-                    submitBtn.setAttribute('aria-label', submitLabel);
-                    kommunicateCommons.show(submitBtn);
-                    submitBtn.removeAttribute('disabled');
-                }
-                if (!document.getElementById('km-password')) {
-                    var passwordLabel =
-                        (_this.getLeadCollectionLabel &&
-                            _this.getLeadCollectionLabel('password', '')) ||
-                        (MCK_LABELS['lead.collection'] || {}).password ||
-                        (MCK_LABELS && MCK_LABELS['lead.collection.password']) ||
-                        'Password';
-                    askUserDetailsContainer.appendChild(
-                        _this.createInputField({
-                            field: passwordLabel,
-                            type: 'password',
-                            placeholder: passwordLabel,
-                            required: true,
-                            id: 'km-password',
-                            name: 'km-password',
-                        })
-                    );
-                }
             }
 
-            function reopenAuthModal(options) {
-                options = options || { skipConversationLaunch: true };
-                ensureWidgetIframeVisible();
-                openWidgetForAuthError(options);
-                var kmChatLoginModal = document.getElementById('km-chat-login-modal');
-                kommunicateCommons.show('#km-chat-login-modal');
-                kommunicateCommons.setDialogVisibility(
-                    kmChatLoginModal,
-                    true,
-                    loginModalFocusFallbacks
-                );
-                return kmChatLoginModal;
+            function resetLazyInitState(resetAuthSubmitTriggered) {
+                LAZY_INIT_STARTED = false;
+                LAZY_INIT_PENDING_OPEN = false;
+                if (resetAuthSubmitTriggered) {
+                    AUTH_SUBMIT_TRIGGERED = false;
+                }
             }
 
             function openWidgetForAuthError(options) {
@@ -2351,12 +2216,7 @@ const firstVisibleMsg = {
                         kommunicateIframe.classList.remove('km-iframe-closed');
                     }
                 } catch (error) {}
-                if (
-                    typeof mckMessageService !== 'undefined' &&
-                    typeof mckMessageService.openChatbox === 'function'
-                ) {
-                    mckMessageService.openChatbox();
-                }
+                mckMessageService.openChatbox();
             }
 
             function ensureWidgetIframeVisible() {
@@ -2371,16 +2231,7 @@ const firstVisibleMsg = {
                 } catch (error) {}
             }
 
-            _this.ensureAuthFailureFormFields = ensureAuthFailureFormFields;
-            _this.reopenAuthModal = reopenAuthModal;
             _this.openWidgetForAuthError = openWidgetForAuthError;
-
-            function isPreLeadCollectionEnabled() {
-                return (
-                    (Array.isArray(KM_ASK_USER_DETAILS) && KM_ASK_USER_DETAILS.length !== 0) ||
-                    (Array.isArray(KM_PRELEAD_COLLECTION) && KM_PRELEAD_COLLECTION.length !== 0)
-                );
-            }
 
             _this.getLauncherHtml = function (isAnonymousChat) {
                 var defaultHtml = kmCustomTheme.customSideboxWidget();
@@ -2433,7 +2284,7 @@ const firstVisibleMsg = {
 
             _this.initializeApp = async function (optns, isReInit) {
                 IS_REINITIALIZE = isReInit;
-                ensureChatLoginModalExists();
+                _this.ensureChatLoginModalExists && _this.ensureChatLoginModalExists();
                 _this.resetPreChatLoginError && _this.resetPreChatLoginError();
                 var userPxy = {
                     applicationId: optns.appId,
@@ -2494,10 +2345,10 @@ const firstVisibleMsg = {
                 }
                 var isValidated = await _this.validateAppSession(userPxy);
                 if (!isValidated) {
-                    if (!isPreLeadCollectionEnabled() && MCK_AUTHENTICATION_TYPE_ID > 0) {
-                        ensureChatLoginModalExists();
-                        ensureAuthFailureFormFields();
-                        reopenAuthModal();
+                    if (!_this.isPreLeadCollectionEnabled() && MCK_AUTHENTICATION_TYPE_ID > 0) {
+                        _this.ensureChatLoginModalExists && _this.ensureChatLoginModalExists();
+                        _this.ensureAuthFailureFormFields && _this.ensureAuthFailureFormFields();
+                        _this.reopenAuthModal && _this.reopenAuthModal();
                         return false;
                     }
                     if (
@@ -2753,43 +2604,31 @@ const firstVisibleMsg = {
                         ALStorage.clearMckMessageArray();
                         ALStorage.clearMckContactNameArray();
                         if (result === 'INVALID_PASSWORD') {
-                            var isPreLeadEnabled = isPreLeadCollectionEnabled();
+                            var isPreLeadEnabled = _this.isPreLeadCollectionEnabled();
                             var getLeadLabel = _this.getLeadCollectionLabel
                                 ? _this.getLeadCollectionLabel.bind(_this)
                                 : function (key, fallback) {
                                       return fallback || '';
                                   };
-                            ensureChatLoginModalExists();
+                            _this.ensureChatLoginModalExists && _this.ensureChatLoginModalExists();
                             if (!AUTH_SUBMIT_TRIGGERED) {
                                 _this.resetPreChatLoginError && _this.resetPreChatLoginError();
-                                reopenAuthModal();
+                                _this.reopenAuthModal && _this.reopenAuthModal();
                                 if (!isPreLeadEnabled) {
-                                    ensureAuthFailureFormFields();
+                                    _this.ensureAuthFailureFormFields &&
+                                        _this.ensureAuthFailureFormFields();
                                 }
-                                var loginErrorNode = document.getElementById('km-error-chat-login');
-                                if (loginErrorNode) {
-                                    loginErrorNode.textContent = '';
-                                    kommunicateCommons.hide(loginErrorNode);
-                                }
-                                kmLocalStorage.deleteUserCookiesOnLogout();
-                                kmLocalStorage.deleteLocalStorage(
-                                    KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
-                                );
-                                kmLocalStorage.deleteLocalStorage(
-                                    KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION
-                                );
-                                ALStorage.clearAppHeaders();
-                                MCK_ACCESS_TOKEN = null;
-                                window.Applozic.ALApiService.AUTH_TOKEN = null;
-                                LAZY_INIT_STARTED = false;
-                                LAZY_INIT_PENDING_OPEN = false;
+                                clearAuthErrorState();
+                                _this.clearAuthSessionState && _this.clearAuthSessionState();
+                                resetLazyInitState(false);
                                 return;
                             }
-                            reopenAuthModal();
+                            _this.reopenAuthModal && _this.reopenAuthModal();
                             if (!isPreLeadEnabled) {
-                                ensureAuthFailureFormFields({
-                                    showUserIdField: true,
-                                });
+                                _this.ensureAuthFailureFormFields &&
+                                    _this.ensureAuthFailureFormFields({
+                                        showUserIdField: true,
+                                    });
                             }
                             if (isPreLeadEnabled && MCK_AUTHENTICATION_TYPE_ID <= 0) {
                                 var hasPreLeadUserId = KM_PRELEAD_COLLECTION.some(function (item) {
@@ -2804,15 +2643,11 @@ const firstVisibleMsg = {
                                     kommunicateCommons.hide(userIdInput);
                                 }
                             }
-                            var submitBtn = document.getElementById('km-submit-chat-login');
-                            if (submitBtn) {
-                                var submitLabel = (MCK_LABELS['lead.collection'] || {}).submit;
-                                submitBtn.innerHTML = submitLabel;
-                                submitBtn.setAttribute('aria-label', submitLabel);
-                                kommunicateCommons.show(submitBtn);
-                                submitBtn.removeAttribute('disabled');
-                            }
-                            loginErrorNode = document.getElementById('km-error-chat-login');
+                            _this.updateAuthSubmitButton &&
+                                _this.updateAuthSubmitButton(
+                                    (MCK_LABELS['lead.collection'] || {}).submit
+                                );
+                            var loginErrorNode = document.getElementById('km-error-chat-login');
                             if (loginErrorNode) {
                                 loginErrorNode.textContent = getLeadLabel(
                                     'invalidPasswordMessage',
@@ -2827,24 +2662,11 @@ const firstVisibleMsg = {
                                     errorMessage: getLeadLabel('invalidPasswordMessage', ''),
                                 });
                             }
-                            // if password invalid then clear cookies
-                            kmLocalStorage.deleteUserCookiesOnLogout();
-                            kmLocalStorage.deleteLocalStorage(
-                                KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
-                            );
-                            kmLocalStorage.deleteLocalStorage(
-                                KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION
-                            );
-                            ALStorage.clearAppHeaders();
-                            MCK_ACCESS_TOKEN = null;
-                            window.Applozic.ALApiService.AUTH_TOKEN = null;
-
-                            LAZY_INIT_STARTED = false;
-                            LAZY_INIT_PENDING_OPEN = false;
-                            AUTH_SUBMIT_TRIGGERED = false;
+                            _this.clearAuthSessionState && _this.clearAuthSessionState();
+                            resetLazyInitState(true);
                             return;
                         } else if (
-                            isPreLeadCollectionEnabled() &&
+                            _this.isPreLeadCollectionEnabled() &&
                             (result === 'error' || result === 'USER_NOT_FOUND')
                         ) {
                             var preLeadErrorMessage = _this.resolvePreLeadErrorMessage
@@ -2860,8 +2682,7 @@ const firstVisibleMsg = {
                                     errorMessage: result,
                                 });
                             }
-                            LAZY_INIT_STARTED = false;
-                            LAZY_INIT_PENDING_OPEN = false;
+                            resetLazyInitState(false);
                             return;
                         } else if (result === 'INVALID_APPID') {
                             Kommunicate.displayKommunicateWidget(false);
@@ -3744,8 +3565,18 @@ const firstVisibleMsg = {
                         return MCK_AUTHENTICATION_TYPE_ID;
                     },
                     appOptions: appOptions,
+                    ensureWidgetIframeVisible: ensureWidgetIframeVisible,
                     openWidgetForAuthError: openWidgetForAuthError,
                     loginModalFocusFallbacks: loginModalFocusFallbacks,
+                    kmLocalStorage: kmLocalStorage,
+                    KommunicateConstants: KommunicateConstants,
+                    clearAppHeaders: function () {
+                        ALStorage.clearAppHeaders();
+                    },
+                    clearAuthTokens: function () {
+                        MCK_ACCESS_TOKEN = null;
+                        window.Applozic.ALApiService.AUTH_TOKEN = null;
+                    },
                     setIntlTelInstance: function (instance) {
                         INTL_TEL_INSTANCE = instance;
                     },

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -711,7 +711,7 @@ const firstVisibleMsg = {
         var ringToneService;
         var lastFetchTime;
         var isUserDeleted = false;
-        var KM_ASK_USER_DETAILS = mckMessageService.checkArray(appOptions.askUserDetails);
+        var KM_ASK_USER_DETAILS = mckMessageService.checkArray(appOptions.askUserDetails) || [];
         typingService.init(appOptions);
         ratingService.init(appOptions);
         var QUICK_REPLIES = appOptions.quickReplies
@@ -1501,11 +1501,24 @@ const firstVisibleMsg = {
                 typeof optns.launchOnUnreadMessage === 'boolean'
                     ? optns.launchOnUnreadMessage
                     : false;
+            if (!Array.isArray(KM_ASK_USER_DETAILS)) {
+                KM_ASK_USER_DETAILS = [];
+            }
             KM_ASK_USER_DETAILS.length = 0;
             if (Array.isArray(appOptions.askUserDetails)) {
                 Array.prototype.push.apply(KM_ASK_USER_DETAILS, appOptions.askUserDetails);
             }
         };
+
+        function clearPersistedAuthState() {
+            kmLocalStorage.deleteLocalStorage(
+                KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
+            );
+            kmLocalStorage.deleteLocalStorage(
+                KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION
+            );
+        }
+
         _this.logout = function () {
             if (typeof window.Applozic.ALSocket !== 'undefined') {
                 kmLocalStorage.removeItemFromLocalStorage('feedbackGroups');
@@ -1515,7 +1528,7 @@ const firstVisibleMsg = {
                 // Below function will clearMckMessageArray, clearAppHeaders, clearMckContactNameArray, removeEncryptionKey
                 ALStorage.clearSessionStorageElements();
                 $applozic.fn.applozic('reset', appOptions);
-                _this.clearStoredAuthState();
+                clearPersistedAuthState();
                 kommunicateCommons.hide('#mck-sidebox', '#mck-sidebox-launcher');
                 parent.document.getElementById('kommunicate-widget-iframe') &&
                     (parent.document.getElementById('kommunicate-widget-iframe').style.display =
@@ -3573,6 +3586,7 @@ const firstVisibleMsg = {
                     loginModalFocusFallbacks: loginModalFocusFallbacks,
                     kmLocalStorage: kmLocalStorage,
                     KommunicateConstants: KommunicateConstants,
+                    clearPersistedAuthState: clearPersistedAuthState,
                     clearAppHeaders: function () {
                         ALStorage.clearAppHeaders();
                     },

--- a/webplugin/js/app/prechat/km-prechat.js
+++ b/webplugin/js/app/prechat/km-prechat.js
@@ -219,11 +219,8 @@ var KMPreChat = (function () {
 
         target.reopenAuthModal = function (options) {
             options = options || { skipConversationLaunch: true };
-            typeof deps.ensureWidgetIframeVisible === 'function' &&
-                deps.ensureWidgetIframeVisible();
-            if (typeof deps.openWidgetForAuthError === 'function') {
-                deps.openWidgetForAuthError(options);
-            }
+            deps.ensureWidgetIframeVisible();
+            deps.openWidgetForAuthError(options);
             var kmChatLoginModal = document.getElementById('km-chat-login-modal');
             kommunicateCommons.show('#km-chat-login-modal');
             kommunicateCommons.setDialogVisibility(
@@ -245,10 +242,10 @@ var KMPreChat = (function () {
             if (options.deleteCookies) {
                 deps.kmLocalStorage.deleteUserCookiesOnLogout();
             }
-            if (options.clearHeaders && typeof deps.clearAppHeaders === 'function') {
+            if (options.clearHeaders) {
                 deps.clearAppHeaders();
             }
-            if (options.clearTokens && typeof deps.clearAuthTokens === 'function') {
+            if (options.clearTokens) {
                 deps.clearAuthTokens();
             }
         };
@@ -267,35 +264,18 @@ var KMPreChat = (function () {
 
         target.showPreChatLoginError = function (message) {
             var resolvedMessage = message || getLeadCollectionLabel('invalidPasswordMessage', '');
-            var kmChatLoginModal = null;
-            if (typeof target.reopenAuthModal === 'function') {
-                kmChatLoginModal = target.reopenAuthModal({
-                    skipConversationLaunch: false,
-                });
-            } else {
-                kmChatLoginModal = document.getElementById('km-chat-login-modal');
-                if (kmChatLoginModal) {
-                    kommunicateCommons.setDialogVisibility(
-                        kmChatLoginModal,
-                        true,
-                        deps.loginModalFocusFallbacks || []
-                    );
-                }
-                if (typeof deps.openWidgetForAuthError === 'function') {
-                    deps.openWidgetForAuthError();
-                }
-            }
+            target.reopenAuthModal({
+                skipConversationLaunch: false,
+            });
             var loginErrorNode = document.getElementById('km-error-chat-login');
             if (loginErrorNode) {
                 loginErrorNode.textContent = resolvedMessage || '';
                 kommunicateCommons.show(loginErrorNode);
                 loginErrorNode.style.display = '';
             }
-            var submitBtn = document.getElementById('km-submit-chat-login');
-            if (submitBtn) {
-                kommunicateCommons.show(submitBtn);
-                submitBtn.removeAttribute('disabled');
-            }
+            target.updateAuthSubmitButton(
+                getLeadCollectionLabel('submit', (deps.MCK_LABELS['lead.collection'] || {}).submit)
+            );
         };
 
         target.resetPreChatLoginError = function () {
@@ -466,12 +446,6 @@ var KMPreChat = (function () {
         };
 
         target.addLeadCollectionInputDiv = function () {
-            if (!Array.isArray(deps.KM_PRELEAD_COLLECTION)) {
-                deps.KM_PRELEAD_COLLECTION = [];
-            }
-            if (!Array.isArray(deps.KM_ASK_USER_DETAILS)) {
-                deps.KM_ASK_USER_DETAILS = [];
-            }
             if (!deps.KM_PRELEAD_COLLECTION.length) {
                 syncPreLeadCollectionFromOptions();
             }
@@ -480,7 +454,7 @@ var KMPreChat = (function () {
                 typeof deps.getAuthenticationTypeId === 'function'
                     ? deps.getAuthenticationTypeId()
                     : deps.MCK_AUTHENTICATION_TYPE_ID;
-            if (typeof authTypeId !== 'undefined' && authTypeId > 0) {
+            if (authTypeId > 0) {
                 var hasUserId = deps.KM_PRELEAD_COLLECTION.some(function (item) {
                     return (
                         item &&
@@ -669,11 +643,9 @@ var KMPreChat = (function () {
             var leadCollectionHeading = document.getElementById('km-lead-collection-heading');
             var tabTitle = document.getElementById('km-tab-title');
             if (submitLogin) {
-                var submitLabel = getLeadCollectionLabel('submit', LEAD_COLLECTION_LABEL.submit);
-                submitLogin.innerHTML = submitLabel;
-                submitLogin.setAttribute('aria-label', submitLabel);
-                kommunicateCommons.show(submitLogin);
-                submitLogin.removeAttribute('disabled');
+                target.updateAuthSubmitButton(
+                    getLeadCollectionLabel('submit', LEAD_COLLECTION_LABEL.submit)
+                );
             }
             if (leadCollectionHeading) {
                 var headingText = deps.appOptions.headingFromWidget

--- a/webplugin/js/app/prechat/km-prechat.js
+++ b/webplugin/js/app/prechat/km-prechat.js
@@ -84,6 +84,183 @@ var KMPreChat = (function () {
 
         target.getLeadCollectionLabel = getLeadCollectionLabel;
 
+        target.isPreLeadCollectionEnabled = function () {
+            return (
+                (Array.isArray(deps.KM_ASK_USER_DETAILS) &&
+                    deps.KM_ASK_USER_DETAILS.length !== 0) ||
+                (Array.isArray(deps.KM_PRELEAD_COLLECTION) &&
+                    deps.KM_PRELEAD_COLLECTION.length !== 0)
+            );
+        };
+
+        target.updateAuthSubmitButton = function (submitLabel) {
+            var submitBtn = document.getElementById('km-submit-chat-login');
+            if (!submitBtn) {
+                return;
+            }
+            submitBtn.innerHTML = submitLabel || '';
+            submitBtn.setAttribute('aria-label', submitLabel || '');
+            kommunicateCommons.show(submitBtn);
+            submitBtn.removeAttribute('disabled');
+        };
+
+        function localizeChatLoginModal(modal) {
+            if (!modal || !deps.MCK_LABELS) {
+                return;
+            }
+            var closeBtn = modal.querySelector('#km-modal-close');
+            var closeLabel = deps.MCK_LABELS['close'];
+            if (closeBtn && closeLabel) {
+                closeBtn.setAttribute('aria-label', closeLabel);
+            }
+            var userIdLabel = modal.querySelector('#km-label-user-id');
+            var userIdText = deps.MCK_LABELS['form.label.userId'];
+            if (userIdLabel && userIdText) {
+                userIdLabel.textContent = userIdText;
+            }
+            var submitBtn = modal.querySelector('#km-submit-chat-login');
+            var submitText = (deps.MCK_LABELS['lead.collection'] || {}).submit || '';
+            if (submitBtn && submitText) {
+                if (!submitBtn.textContent) {
+                    submitBtn.textContent = submitText;
+                }
+                submitBtn.setAttribute('aria-label', submitText);
+            }
+        }
+
+        target.ensureChatLoginModalExists = function () {
+            var existingModal = document.getElementById('km-chat-login-modal');
+            if (existingModal) {
+                localizeChatLoginModal(existingModal);
+                return existingModal;
+            }
+            return null;
+        };
+
+        target.ensureAuthFailureFormFields = function (config) {
+            config = config || {};
+            var showUserIdField = config.showUserIdField !== false;
+            if (target.isPreLeadCollectionEnabled()) {
+                return;
+            }
+            target.resetPreChatLoginError && target.resetPreChatLoginError();
+            var form = document.getElementById('km-form-chat-login');
+            if (!form) {
+                return;
+            }
+            var askUserDetailsContainer = form.querySelector('.mck-askuserdetail-inputdiv');
+            if (!askUserDetailsContainer) {
+                return;
+            }
+            var userIdInput = document.getElementById('km-userId');
+            if (userIdInput) {
+                kommunicateCommons.show(userIdInput);
+                userIdInput.setAttribute('type', 'text');
+                if (showUserIdField) {
+                    userIdInput.setAttribute('required', 'true');
+                } else {
+                    userIdInput.removeAttribute('required');
+                }
+                var userIdLabel = deps.MCK_LABELS['form.label.userId'];
+                userIdInput.setAttribute('placeholder', userIdLabel);
+                userIdInput.setAttribute('aria-label', userIdLabel);
+                var userIdLabelNode = document.getElementById('km-label-user-id');
+                if (userIdLabelNode) {
+                    var requiredSvg =
+                        '<svg width="6" height="6" viewBox="0 0 6 6" focusable="false" aria-hidden="true">' +
+                        '<use xlink:href="#icon-69" href="#icon-69"></use>' +
+                        '</svg>';
+                    userIdLabelNode.textContent = userIdLabel;
+                    userIdLabelNode.classList.remove('sr-only');
+                    userIdLabelNode.classList.add('km-form-label', 'km-tertiary-title');
+                    if (userIdInput.hasAttribute('required')) {
+                        userIdLabelNode.innerHTML = userIdLabel + ' ' + requiredSvg;
+                    }
+                    if (
+                        !userIdLabelNode.parentElement.classList.contains('km-form-label-container')
+                    ) {
+                        var labelContainer = document.createElement('div');
+                        labelContainer.className = 'km-form-label-container';
+                        userIdLabelNode.parentElement.insertBefore(labelContainer, userIdLabelNode);
+                        labelContainer.appendChild(userIdLabelNode);
+                    }
+                    var userIdContainer =
+                        typeof userIdInput.closest === 'function'
+                            ? userIdInput.closest('.km-form-group')
+                            : null;
+                    if (!showUserIdField) {
+                        kommunicateCommons.hide(userIdContainer);
+                        userIdLabelNode.classList.add('sr-only');
+                    } else {
+                        kommunicateCommons.show(userIdContainer);
+                        userIdLabelNode.classList.remove('sr-only');
+                    }
+                }
+            }
+            target.updateAuthSubmitButton(target.getLeadCollectionLabel('submit', ''));
+            if (!document.getElementById('km-password')) {
+                var passwordLabel =
+                    target.getLeadCollectionLabel('password', '') ||
+                    (deps.MCK_LABELS['lead.collection'] || {}).password ||
+                    (deps.MCK_LABELS && deps.MCK_LABELS['lead.collection.password']) ||
+                    'Password';
+                askUserDetailsContainer.appendChild(
+                    target.createInputField({
+                        field: passwordLabel,
+                        type: 'password',
+                        placeholder: passwordLabel,
+                        required: true,
+                        id: 'km-password',
+                        name: 'km-password',
+                    })
+                );
+            }
+        };
+
+        target.reopenAuthModal = function (options) {
+            options = options || { skipConversationLaunch: true };
+            typeof deps.ensureWidgetIframeVisible === 'function' &&
+                deps.ensureWidgetIframeVisible();
+            if (typeof deps.openWidgetForAuthError === 'function') {
+                deps.openWidgetForAuthError(options);
+            }
+            var kmChatLoginModal = document.getElementById('km-chat-login-modal');
+            kommunicateCommons.show('#km-chat-login-modal');
+            kommunicateCommons.setDialogVisibility(
+                kmChatLoginModal,
+                true,
+                deps.loginModalFocusFallbacks || []
+            );
+            return kmChatLoginModal;
+        };
+
+        target.clearStoredAuthState = function (options) {
+            options = options || {};
+            deps.kmLocalStorage.deleteLocalStorage(
+                deps.KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
+            );
+            deps.kmLocalStorage.deleteLocalStorage(
+                deps.KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION
+            );
+            if (options.deleteCookies) {
+                deps.kmLocalStorage.deleteUserCookiesOnLogout();
+            }
+            if (options.clearHeaders && typeof deps.clearAppHeaders === 'function') {
+                deps.clearAppHeaders();
+            }
+            if (options.clearTokens && typeof deps.clearAuthTokens === 'function') {
+                deps.clearAuthTokens();
+            }
+        };
+
+        target.clearAuthSessionState = function () {
+            target.clearStoredAuthState({
+                deleteCookies: true,
+                clearHeaders: true,
+                clearTokens: true,
+            });
+        };
+
         target.resolvePreLeadErrorMessage = function () {
             return getLeadCollectionLabel('invalidPasswordMessage', '');
         };

--- a/webplugin/js/app/prechat/km-prechat.js
+++ b/webplugin/js/app/prechat/km-prechat.js
@@ -119,11 +119,12 @@ var KMPreChat = (function () {
                 userIdLabel.textContent = userIdText;
             }
             var submitBtn = modal.querySelector('#km-submit-chat-login');
-            var submitText = (deps.MCK_LABELS['lead.collection'] || {}).submit || '';
+            var submitText = getLeadCollectionLabel(
+                'submit',
+                (deps.MCK_LABELS['lead.collection'] || {}).submit || ''
+            );
             if (submitBtn && submitText) {
-                if (!submitBtn.textContent) {
-                    submitBtn.textContent = submitText;
-                }
+                submitBtn.textContent = submitText;
                 submitBtn.setAttribute('aria-label', submitText);
             }
         }

--- a/webplugin/js/app/prechat/km-prechat.js
+++ b/webplugin/js/app/prechat/km-prechat.js
@@ -233,12 +233,7 @@ var KMPreChat = (function () {
 
         target.clearStoredAuthState = function (options) {
             options = options || {};
-            deps.kmLocalStorage.deleteLocalStorage(
-                deps.KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID
-            );
-            deps.kmLocalStorage.deleteLocalStorage(
-                deps.KommunicateConstants.COOKIES.IS_USER_ID_FOR_LEAD_COLLECTION
-            );
+            deps.clearPersistedAuthState();
             if (options.deleteCookies) {
                 deps.kmLocalStorage.deleteUserCookiesOnLogout();
             }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Refactored the new auth/pre-chat recovery flow to reduce duplication, remove redundant guards, and move auth modal/session handling out of mck-sidebox-1.0.js into the KMPreChat module.
Also cleaned up unused exports and simplified widget/auth state handling while keeping the existing auth-error behavior intact.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized logout/session cleanup and smoother re-authentication flows.
  * New pre-chat modal controls/APIs for labels, accessibility, reopening auth modal, and lead-collection gating.
  * Richer message rendering: media/link previews, reply rendering, custom rich text, encryption-aware uploads, and desktop/in-browser notifications.
  * Expanded group and contact management: member updates, role changes, and detailed group info handling.

* **Bug Fixes**
  * More reliable socket reconnection and session reinitialization.
  * Improved delivery/read status tracking and UI synchronization.
  * Consistent pre-chat error handling and submit-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->