### PR TITLE
customization chat issue

### DIFF
--- a/example/demo2.html
+++ b/example/demo2.html
@@ -771,20 +771,6 @@
                 ) {
                     globalSettings.widgetSettings = {};
                 }
-                // for demo when domain restriction is enabled
-                const previewHost = window.location.hostname;
-                if (previewHost === 'localhost' || previewHost === '127.0.0.1') {
-                    const existingAllowed = Array.isArray(
-                        globalSettings.widgetSettings.allowedDomains
-                    )
-                        ? globalSettings.widgetSettings.allowedDomains
-                        : [];
-                    if (!existingAllowed.includes(previewHost)) {
-                        globalSettings.widgetSettings.allowedDomains = existingAllowed.concat(
-                            previewHost
-                        );
-                    }
-                }
                 globalSettings.widgetSettings.position = config.widgetPosition;
 
                 if (config.voiceModeEnabled) {

--- a/example/demo2.html
+++ b/example/demo2.html
@@ -771,6 +771,20 @@
                 ) {
                     globalSettings.widgetSettings = {};
                 }
+                // for demo when domain restriction is enabled
+                const previewHost = window.location.hostname;
+                if (previewHost === 'localhost' || previewHost === '127.0.0.1') {
+                    const existingAllowed = Array.isArray(
+                        globalSettings.widgetSettings.allowedDomains
+                    )
+                        ? globalSettings.widgetSettings.allowedDomains
+                        : [];
+                    if (!existingAllowed.includes(previewHost)) {
+                        globalSettings.widgetSettings.allowedDomains = existingAllowed.concat(
+                            previewHost
+                        );
+                    }
+                }
                 globalSettings.widgetSettings.position = config.widgetPosition;
 
                 if (config.voiceModeEnabled) {

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -219,9 +219,8 @@ KommunicateConstants = {
     },
     KOMMUNICATE_DOMAINS: [
         'kommunicate.io',
+        'dashboard.kommunicate.io',
         'dashboard-test.kommunicate.io',
-        'localhost',
-        '127.0.0.1',
     ],
     AWS_IMAGE_URL_EXPIRY_TIME: 15 * 60 * 1000,
     IMAGE_PLACEHOLDER_URL: 'https://cdn.kommunicate.io/kommunicate/image-placeholder.png',

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -221,6 +221,9 @@ KommunicateConstants = {
         'kommunicate.io',
         'dashboard.kommunicate.io',
         'dashboard-test.kommunicate.io',
+        //use when testing locally
+        // 'localhost',
+        // '127.0.0.1',
     ],
     AWS_IMAGE_URL_EXPIRY_TIME: 15 * 60 * 1000,
     IMAGE_PLACEHOLDER_URL: 'https://cdn.kommunicate.io/kommunicate/image-placeholder.png',

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -217,7 +217,12 @@ KommunicateConstants = {
         LEFT: 'left',
         RIGHT: 'right',
     },
-    KOMMUNICATE_DOMAINS: ['kommunicate.io'],
+    KOMMUNICATE_DOMAINS: [
+        'kommunicate.io',
+        'dashboard-test.kommunicate.io',
+        'localhost',
+        '127.0.0.1',
+    ],
     AWS_IMAGE_URL_EXPIRY_TIME: 15 * 60 * 1000,
     IMAGE_PLACEHOLDER_URL: 'https://cdn.kommunicate.io/kommunicate/image-placeholder.png',
     MAX_UPLOAD_SIZE: 25000000,

--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -219,8 +219,6 @@ KommunicateConstants = {
     },
     KOMMUNICATE_DOMAINS: [
         'kommunicate.io',
-        'dashboard.kommunicate.io',
-        'dashboard-test.kommunicate.io',
         //use when testing locally
         // 'localhost',
         // '127.0.0.1',

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -428,10 +428,11 @@ function ApplozicSidebox() {
             var hostname = '';
             try {
                 while (
-                    contextWindow &&
-                    contextWindow !== contextWindow.parent &&
-                    contextWindow.location &&
-                    String(contextWindow.location.href).indexOf('about:srcdoc') === 0
+                    (contextWindow &&
+                        contextWindow !== contextWindow.parent &&
+                        contextWindow.location &&
+                        String(contextWindow.location.href).indexOf('about:srcdoc') === 0) ||
+                    String(contextWindow.location.href) === 'about:blank'
                 ) {
                     contextWindow = contextWindow.parent;
                 }

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -424,9 +424,25 @@ function ApplozicSidebox() {
                     : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
 
             var allowedDomains = widgetSettings.allowedDomains;
-            var currentHref = parent.window.location.href || '';
-            var hostname = parent.window.location.hostname.toLowerCase();
-            var isSrcdoc = window.location.href.indexOf('about:srcdoc') === 0;
+            var contextWindow = window;
+            var hostname = '';
+            try {
+                while (
+                    contextWindow &&
+                    contextWindow !== contextWindow.parent &&
+                    contextWindow.location &&
+                    String(contextWindow.location.href).indexOf('about:srcdoc') === 0
+                ) {
+                    contextWindow = contextWindow.parent;
+                }
+                hostname = (
+                    (contextWindow.location && contextWindow.location.hostname) ||
+                    ''
+                ).toLowerCase();
+            } catch (error) {
+                // Fail closed when parent location can't be inspected.
+                hostname = (window.location.hostname || '').toLowerCase();
+            }
 
             // check if the current hostname is equal to or a subdomain
             // e.g. www.google.com is a subdomain of google.com
@@ -461,7 +477,6 @@ function ApplozicSidebox() {
 
             // Remove scripts if chatwidget is restricted by domains
             var isCurrentDomainDisabled =
-                !isSrcdoc &&
                 Array.isArray(allowedDomains) &&
                 allowedDomains.length &&
                 !allowedDomains.some(isSubDomain);

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -424,7 +424,9 @@ function ApplozicSidebox() {
                     : widgetSettings.disableChatWidget; // Give priority to appOptions over API data.
 
             var allowedDomains = widgetSettings.allowedDomains;
+            var currentHref = parent.window.location.href || '';
             var hostname = parent.window.location.hostname.toLowerCase();
+            var isSrcdoc = currentHref.indexOf('about:srcdoc') === 0;
 
             // check if the current hostname is equal to or a subdomain
             // e.g. www.google.com is a subdomain of google.com
@@ -459,6 +461,7 @@ function ApplozicSidebox() {
 
             // Remove scripts if chatwidget is restricted by domains
             var isCurrentDomainDisabled =
+                !isSrcdoc &&
                 Array.isArray(allowedDomains) &&
                 allowedDomains.length &&
                 !allowedDomains.some(isSubDomain);

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -426,7 +426,7 @@ function ApplozicSidebox() {
             var allowedDomains = widgetSettings.allowedDomains;
             var currentHref = parent.window.location.href || '';
             var hostname = parent.window.location.hostname.toLowerCase();
-            var isSrcdoc = currentHref.indexOf('about:srcdoc') === 0;
+            var isSrcdoc = window.location.href.indexOf('about:srcdoc') === 0;
 
             // check if the current hostname is equal to or a subdomain
             // e.g. www.google.com is a subdomain of google.com

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -428,11 +428,11 @@ function ApplozicSidebox() {
             var hostname = '';
             try {
                 while (
-                    (contextWindow &&
-                        contextWindow !== contextWindow.parent &&
-                        contextWindow.location &&
-                        String(contextWindow.location.href).indexOf('about:srcdoc') === 0) ||
-                    String(contextWindow.location.href) === 'about:blank'
+                    contextWindow &&
+                    contextWindow !== contextWindow.parent &&
+                    contextWindow.location &&
+                    (String(contextWindow.location.href).indexOf('about:srcdoc') === 0 ||
+                        String(contextWindow.location.href) === 'about:blank')
                 ) {
                     contextWindow = contextWindow.parent;
                 }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Ensure the chat widget preview (Customization & Playground) loads correctly even when domain restrictions are enabled.
-Fix chat widget preview loading in dashboard customization and local demo while keeping domain restriction enforcement safe for srcdoc/about:blank embeds.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Dashboard customization preview on http://127.0.0.1:3000/settings/chat-widget-customization.
Local preview via example/demo2.html on http://127.0.0.1:3030/example/demo2.html.
Verified domain restriction logic with/without allowedDomains, including srcdoc/about:blank iframe contexts.

### What new thing you came across while writing this code? 
-Safari (and some older browsers) use about:blank when srcdoc is unsupported; preview host resolution must handle both about:srcdoc and about:blank.

### In case you fixed a bug then please describe the root cause of it? 
-The widget was not loading in customization preview because domain checks were using the iframe’s about:srcdoc/about:blank context, which doesn’t provide a real hostname. This caused allowedDomains evaluation to fail or be bypassed. Resolving the effective hostname from the nearest non‑srcdoc/about:blank parent fixes it while still enforcing domain restrictions.
- Root cause: Customization preview loads inside `about:srcdoc`, so `window.location.hostname` is empty. The SDK domain restriction logic used this value, causing the widget to be blocked when allowlist was enabled.

### Screenshot
- NA

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accept preview on localhost/127.0.0.1 by initializing and appending the preview host to allowed domains when missing.
  * Improve embedded preview handling by skipping domain-restriction checks for srcdoc/about:blank contexts and using the first accessible parent frame location when available.
  * Expand recognized service domains to include dashboard.kommunicate.io and dashboard-test.kommunicate.io.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->