### PR TITLE
restart conversation

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -110,9 +110,15 @@ KommunicateUI = {
         KommunicateUI.pendingClosedConversationBanner = true;
         KommunicateUI.closedConversationBannerTabId = tabId;
         KommunicateUI.closedConversationBannerTimeoutId = setTimeout(function () {
+            var messageBody = document.querySelector('.mck-message-inner.mck-group-inner');
+            var activeTabId =
+                messageBody && typeof messageBody.getAttribute === 'function'
+                    ? messageBody.getAttribute('data-mck-id')
+                    : null;
             if (
                 !KommunicateUI.pendingClosedConversationBanner ||
-                KommunicateUI.closedConversationBannerTabId !== CURRENT_GROUP_DATA.tabId
+                (activeTabId &&
+                    String(KommunicateUI.closedConversationBannerTabId) !== String(activeTabId))
             ) {
                 return;
             }
@@ -1405,6 +1411,9 @@ KommunicateUI = {
     },
     showClosedConversationBanner: function (isConversationClosed) {
         if (!isConversationClosed) {
+            if (CURRENT_GROUP_DATA && CURRENT_GROUP_DATA.feedbackSubmitted) {
+                return;
+            }
             KommunicateUI.clearClosedConversationBannerTimeout();
         }
         var isConvRated = document.getElementsByClassName('mck-rated').length > 0;
@@ -1440,6 +1449,18 @@ KommunicateUI = {
             : kommunicate._globals.collectFeedback;
         var messageBody = document.querySelector('.mck-message-inner.mck-group-inner');
         isConversationClosed && kommunicateCommons.hide('.mck-box-form-container');
+        if (CURRENT_GROUP_DATA && CURRENT_GROUP_DATA.feedbackSubmitted) {
+            kommunicateCommons.hide('#csat-1', '#csat-2', '#csat-3', '#km-widget-options');
+            kommunicateCommons.show('.mck-csat-text-1');
+            kommunicateCommons.modifyClassList(
+                {
+                    id: ['mck-sidebox-ft'],
+                },
+                'mck-restart-conv-banner'
+            );
+            KommunicateUI.updateScroll(messageBody);
+            return;
+        }
         if (KommunicateUI.isConversationResolvedFromZendesk) {
             isCSATenabled && KommunicateUI.triggerCSAT();
             document.getElementById('mck-submit-comment').onclick = function (e) {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1440,22 +1440,30 @@ KommunicateUI = {
             !isCSATtriggeredByUser &&
             !isConvJustResolved
         ) {
-            kommunicateCommons.getFeedback(CURRENT_GROUP_DATA.tabId, feedbackResponseCallback);
+            var activeTabIdForFeedback = CURRENT_GROUP_DATA.tabId;
+            kommunicateCommons.hide('.mck-box-form-container');
+            kommunicateCommons.show('.mck-csat-text-1');
+            kommunicateCommons.modifyClassList(
+                {
+                    id: ['mck-sidebox-ft'],
+                },
+                'mck-restart-conv-banner'
+            );
+            kommunicateCommons.hide('#csat-1', '#csat-2', '#csat-3', '#km-widget-options');
+            KommunicateUI.updateScroll(messageBody);
+            kommunicateCommons.getFeedback(activeTabIdForFeedback, feedbackResponseCallback);
             function feedbackResponseCallback(data) {
+                if (
+                    !CURRENT_GROUP_DATA ||
+                    String(CURRENT_GROUP_DATA.tabId) !== String(activeTabIdForFeedback)
+                ) {
+                    return;
+                }
                 var feedback = data.data;
                 KommunicateUI.convRatedTabIds[CURRENT_GROUP_DATA.tabId] = feedback
                     ? KommunicateConstants.FEEDBACK_API_STATUS.RATED
                     : KommunicateConstants.FEEDBACK_API_STATUS.INIT;
                 CURRENT_GROUP_DATA.currentGroupFeedback = feedback;
-                kommunicateCommons.hide('.mck-box-form-container');
-                kommunicateCommons.show('.mck-csat-text-1');
-                kommunicateCommons.modifyClassList(
-                    {
-                        id: ['mck-sidebox-ft'],
-                    },
-                    'mck-restart-conv-banner'
-                );
-                kommunicateCommons.hide('#csat-1', '#csat-2', '#csat-3', '#km-widget-options');
                 /*
                 csat-1 : csat rating first screen where you can rate via emoticons.
                 csat-2 : csat rating second screen where you can add comments.

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1379,9 +1379,6 @@ KommunicateUI = {
         KommunicateUI.triggerCSAT(triggeredByBot);
     },
     showClosedConversationBanner: function (isConversationClosed) {
-        if (!isConversationClosed) {
-            // keep block for readability; no scheduler cleanup needed
-        }
         var isConvRated = document.getElementsByClassName('mck-rated').length > 0;
         if (kommunicate._globals.oneTimeRating) {
             if (isConvRated && CURRENT_GROUP_DATA.tabId) {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -85,6 +85,7 @@ KommunicateUI = {
     isCSATtriggeredByUser: false,
     isConvJustResolved: false,
     isConversationResolvedFromZendesk: false,
+    restartBannerForced: false,
     faqEventsInitialized: false,
     faqCategoriesReady: false,
     faqCategoryRequestPending: false,
@@ -1441,16 +1442,18 @@ KommunicateUI = {
             !isConvJustResolved
         ) {
             var activeTabIdForFeedback = CURRENT_GROUP_DATA.tabId;
-            kommunicateCommons.hide('.mck-box-form-container');
-            kommunicateCommons.show('.mck-csat-text-1');
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['mck-sidebox-ft'],
-                },
-                'mck-restart-conv-banner'
-            );
+            if (!KommunicateUI.restartBannerForced) {
+                kommunicateCommons.hide('.mck-box-form-container');
+                kommunicateCommons.show('.mck-csat-text-1');
+                kommunicateCommons.modifyClassList(
+                    {
+                        id: ['mck-sidebox-ft'],
+                    },
+                    'mck-restart-conv-banner'
+                );
+                KommunicateUI.updateScroll(messageBody);
+            }
             kommunicateCommons.hide('#csat-1', '#csat-2', '#csat-3', '#km-widget-options');
-            KommunicateUI.updateScroll(messageBody);
             kommunicateCommons.getFeedback(activeTabIdForFeedback, feedbackResponseCallback);
             function feedbackResponseCallback(data) {
                 if (
@@ -1524,6 +1527,7 @@ KommunicateUI = {
             kommunicateCommons.hide('#mck-conversation-status-box');
             !KM_GLOBAL.disableTextArea && kommunicateCommons.show('.mck-box-form-container');
             kommunicateCommons.hide('.mck-csat-text-1');
+            KommunicateUI.restartBannerForced = false;
         }
     },
     handleAttachmentIconVisibility: function (enableAttachment, msg, groupReloaded) {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1411,9 +1411,6 @@ KommunicateUI = {
     },
     showClosedConversationBanner: function (isConversationClosed) {
         if (!isConversationClosed) {
-            if (CURRENT_GROUP_DATA && CURRENT_GROUP_DATA.feedbackSubmitted) {
-                return;
-            }
             KommunicateUI.clearClosedConversationBannerTimeout();
         }
         var isConvRated = document.getElementsByClassName('mck-rated').length > 0;
@@ -1449,18 +1446,6 @@ KommunicateUI = {
             : kommunicate._globals.collectFeedback;
         var messageBody = document.querySelector('.mck-message-inner.mck-group-inner');
         isConversationClosed && kommunicateCommons.hide('.mck-box-form-container');
-        if (CURRENT_GROUP_DATA && CURRENT_GROUP_DATA.feedbackSubmitted) {
-            kommunicateCommons.hide('#csat-1', '#csat-2', '#csat-3', '#km-widget-options');
-            kommunicateCommons.show('.mck-csat-text-1');
-            kommunicateCommons.modifyClassList(
-                {
-                    id: ['mck-sidebox-ft'],
-                },
-                'mck-restart-conv-banner'
-            );
-            KommunicateUI.updateScroll(messageBody);
-            return;
-        }
         if (KommunicateUI.isConversationResolvedFromZendesk) {
             isCSATenabled && KommunicateUI.triggerCSAT();
             document.getElementById('mck-submit-comment').onclick = function (e) {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -89,10 +89,35 @@ KommunicateUI = {
     faqCategoriesReady: false,
     faqCategoryRequestPending: false,
     faqAppData: null,
+    closedConversationBannerTimeoutId: null,
+    closedConversationBannerTabId: null,
+    pendingClosedConversationBanner: false,
     convRatedTabIds: {
         // using for optimize the feedback get api call
         // [tabId]: 1 => init the feedback api
         // [tabId]: 2 => conversations rated
+    },
+    clearClosedConversationBannerTimeout: function () {
+        if (KommunicateUI.closedConversationBannerTimeoutId) {
+            clearTimeout(KommunicateUI.closedConversationBannerTimeoutId);
+            KommunicateUI.closedConversationBannerTimeoutId = null;
+        }
+        KommunicateUI.closedConversationBannerTabId = null;
+        KommunicateUI.pendingClosedConversationBanner = false;
+    },
+    scheduleClosedConversationBanner: function (delayMs, tabId) {
+        KommunicateUI.clearClosedConversationBannerTimeout();
+        KommunicateUI.pendingClosedConversationBanner = true;
+        KommunicateUI.closedConversationBannerTabId = tabId;
+        KommunicateUI.closedConversationBannerTimeoutId = setTimeout(function () {
+            if (
+                !KommunicateUI.pendingClosedConversationBanner ||
+                KommunicateUI.closedConversationBannerTabId !== CURRENT_GROUP_DATA.tabId
+            ) {
+                return;
+            }
+            KommunicateUI.showClosedConversationBanner(true);
+        }, delayMs);
     },
     faqSVGImage:
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><circle class="km-custom-widget-fill" cx="12" cy="12" r="12" fill="#5553B7" fill-rule="nonzero" opacity=".654"/><g transform="translate(6.545 5.818)"><polygon fill="#FFF" points=".033 2.236 .033 12.057 10.732 12.057 10.732 .02 3.324 .02"/><rect class="km-custom-widget-fill" width="6.433" height="1" x="2.144" y="5.468" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><rect class="km-custom-widget-fill" width="4.289" height="1" x="2.144" y="8.095" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><polygon class="km-custom-widget-fill" fill="#5553B7" points="2.656 .563 3.384 2.487 1.162 3.439" opacity=".65" transform="rotate(26 2.273 2.001)"/></g></g></svg>',
@@ -1379,6 +1404,9 @@ KommunicateUI = {
         KommunicateUI.triggerCSAT(triggeredByBot);
     },
     showClosedConversationBanner: function (isConversationClosed) {
+        if (!isConversationClosed) {
+            KommunicateUI.clearClosedConversationBannerTimeout();
+        }
         var isConvRated = document.getElementsByClassName('mck-rated').length > 0;
         if (kommunicate._globals.oneTimeRating) {
             if (isConvRated && CURRENT_GROUP_DATA.tabId) {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -89,41 +89,10 @@ KommunicateUI = {
     faqCategoriesReady: false,
     faqCategoryRequestPending: false,
     faqAppData: null,
-    closedConversationBannerTimeoutId: null,
-    closedConversationBannerTabId: null,
-    pendingClosedConversationBanner: false,
     convRatedTabIds: {
         // using for optimize the feedback get api call
         // [tabId]: 1 => init the feedback api
         // [tabId]: 2 => conversations rated
-    },
-    clearClosedConversationBannerTimeout: function () {
-        if (KommunicateUI.closedConversationBannerTimeoutId) {
-            clearTimeout(KommunicateUI.closedConversationBannerTimeoutId);
-            KommunicateUI.closedConversationBannerTimeoutId = null;
-        }
-        KommunicateUI.closedConversationBannerTabId = null;
-        KommunicateUI.pendingClosedConversationBanner = false;
-    },
-    scheduleClosedConversationBanner: function (delayMs, tabId) {
-        KommunicateUI.clearClosedConversationBannerTimeout();
-        KommunicateUI.pendingClosedConversationBanner = true;
-        KommunicateUI.closedConversationBannerTabId = tabId;
-        KommunicateUI.closedConversationBannerTimeoutId = setTimeout(function () {
-            var messageBody = document.querySelector('.mck-message-inner.mck-group-inner');
-            var activeTabId =
-                messageBody && typeof messageBody.getAttribute === 'function'
-                    ? messageBody.getAttribute('data-mck-id')
-                    : null;
-            if (
-                !KommunicateUI.pendingClosedConversationBanner ||
-                (activeTabId &&
-                    String(KommunicateUI.closedConversationBannerTabId) !== String(activeTabId))
-            ) {
-                return;
-            }
-            KommunicateUI.showClosedConversationBanner(true);
-        }, delayMs);
     },
     faqSVGImage:
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><circle class="km-custom-widget-fill" cx="12" cy="12" r="12" fill="#5553B7" fill-rule="nonzero" opacity=".654"/><g transform="translate(6.545 5.818)"><polygon fill="#FFF" points=".033 2.236 .033 12.057 10.732 12.057 10.732 .02 3.324 .02"/><rect class="km-custom-widget-fill" width="6.433" height="1" x="2.144" y="5.468" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><rect class="km-custom-widget-fill" width="4.289" height="1" x="2.144" y="8.095" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><polygon class="km-custom-widget-fill" fill="#5553B7" points="2.656 .563 3.384 2.487 1.162 3.439" opacity=".65" transform="rotate(26 2.273 2.001)"/></g></g></svg>',
@@ -1411,7 +1380,7 @@ KommunicateUI = {
     },
     showClosedConversationBanner: function (isConversationClosed) {
         if (!isConversationClosed) {
-            KommunicateUI.clearClosedConversationBannerTimeout();
+            // keep block for readability; no scheduler cleanup needed
         }
         var isConvRated = document.getElementsByClassName('mck-rated').length > 0;
         if (kommunicate._globals.oneTimeRating) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3776,6 +3776,7 @@ const firstVisibleMsg = {
                         userId: MCK_USER_ID,
                         email: LOGGED_IN_USER.email,
                     };
+                    CURRENT_GROUP_DATA.feedbackSubmitted = true;
                     kommunicateCommons.hide(
                         '#csat-1',
                         '#csat-2',
@@ -3790,13 +3791,6 @@ const firstVisibleMsg = {
                         },
                         'mck-restart-conv-banner'
                     );
-                    setTimeout(function () {
-                        KommunicateUI.showClosedConversationBanner(true);
-                        var messageBody = document.querySelector(
-                            '.mck-message-inner.mck-group-inner'
-                        );
-                        messageBody && KommunicateUI.updateScroll(messageBody);
-                    }, 0);
                     _this.sendFeedback(feedbackObject);
                 });
                 function updateStarFillFromValue(val) {
@@ -9606,6 +9600,7 @@ const firstVisibleMsg = {
                 }
                 if (msg.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.NOTIFY_MESSAGE) {
                     if (msg.metadata && msg.metadata.feedback) {
+                        CURRENT_GROUP_DATA.feedbackSubmitted = true;
                         var userFeedback = JSON.parse(msg.metadata.feedback);
                         var ratingSmileSVG = kommunicateCommons.getRatingSmilies(
                             userFeedback.rating
@@ -9646,6 +9641,20 @@ const firstVisibleMsg = {
                             },
                         ];
                         _this.getAssineeAndCsatTemplate(replyId, 'csatModule', ratingData);
+                        kommunicateCommons.hide(
+                            '#csat-1',
+                            '#csat-2',
+                            '#csat-3',
+                            '#km-widget-options',
+                            '.mck-box-form-container'
+                        );
+                        kommunicateCommons.show('.mck-csat-text-1');
+                        kommunicateCommons.modifyClassList(
+                            {
+                                id: ['mck-sidebox-ft'],
+                            },
+                            'mck-restart-conv-banner'
+                        );
                     } else if (msg.metadata && msg.metadata.KM_ASSIGN) {
                         var moduleData = {
                             assignee: msg.metadata.LOCALIZATION_VALUE || msg.metadata.KM_ASSIGN,

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3401,11 +3401,9 @@ const firstVisibleMsg = {
                             }
 
                             CURRENT_GROUP_DATA.currentGroupFeedback = result.data.data;
-                            KommunicateUI.showClosedConversationBanner(false);
+                            KommunicateUI.restartBannerForced = true;
+                            KommunicateUI.showClosedConversationBanner(true);
                             document.getElementById('mck-feedback-comment').value = '';
-                            $applozic('#mck-sidebox-ft').removeClass(
-                                'mck-restart-conv-banner km-mid-conv-csat'
-                            );
                             if (appOptions?.appSettings?.chatWidget?.csatRatingBase == 5) {
                                 ratingService.resetStarsColor();
                             }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4221,7 +4221,9 @@ const firstVisibleMsg = {
                 });
             _this.restartConversation = function (event) {
                 kmWidgetEvents.eventTracking(eventMapping.onRestartConversationClick);
-                KommunicateUI.clearClosedConversationBannerTimeout();
+                if (KommunicateUI.closedConversationBannerTabId === CURRENT_GROUP_DATA.tabId) {
+                    KommunicateUI.clearClosedConversationBannerTimeout();
+                }
                 if (
                     event.currentTarget.id == 'km-restart-conversation' &&
                     appOptions.restartConversationByUser

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3776,6 +3776,27 @@ const firstVisibleMsg = {
                         userId: MCK_USER_ID,
                         email: LOGGED_IN_USER.email,
                     };
+                    kommunicateCommons.hide(
+                        '#csat-1',
+                        '#csat-2',
+                        '#csat-3',
+                        '#km-widget-options',
+                        '.mck-box-form-container'
+                    );
+                    kommunicateCommons.show('.mck-csat-text-1');
+                    kommunicateCommons.modifyClassList(
+                        {
+                            id: ['mck-sidebox-ft'],
+                        },
+                        'mck-restart-conv-banner'
+                    );
+                    setTimeout(function () {
+                        KommunicateUI.showClosedConversationBanner(true);
+                        var messageBody = document.querySelector(
+                            '.mck-message-inner.mck-group-inner'
+                        );
+                        messageBody && KommunicateUI.updateScroll(messageBody);
+                    }, 0);
                     _this.sendFeedback(feedbackObject);
                 });
                 function updateStarFillFromValue(val) {
@@ -4243,6 +4264,11 @@ const firstVisibleMsg = {
                     KommunicateUI.showClosedConversationBanner(false);
                     KommunicateUI.isConvJustResolved = false;
                     KommunicateUI.isConversationResolvedFromZendesk = false;
+                    if (CURRENT_GROUP_DATA) {
+                        CURRENT_GROUP_DATA.feedbackSubmitted = false;
+                        CURRENT_GROUP_DATA.currentGroupFeedback = null;
+                    }
+                    kommunicateCommons.hide('.mck-csat-text-1');
                     mckMessageLayout.loadDropdownOptions();
                 }
             };

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3403,6 +3403,8 @@ const firstVisibleMsg = {
                             CURRENT_GROUP_DATA.currentGroupFeedback = result.data.data;
                             KommunicateUI.restartBannerForced = true;
                             KommunicateUI.showClosedConversationBanner(true);
+                            var submitBtn = document.getElementById('mck-submit-comment');
+                            submitBtn && submitBtn.removeAttribute('disabled');
                             document.getElementById('mck-feedback-comment').value = '';
                             if (appOptions?.appSettings?.chatWidget?.csatRatingBase == 5) {
                                 ratingService.resetStarsColor();
@@ -3421,6 +3423,8 @@ const firstVisibleMsg = {
                         }
                     },
                     error: function () {
+                        var submitBtn = document.getElementById('mck-submit-comment');
+                        submitBtn && submitBtn.removeAttribute('disabled');
                         console.log('Error submitting feedback');
                     },
                 });

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -15513,7 +15513,7 @@ const firstVisibleMsg = {
                                 resp.message.metadata.KM_STATUS ===
                                     KommunicateConstants.CONVERSATION_RESOLVED_STATUS
                             ) {
-                                KommunicateUI.isConvJustResolved = !!!KommunicateUI.isConvJustResolved;
+                                KommunicateUI.isConvJustResolved = true;
                                 if (
                                     MCK_BOT_MESSAGE_DELAY !== 0 &&
                                     mckMessageLayout.isMessageSentByBot(resp.message, contact) &&

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3776,13 +3776,6 @@ const firstVisibleMsg = {
                         userId: MCK_USER_ID,
                         email: LOGGED_IN_USER.email,
                     };
-                    kommunicateCommons.hide(
-                        '#csat-1',
-                        '#csat-2',
-                        '#csat-3',
-                        '#km-widget-options',
-                        '.mck-box-form-container'
-                    );
                     kommunicateCommons.show('.mck-csat-text-1');
                     kommunicateCommons.modifyClassList(
                         {
@@ -4237,15 +4230,6 @@ const firstVisibleMsg = {
                 });
             _this.restartConversation = function (event) {
                 kmWidgetEvents.eventTracking(eventMapping.onRestartConversationClick);
-                kommunicateCommons.hide('.mck-csat-text-1');
-                kommunicateCommons.modifyClassList(
-                    {
-                        id: ['mck-sidebox-ft'],
-                    },
-                    '',
-                    'mck-restart-conv-banner'
-                );
-                !KM_GLOBAL.disableTextArea && kommunicateCommons.show('.mck-box-form-container');
                 if (
                     event.currentTarget.id == 'km-restart-conversation' &&
                     appOptions.restartConversationByUser
@@ -4254,6 +4238,13 @@ const firstVisibleMsg = {
                 } else {
                     appOptions.restartConversationByUser &&
                         kommunicateCommons.show('#km-widget-options');
+                    kommunicateCommons.modifyClassList(
+                        {
+                            id: ['mck-sidebox-ft'],
+                        },
+                        '',
+                        'mck-restart-conv-banner'
+                    );
                     if (CURRENT_GROUP_DATA) {
                         CURRENT_GROUP_DATA.currentGroupFeedback = null;
                     }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -15518,6 +15518,7 @@ const firstVisibleMsg = {
                                     mckMessageLayout.isMessageSentByBot(resp.message, contact) &&
                                     !CURRENT_GROUP_DATA.TOKENIZE_RESPONSE
                                 ) {
+                                    KommunicateUI.isConvJustResolved = !!!KommunicateUI.isConvJustResolved;
                                     KommunicateUI.scheduleClosedConversationBanner(
                                         MCK_BOT_MESSAGE_DELAY,
                                         CURRENT_GROUP_DATA.tabId

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3776,7 +3776,6 @@ const firstVisibleMsg = {
                         userId: MCK_USER_ID,
                         email: LOGGED_IN_USER.email,
                     };
-                    CURRENT_GROUP_DATA.feedbackSubmitted = true;
                     kommunicateCommons.hide(
                         '#csat-1',
                         '#csat-2',
@@ -3791,6 +3790,8 @@ const firstVisibleMsg = {
                         },
                         'mck-restart-conv-banner'
                     );
+                    var messageBody = document.querySelector('.mck-message-inner.mck-group-inner');
+                    messageBody && KommunicateUI.updateScroll(messageBody);
                     _this.sendFeedback(feedbackObject);
                 });
                 function updateStarFillFromValue(val) {
@@ -4236,9 +4237,15 @@ const firstVisibleMsg = {
                 });
             _this.restartConversation = function (event) {
                 kmWidgetEvents.eventTracking(eventMapping.onRestartConversationClick);
-                if (KommunicateUI.closedConversationBannerTabId === CURRENT_GROUP_DATA.tabId) {
-                    KommunicateUI.clearClosedConversationBannerTimeout();
-                }
+                kommunicateCommons.hide('.mck-csat-text-1');
+                kommunicateCommons.modifyClassList(
+                    {
+                        id: ['mck-sidebox-ft'],
+                    },
+                    '',
+                    'mck-restart-conv-banner'
+                );
+                !KM_GLOBAL.disableTextArea && kommunicateCommons.show('.mck-box-form-container');
                 if (
                     event.currentTarget.id == 'km-restart-conversation' &&
                     appOptions.restartConversationByUser
@@ -4247,22 +4254,12 @@ const firstVisibleMsg = {
                 } else {
                     appOptions.restartConversationByUser &&
                         kommunicateCommons.show('#km-widget-options');
-                    kommunicateCommons.modifyClassList(
-                        {
-                            id: ['mck-sidebox-ft'],
-                        },
-                        '',
-                        'mck-restart-conv-banner'
-                    );
-
+                    if (CURRENT_GROUP_DATA) {
+                        CURRENT_GROUP_DATA.currentGroupFeedback = null;
+                    }
                     KommunicateUI.showClosedConversationBanner(false);
                     KommunicateUI.isConvJustResolved = false;
                     KommunicateUI.isConversationResolvedFromZendesk = false;
-                    if (CURRENT_GROUP_DATA) {
-                        CURRENT_GROUP_DATA.feedbackSubmitted = false;
-                        CURRENT_GROUP_DATA.currentGroupFeedback = null;
-                    }
-                    kommunicateCommons.hide('.mck-csat-text-1');
                     mckMessageLayout.loadDropdownOptions();
                 }
             };
@@ -9600,7 +9597,6 @@ const firstVisibleMsg = {
                 }
                 if (msg.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.NOTIFY_MESSAGE) {
                     if (msg.metadata && msg.metadata.feedback) {
-                        CURRENT_GROUP_DATA.feedbackSubmitted = true;
                         var userFeedback = JSON.parse(msg.metadata.feedback);
                         var ratingSmileSVG = kommunicateCommons.getRatingSmilies(
                             userFeedback.rating
@@ -9641,20 +9637,6 @@ const firstVisibleMsg = {
                             },
                         ];
                         _this.getAssineeAndCsatTemplate(replyId, 'csatModule', ratingData);
-                        kommunicateCommons.hide(
-                            '#csat-1',
-                            '#csat-2',
-                            '#csat-3',
-                            '#km-widget-options',
-                            '.mck-box-form-container'
-                        );
-                        kommunicateCommons.show('.mck-csat-text-1');
-                        kommunicateCommons.modifyClassList(
-                            {
-                                id: ['mck-sidebox-ft'],
-                            },
-                            'mck-restart-conv-banner'
-                        );
                     } else if (msg.metadata && msg.metadata.KM_ASSIGN) {
                         var moduleData = {
                             assignee: msg.metadata.LOCALIZATION_VALUE || msg.metadata.KM_ASSIGN,
@@ -15549,18 +15531,7 @@ const firstVisibleMsg = {
                                     KommunicateConstants.CONVERSATION_RESOLVED_STATUS
                             ) {
                                 KommunicateUI.isConvJustResolved = true;
-                                if (
-                                    MCK_BOT_MESSAGE_DELAY !== 0 &&
-                                    mckMessageLayout.isMessageSentByBot(resp.message, contact) &&
-                                    !CURRENT_GROUP_DATA.TOKENIZE_RESPONSE
-                                ) {
-                                    KommunicateUI.scheduleClosedConversationBanner(
-                                        MCK_BOT_MESSAGE_DELAY,
-                                        CURRENT_GROUP_DATA.tabId
-                                    );
-                                } else {
-                                    KommunicateUI.showClosedConversationBanner(true);
-                                }
+                                // banner is now shown immediately on submit; avoid delayed re-show
                             } else if (
                                 resp.message.metadata.KM_STATUS ===
                                 KommunicateConstants.CONVERSATION_OPEN_STATUS

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -15522,7 +15522,7 @@ const firstVisibleMsg = {
                                     KommunicateConstants.CONVERSATION_RESOLVED_STATUS
                             ) {
                                 KommunicateUI.isConvJustResolved = true;
-                                // banner is now shown immediately on submit; avoid delayed re-show
+                                KommunicateUI.showClosedConversationBanner(true);
                             } else if (
                                 resp.message.metadata.KM_STATUS ===
                                 KommunicateConstants.CONVERSATION_OPEN_STATUS

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6911,6 +6911,23 @@ const firstVisibleMsg = {
                             data.message[0] && data.message[0].contactIds;
                         CURRENT_GROUP_DATA.teamId =
                             data && data.groupFeeds[0] && data.groupFeeds[0].metadata.KM_TEAM_ID;
+                        // Ensure resolved/closed banner shows immediately on chat open.
+                        if (
+                            !params.startTime &&
+                            params.tabId &&
+                            params.isGroup &&
+                            typeof CURRENT_GROUP_DATA.conversationStatus !== 'undefined'
+                        ) {
+                            var isClosedConversation =
+                                CURRENT_GROUP_DATA.conversationStatus ==
+                                Kommunicate.conversationHelper.status.CLOSED;
+                            if (isClosedConversation) {
+                                KommunicateUI.isConvJustResolved = true;
+                                KommunicateUI.showClosedConversationBanner(true);
+                            } else {
+                                KommunicateUI.showClosedConversationBanner(false);
+                            }
+                        }
                         params.isWaitingQueue && KommunicateUI.handleWaitingQueueMessage();
 
                         const assignee =

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -15513,18 +15513,17 @@ const firstVisibleMsg = {
                                 resp.message.metadata.KM_STATUS ===
                                     KommunicateConstants.CONVERSATION_RESOLVED_STATUS
                             ) {
+                                KommunicateUI.isConvJustResolved = !!!KommunicateUI.isConvJustResolved;
                                 if (
                                     MCK_BOT_MESSAGE_DELAY !== 0 &&
                                     mckMessageLayout.isMessageSentByBot(resp.message, contact) &&
                                     !CURRENT_GROUP_DATA.TOKENIZE_RESPONSE
                                 ) {
-                                    KommunicateUI.isConvJustResolved = !!!KommunicateUI.isConvJustResolved;
                                     KommunicateUI.scheduleClosedConversationBanner(
                                         MCK_BOT_MESSAGE_DELAY,
                                         CURRENT_GROUP_DATA.tabId
                                     );
                                 } else {
-                                    KommunicateUI.isConvJustResolved = !!!KommunicateUI.isConvJustResolved;
                                     KommunicateUI.showClosedConversationBanner(true);
                                 }
                             } else if (

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4221,6 +4221,7 @@ const firstVisibleMsg = {
                 });
             _this.restartConversation = function (event) {
                 kmWidgetEvents.eventTracking(eventMapping.onRestartConversationClick);
+                KommunicateUI.clearClosedConversationBannerTimeout();
                 if (
                     event.currentTarget.id == 'km-restart-conversation' &&
                     appOptions.restartConversationByUser
@@ -15515,9 +15516,10 @@ const firstVisibleMsg = {
                                     mckMessageLayout.isMessageSentByBot(resp.message, contact) &&
                                     !CURRENT_GROUP_DATA.TOKENIZE_RESPONSE
                                 ) {
-                                    setTimeout(function () {
-                                        KommunicateUI.showClosedConversationBanner(true);
-                                    }, MCK_BOT_MESSAGE_DELAY);
+                                    KommunicateUI.scheduleClosedConversationBanner(
+                                        MCK_BOT_MESSAGE_DELAY,
+                                        CURRENT_GROUP_DATA.tabId
+                                    );
                                 } else {
                                     KommunicateUI.isConvJustResolved = !!!KommunicateUI.isConvJustResolved;
                                     KommunicateUI.showClosedConversationBanner(true);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Enable Restart Conversation and chat field after a conversation is resolved.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Locally

### What new thing you came across while writing this code? 
-The closed‑conversation banner is delayed via MCK_BOT_MESSAGE_DELAY, and showClosedConversationBanner behavior is influenced by KommunicateUI.isConvJustResolved.

### In case you fixed a bug then please describe the root cause of it? 
-Root cause: the delayed setTimeout that shows the “Restart this conversation” banner wasn’t cancelled on restart, so it could fire later and re‑show the banner, clearing the input.

### Screenshot
- 
<img width="927" height="909" alt="image" src="https://github.com/user-attachments/assets/f26c9b37-8698-47be-9dbd-3e408e17218d" />

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delayed, debounced display of the "closed conversation" banner that respects tab activity and timing.

* **Bug Fixes**
  * Clears pending closed-conversation banners when conversations restart or reopen to avoid stale UI.
  * Prevents duplicate or lingering banners by canceling scheduled banners when conditions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->