### PR TITLE
Added code for send button sync

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -1779,6 +1779,7 @@ mck-sidebox .mck-group-member-list li a:hover {
     background-color: #fff;
     text-align: left;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 10px;
     padding: 10px 12px;
@@ -2009,15 +2010,21 @@ ul.mck-intent-menu > li:hover {
     margin-top: 2px !important;
 }
 
+#mck-file-box {
+    order: -1;
+    flex: 0 0 100%;
+    margin-bottom: 1px;
+}
+
 .mck-file-box .mck-file-expr {
-    background-color: lavender;
-    color: #5ea9dd;
+    background-color: #efeff5;
+    color: #5F46F8;
     padding: 2px 3px !important;
     font-size: 12px !important;
     font-weight: bold;
     overflow: hidden;
     max-height: 30px;
-    border-radius: 4px;
+    border-radius: 14px;
     width: 99%;
 }
 
@@ -2031,6 +2038,7 @@ ul.mck-intent-menu > li:hover {
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: middle;
+    margin-left: 10px;
     white-space: nowrap;
     max-width: 70%;
 }
@@ -2039,6 +2047,12 @@ ul.mck-intent-menu > li:hover {
     color: #777;
     display: inline-block;
     vertical-align: middle;
+}
+
+.mck-file-expr button.mck-remove-file.mck-box-close {
+    width: 24px;
+    height: 24px;
+    line-height: 1;
 }
 
 .mck-file-expr .km-progress {
@@ -2051,7 +2065,7 @@ ul.mck-intent-menu > li:hover {
 .mck-file-expr .km-progress .km-bar {
     height: 20px;
     background: green;
-    border-radius: 4px;
+    border-radius: 14px;
     width: 0%;
 }
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6419,8 +6419,8 @@ const firstVisibleMsg = {
                     .removeClass('mck-sent-icon')
                     .addClass('mck-pending-icon');
                 mckMessageLayout.addTooltip(randomId);
-                mckMessageLayout.clearMessageField(true);
                 FILE_META = [];
+                mckMessageLayout.clearMessageField(true);
                 delete TAB_MESSAGE_DRAFT[contact.contactId];
             };
             _this.sendForwardMessage = function (forwardMessageKey) {
@@ -14015,7 +14015,11 @@ const firstVisibleMsg = {
                         null,
                         MCK_CUSTOM_UPLOAD_SETTINGS
                     );
-                    mckMessageService.toggleMediaOptions(document.getElementById('mck-text-box'));
+                    setTimeout(function () {
+                        mckMessageService.toggleMediaOptions(
+                            document.getElementById('mck-text-box')
+                        );
+                    }, 0);
                 });
 
                 $applozic(d).on('click', '.mck-remove-file', function () {
@@ -14038,7 +14042,11 @@ const firstVisibleMsg = {
                             }
                         });
                     }
