### PR TITLE
Fix chat widget collapsing at 4K resolution

### DIFF
--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -84,20 +84,22 @@
 }
 
 /* Ensure iframe sidebox fills available height when open on large viewports */
-body.mck-box-open .mck-sidebox,
-body.mck-box-open .mck-sidebox.mck-box,
-body.mck-box-open .mck-sidebox.mck-box.fade.in {
-    height: 100% !important;
-    max-height: 100% !important;
-}
-body.mck-box-open .mck-sidebox .mck-box-dialog,
-body.mck-box-open .mck-sidebox .mck-box-sm,
-body.mck-box-open .mck-sidebox .mck-box-md {
-    height: 100% !important;
-    max-height: 100% !important;
-}
-body.mck-box-open .mck-sidebox .mck-right {
-    bottom: 0 !important;
+@media (min-height: 1000px) {
+    body.mck-box-open .mck-sidebox,
+    body.mck-box-open .mck-sidebox.mck-box,
+    body.mck-box-open .mck-sidebox.mck-box.fade.in {
+        height: 100% !important;
+        max-height: 100% !important;
+    }
+    body.mck-box-open .mck-sidebox .mck-box-dialog,
+    body.mck-box-open .mck-sidebox .mck-box-sm,
+    body.mck-box-open .mck-sidebox .mck-box-md {
+        height: 100% !important;
+        max-height: 100% !important;
+    }
+    body.mck-box-open .mck-sidebox .mck-right {
+        bottom: 0 !important;
+    }
 }
 
 /* Container mode: ensure html, body, and wrapper elements have full height */

--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -88,8 +88,8 @@
     body.mck-box-open .mck-sidebox,
     body.mck-box-open .mck-sidebox.mck-box,
     body.mck-box-open .mck-sidebox.mck-box.fade.in {
-        height: 100% !important;
-        max-height: 100% !important;
+        height: calc(100% - 38px) !important;
+        max-height: calc(100% - 38px) !important;
     }
     body.mck-box-open .mck-sidebox .mck-box-dialog,
     body.mck-box-open .mck-sidebox .mck-box-sm,

--- a/webplugin/css/app/mck-sidebox-1.0.css
+++ b/webplugin/css/app/mck-sidebox-1.0.css
@@ -83,6 +83,23 @@
     box-shadow: 0 1.5rem 2rem rgba(0, 0, 0, 0.3);
 }
 
+/* Ensure iframe sidebox fills available height when open on large viewports */
+body.mck-box-open .mck-sidebox,
+body.mck-box-open .mck-sidebox.mck-box,
+body.mck-box-open .mck-sidebox.mck-box.fade.in {
+    height: 100% !important;
+    max-height: 100% !important;
+}
+body.mck-box-open .mck-sidebox .mck-box-dialog,
+body.mck-box-open .mck-sidebox .mck-box-sm,
+body.mck-box-open .mck-sidebox .mck-box-md {
+    height: 100% !important;
+    max-height: 100% !important;
+}
+body.mck-box-open .mck-sidebox .mck-right {
+    bottom: 0 !important;
+}
+
 /* Container mode: ensure html, body, and wrapper elements have full height */
 body.km-container-mode,
 body.km-container-mode.mck-box-open {

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -60,8 +60,9 @@ var kmCustomIframe =
     '.km-iframe-dimension-with-popup{ ' +
     '    height: 85vh; ' +
     '    max-height: 800px; ' +
-    '    width: 390px; ' +
-    '    max-width: 390px; ' +
+    '    width: 27vw; ' +
+    '    min-width: 390px; ' +
+    '    max-width: 460px; ' +
     '    box-shadow: 0 1.5rem 2rem rgba(0,0,0,.3);' +
     '} \n ' +
     '@media only screen and (max-width:600px) { ' +

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -60,8 +60,8 @@ var kmCustomIframe =
     '.km-iframe-dimension-with-popup{ ' +
     '    height: 85vh; ' +
     '    max-height: 800px; ' +
-    '    width: 27vw; ' +
-    '    min-width: 390px; ' +
+    '    width: 390px; ' +
+    '    max-width: 390px; ' +
     '    box-shadow: 0 1.5rem 2rem rgba(0,0,0,.3);' +
     '} \n ' +
     '@media only screen and (max-width:600px) { ' +


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix chat widget collapsing/misaligned at 4K resolution by ensuring the sidebox/dialog height is properly set and keeping popup width consistent.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Manual: open example/demo2.html at 3840×2160, launch widget, verify iframe loads and sidebox/dialog heights are non‑zero and layout is aligned. Also verified at smaller resolution for consistency.


### What new thing you came across while writing this code? 
-The widget iframe can be correctly sized while the internal sidebox collapses because .mck-right is absolutely positioned and the parent has no explicit height at large viewports.

### In case you fixed a bug then please describe the root cause of it? 
-At large viewports, #mck-sidebox and .mck-box-dialog computed to 0px height because their parent chain lacked explicit height, causing the backdrop height to collapse and the layout to misalign. Mobile rules masked this by forcing top/bottom anchoring.


### Screenshot
Before
4k
<img width="935" height="528" alt="image" src="https://github.com/user-attachments/assets/39cef0ff-decd-4fe2-83fc-1970309c4830" />
After->
4k
<img width="863" height="523" alt="image" src="https://github.com/user-attachments/assets/6ee2aa6c-5531-4abf-a633-bb00c5be99e7" />
DCI 4k
<img width="921" height="527" alt="image" src="https://github.com/user-attachments/assets/3d23417d-12d6-4e52-a6d4-8ec4b59471d8" />


NOTE: Make sure you're comparing your branch with the correct base branch

Summary:
The iframe is the “window” where the chat lives, and that window is the right size.
But inside that window, the chat box is positioned absolutely, and its parent doesn’t have a fixed height.
Without a fixed height, the browser treats the chat box’s height as zero, so it collapses.
On small screens it works because a mobile rule pins it to top and bottom, so it gets a real height.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sidebox layout for larger viewport heights to ensure better content display.
  * Adjusted iframe width behavior for more consistent rendering across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->