### PR TITLE
Add box-shadow in Web widget Iframe.

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -5702,14 +5702,10 @@ div[name='message']:last-child {
 }
 
 .mck-sidebox.km-iframe-sidebox-border-radius {
-    bottom: 4px !important;
+    bottom: 0px !important;
     height: auto !important;
     max-height: none !important;
     right: 35px !important;
-}
-
-.mck-sidebox.km-iframe-sidebox-bottom-reset {
-    bottom: 0 !important;
 }
 
 

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -355,6 +355,9 @@ KommunicateUI = {
         }
     },
     isAttachmentV2: function (mediaType) {
+        if (KM_FORCE_COMPOSE_ATTACHMENT_FLOW) {
+            return false;
+        }
         if (!mediaType) {
             return true;
             // if attachment has no file type or media type considering as v2 attachment. for example java file doesn't have media type.

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -15,6 +15,7 @@ var MCK_BOT_MESSAGE_QUEUE = [];
 var WAITING_QUEUE = [];
 var AVAILABLE_VOICES_FOR_TTS = new Array();
 // Keep attachments in the compose area instead of the direct-send V2 flow.
+var KM_FORCE_COMPOSE_ATTACHMENT_FLOW = true;
 var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = [];
 var FILE_ERROR_LABEL_KEYS = {
     INVALID_FILE: 'file.error.invalid',

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -14,7 +14,8 @@ var IS_SOCKET_CONNECTED = false;
 var MCK_BOT_MESSAGE_QUEUE = [];
 var WAITING_QUEUE = [];
 var AVAILABLE_VOICES_FOR_TTS = new Array();
-var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = ['application', 'text', 'image'];
+// Keep attachments in the compose area instead of the direct-send V2 flow.
+var KM_ATTACHMENT_V2_SUPPORTED_MIME_TYPES = [];
 var FILE_ERROR_LABEL_KEYS = {
     INVALID_FILE: 'file.error.invalid',
     FILE_TOO_LARGE: 'file.error.tooLarge',
@@ -3354,11 +3355,6 @@ const firstVisibleMsg = {
                         return;
                     }
                     sidebox.classList.add('km-iframe-sidebox-border-radius');
-                    if (iframeMedia.matches) {
-                        sidebox.classList.add('km-iframe-sidebox-bottom-reset');
-                    } else {
-                        sidebox.classList.remove('km-iframe-sidebox-bottom-reset');
-                    }
                 };
                 updateIframeBorderRadiusForViewport();
                 iframeMedia.addListener(updateIframeBorderRadiusForViewport);

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -62,7 +62,7 @@ var kmCustomIframe =
     '    max-height: 800px; ' +
     '    width: 27vw; ' +
     '    min-width: 390px; ' +
-    '    box-shadow: 0 2rem 3rem -1rem rgba(0,0,0,.4)' +
+    '    box-shadow: 0 1.5rem 2rem rgba(0,0,0,.3);' +
     '} \n ' +
     '@media only screen and (max-width:600px) { ' +
     '.kommunicate-custom-iframe.km-iframe-dimension-with-popup, ' +

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -62,6 +62,7 @@ var kmCustomIframe =
     '    max-height: 800px; ' +
     '    width: 27vw; ' +
     '    min-width: 390px; ' +
+    '    box-shadow: 0 2rem 3rem -1rem rgba(0,0,0,.4)' +
     '} \n ' +
     '@media only screen and (max-width:600px) { ' +
     '.kommunicate-custom-iframe.km-iframe-dimension-with-popup, ' +


### PR DESCRIPTION
### What do you want to achieve?
#### In the iframe view, the boundary/border is not visible and the UI currently looks like this:

- After the fix, the iframe appears correctly with the expected boundary:

### PR Checklist
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.


### How was the code tested?
- 


### What new thing you came across while writing this code?
- 


### In case you fixed a bug then please describe the root cause of it?
- The iframe container was not rendering the expected visible boundary styling, which caused the UI to look incomplete. The fix ensures the proper border/boundary styling is applied in iframe view.


### Screenshot
- Before : <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/248e438d-1912-4a11-8b85-8ffdd22e07a6" />   
- After : <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/4db2c98e-c84f-4680-953e-41cf05bee897" />

# Added text area for attachments. 
<img width="477" height="615" alt="image" src="https://github.com/user-attachments/assets/4cbfe2f5-128f-4a52-9df6-1f7b5be4c086" />



### Note
- Make sure you are comparing your branch with the correct base branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Popup iframes now render a drop shadow for improved visual depth.
* **Bug Fixes**
  * Sidebox iframe positioning adjusted to sit flush at the bottom.
  * Attachment handling updated so attachments open in the compose area (no longer routed through the previous direct-send flow).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->