-                    mckMessageService.toggleMediaOptions(document.getElementById('mck-text-box'));
+                    setTimeout(function () {
+                        mckMessageService.toggleMediaOptions(
+                            document.getElementById('mck-text-box')
+                        );
+                    }, 0);
                 });
 
                 $mck_autosuggest_search_input.on('input', function (e) {

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4291,12 +4291,13 @@ const firstVisibleMsg = {
             };
             _this.toggleMediaOptions = function (el) {
                 var text = '';
+                var hasAttachments = FILE_META.length > 0 || $applozic('.mck-file-box').length > 0;
                 if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
                     text = el.value;
                 } else {
                     text = el.textContent;
                 }
-                if (text == '' || !text.replace(/\s/g, '').length) {
+                if ((text == '' || !text.replace(/\s/g, '').length) && !hasAttachments) {
                     _this.hideSendButton();
                     Kommunicate.typingAreaService.showMicIfRequiredWebAPISupported();
                     appOptions.voiceChat && kommunicateCommons.show('#mck-voice-web');
@@ -14014,6 +14015,7 @@ const firstVisibleMsg = {
                         null,
                         MCK_CUSTOM_UPLOAD_SETTINGS
                     );
+                    mckMessageService.toggleMediaOptions(document.getElementById('mck-text-box'));
                 });
 
                 $applozic(d).on('click', '.mck-remove-file', function () {
@@ -14036,6 +14038,7 @@ const firstVisibleMsg = {
                             }
                         });
                     }
+                    mckMessageService.toggleMediaOptions(document.getElementById('mck-text-box'));
                 });
 
                 $mck_autosuggest_search_input.on('input', function (e) {
@@ -14204,6 +14207,9 @@ const firstVisibleMsg = {
                             );
                             $mck_text_box.removeAttr('required');
                             FILE_META.push(file_meta);
+                            mckMessageService.toggleMediaOptions(
+                                document.getElementById('mck-text-box')
+                            );
                             $fileContainer.data('mckfile', file_meta);
                             $mck_file_upload.children('input').val('');
                             if (params.callback) {
@@ -14377,6 +14383,9 @@ const firstVisibleMsg = {
                             );
                             $mck_text_box.removeAttr('required');
                             FILE_META.push(file_meta);
+                            mckMessageService.toggleMediaOptions(
+                                document.getElementById('mck-text-box')
+                            );
                             $fileContainer.data('mckfile', file_meta);
                             $mck_file_upload.children('input').val('');
                             if (params.callback) {
@@ -14508,6 +14517,7 @@ const firstVisibleMsg = {
                     $file_remove.attr('disabled', false);
                     kommunicateCommons.hide('.mck-file-box.' + fileboxId + ' .km-progress');
                     FILE_META.push(file.fileMeta);
+                    mckMessageService.toggleMediaOptions(document.getElementById('mck-text-box'));
                 } else {
                     $mck_msg_sbmt.attr('disabled', true);
                     $file_remove.attr('disabled', true);

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -60,8 +60,7 @@ var kmCustomIframe =
     '.km-iframe-dimension-with-popup{ ' +
     '    height: 85vh; ' +
     '    max-height: 800px; ' +
-    '    width: 27vw; ' +
-    '    min-width: 390px; ' +
+    '    width: 420px; ' +
     '} \n ' +
     '.km-iframe-closed{ ' +
     '    height: 75px; ' +

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -60,8 +60,19 @@ var kmCustomIframe =
     '.km-iframe-dimension-with-popup{ ' +
     '    height: 85vh; ' +
     '    max-height: 800px; ' +
-    '    width: 420px; ' +
+    '    width: 27vw; ' +
+    '    min-width: 390px; ' +
     '} \n ' +
+    '@media only screen and (max-width:600px) { ' +
+    '.kommunicate-custom-iframe.km-iframe-dimension-with-popup, ' +
+    '.kommunicate-custom-iframe.km-iframe-dimension-no-popup { ' +
+    '   width: 100% !important;' +
+    '   min-width: 0 !important;' +
+    '   left: 0 !important;' +
+    '   right: 0 !important;' +
+    '   bottom: 0 !important;' +
+    '} ' +
+    '} \n' +
     '.km-iframe-closed{ ' +
     '    height: 75px; ' +
     '    width:  75px; ' +

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -1089,6 +1089,7 @@
                                 </div>
                                 <div class="mck-form-group last last-child">
                                     <div id="mck-textbox-container" class="mck-textbox-container">
+                                        <div id="mck-file-box" class="n-vis"></div>
                                         <div class="mck-icons-wrapper">
                                             <!-- Emoji Picker Button -->
                                             <button
@@ -1418,7 +1419,6 @@
                                             accept="video/*"
                                             capture
                                         />
-                                        <div id="mck-file-box" class="n-vis"></div>
                                         <div
                                             id="km-voice-listening-status"
                                             class="km-voice-inline-status n-vis"


### PR DESCRIPTION
### What do you want to achieve?
- Show send button when a video is added in the chat widget message.
- Currently, the send button only appears when the text box has content.
Reference : https://intentive-ai.slack.com/archives/C01JLBPFNJ0/p1773912026979339 (Only Video part)

### PR Checklist
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
- Tested locally by attaching video/file in chat widget.


### What new thing you came across while writing this code?
- 

### In case you fixed a bug then please describe the root cause of it?
- Send button logic was only checking text-box value.
- It was not considering files/videos present in file-box.

### Screenshot
- Before : 
<img width="385" height="635" alt="image" src="https://github.com/user-attachments/assets/21721aaa-4282-4aa4-b308-7868498342de" />

- Fixed UI : 
<img width="288" height="572" alt="image" src="https://github.com/user-attachments/assets/23a15f05-7a92-41f4-bdf5-d2a3e825d7c5" />


NOTE: Make sure you're comparing your branch with the correct base branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Send button stays enabled when attachments exist even if message text is empty/whitespace.
  * Attachment removal reliably clears attachments and updates the input field state.
  * Media options and send-button update immediately after adding, removing, or selecting files.

* **Style / Layout**
  * File preview area moved into the message input region, reordered for better wrapping and rounded visuals.
  * Mobile/widget viewport now forces full-width on narrow screens for more consistent sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->