### PR TITLE
Fix race condition in conversation create

### DIFF
--- a/webplugin/js/app/km-bottom-tabs.js
+++ b/webplugin/js/app/km-bottom-tabs.js
@@ -312,10 +312,21 @@
         function getActiveConversationId() {
             var messageInner =
                 documentRef && documentRef.querySelector('#mck-message-cell .mck-message-inner');
+            var messageInnerDataId = null;
+            var jq =
+                (typeof w !== 'undefined' && (w.$applozic || w.jQuery)) ||
+                (typeof $applozic !== 'undefined' && $applozic) ||
+                (typeof jQuery !== 'undefined' && jQuery);
+            if (messageInner && typeof jq === 'function') {
+                try {
+                    messageInnerDataId = jq(messageInner).data('mck-id');
+                } catch (e) {}
+            }
             return (
                 messageInner &&
                 (messageInner.getAttribute('data-mck-id') ||
-                    (messageInner.dataset && messageInner.dataset.mckId))
+                    (messageInner.dataset && messageInner.dataset.mckId) ||
+                    messageInnerDataId)
             );
         }
 
@@ -453,10 +464,21 @@
                         var latestMessageInner =
                             documentRef &&
                             documentRef.querySelector('#mck-message-cell .mck-message-inner');
+                        var latestMessageInnerDataId = null;
+                        var jq =
+                            (typeof w !== 'undefined' && (w.$applozic || w.jQuery)) ||
+                            (typeof $applozic !== 'undefined' && $applozic) ||
+                            (typeof jQuery !== 'undefined' && jQuery);
+                        if (latestMessageInner && typeof jq === 'function') {
+                            try {
+                                latestMessageInnerDataId = jq(latestMessageInner).data('mck-id');
+                            } catch (e) {}
+                        }
                         var lastTabId =
                             latestMessageInner &&
                             (latestMessageInner.getAttribute('data-mck-id') ||
-                                (latestMessageInner.dataset && latestMessageInner.dataset.mckId));
+                                (latestMessageInner.dataset && latestMessageInner.dataset.mckId) ||
+                                latestMessageInnerDataId);
                         if (lastTabId) {
                             kommunicateCommons.show('#mck-tab-individual');
                             kommunicateCommons.hide('#mck-tab-conversation');

--- a/webplugin/js/app/km-bottom-tabs.js
+++ b/webplugin/js/app/km-bottom-tabs.js
@@ -312,11 +312,7 @@
         function getActiveConversationId() {
             var messageInner =
                 documentRef && documentRef.querySelector('#mck-message-cell .mck-message-inner');
-            return (
-                messageInner &&
-                (messageInner.getAttribute('data-mck-id') ||
-                    (messageInner.dataset && messageInner.dataset.mckId))
-            );
+            return messageInner && messageInner.getAttribute('data-mck-id');
         }
 
         function isConversationTabActive() {
@@ -454,9 +450,7 @@
                             documentRef &&
                             documentRef.querySelector('#mck-message-cell .mck-message-inner');
                         var lastTabId =
-                            latestMessageInner &&
-                            (latestMessageInner.getAttribute('data-mck-id') ||
-                                (latestMessageInner.dataset && latestMessageInner.dataset.mckId));
+                            latestMessageInner && latestMessageInner.getAttribute('data-mck-id');
                         if (lastTabId) {
                             kommunicateCommons.show('#mck-tab-individual');
                             kommunicateCommons.hide('#mck-tab-conversation');

--- a/webplugin/js/app/km-bottom-tabs.js
+++ b/webplugin/js/app/km-bottom-tabs.js
@@ -312,21 +312,10 @@
         function getActiveConversationId() {
             var messageInner =
                 documentRef && documentRef.querySelector('#mck-message-cell .mck-message-inner');
-            var messageInnerDataId = null;
-            var jq =
-                (typeof w !== 'undefined' && (w.$applozic || w.jQuery)) ||
-                (typeof $applozic !== 'undefined' && $applozic) ||
-                (typeof jQuery !== 'undefined' && jQuery);
-            if (messageInner && typeof jq === 'function') {
-                try {
-                    messageInnerDataId = jq(messageInner).data('mck-id');
-                } catch (e) {}
-            }
             return (
                 messageInner &&
                 (messageInner.getAttribute('data-mck-id') ||
-                    (messageInner.dataset && messageInner.dataset.mckId) ||
-                    messageInnerDataId)
+                    (messageInner.dataset && messageInner.dataset.mckId))
             );
         }
 
@@ -464,21 +453,10 @@
                         var latestMessageInner =
                             documentRef &&
                             documentRef.querySelector('#mck-message-cell .mck-message-inner');
-                        var latestMessageInnerDataId = null;
-                        var jq =
-                            (typeof w !== 'undefined' && (w.$applozic || w.jQuery)) ||
-                            (typeof $applozic !== 'undefined' && $applozic) ||
-                            (typeof jQuery !== 'undefined' && jQuery);
-                        if (latestMessageInner && typeof jq === 'function') {
-                            try {
-                                latestMessageInnerDataId = jq(latestMessageInner).data('mck-id');
-                            } catch (e) {}
-                        }
                         var lastTabId =
                             latestMessageInner &&
                             (latestMessageInner.getAttribute('data-mck-id') ||
-                                (latestMessageInner.dataset && latestMessageInner.dataset.mckId) ||
-                                latestMessageInnerDataId);
+                                (latestMessageInner.dataset && latestMessageInner.dataset.mckId));
                         if (lastTabId) {
                             kommunicateCommons.show('#mck-tab-individual');
                             kommunicateCommons.hide('#mck-tab-conversation');

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -724,6 +724,7 @@ $applozic.extend(true, Kommunicate, {
     setDefaultIframeConfigForClosedChat: function () {
         var kommunicateIframe = parent.document.getElementById('kommunicate-widget-iframe');
         if (kommunicateIframe) {
+            kommunicateCommons.cleanupIframeResizeListener(kommunicateIframe);
             kommunicateIframe.style.height = '';
             kommunicateIframe.classList.add('km-iframe-closed');
             kommunicateIframe.classList.remove('kommunicate-iframe-enable-media-query');

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -724,7 +724,6 @@ $applozic.extend(true, Kommunicate, {
     setDefaultIframeConfigForClosedChat: function () {
         var kommunicateIframe = parent.document.getElementById('kommunicate-widget-iframe');
         if (kommunicateIframe) {
-            kommunicateCommons.cleanupIframeResizeListener(kommunicateIframe);
             kommunicateIframe.style.height = '';
             kommunicateIframe.classList.add('km-iframe-closed');
             kommunicateIframe.classList.remove('kommunicate-iframe-enable-media-query');

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -129,7 +129,6 @@ function KommunicateCommons() {
         if (
             !iframeElement ||
             _this.checkIfDeviceIsHandheld() ||
-            (iframeElement.classList && iframeElement.classList.contains('km-iframe-closed')) ||
             (iframeElement.classList &&
                 (iframeElement.classList.contains('chat-popup-widget-horizontal') ||
                     iframeElement.classList.contains('chat-popup-widget-vertical') ||

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -130,7 +130,8 @@ function KommunicateCommons() {
             !iframeElement ||
             _this.checkIfDeviceIsHandheld() ||
             (iframeElement.classList &&
-                (iframeElement.classList.contains('chat-popup-widget-horizontal') ||
+                (iframeElement.classList.contains('km-iframe-closed') ||
+                    iframeElement.classList.contains('chat-popup-widget-horizontal') ||
                     iframeElement.classList.contains('chat-popup-widget-vertical') ||
                     iframeElement.classList.contains('chat-popup-widget-actionable')))
         ) {

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -129,6 +129,7 @@ function KommunicateCommons() {
         if (
             !iframeElement ||
             _this.checkIfDeviceIsHandheld() ||
+            (iframeElement.classList && iframeElement.classList.contains('km-iframe-closed')) ||
             (iframeElement.classList &&
                 (iframeElement.classList.contains('chat-popup-widget-horizontal') ||
                     iframeElement.classList.contains('chat-popup-widget-vertical') ||

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -957,10 +957,14 @@ const firstVisibleMsg = {
                 var messageInner = document.querySelector('#mck-message-cell .mck-message-inner');
                 var currentTabId = null;
                 if (messageInner) {
+                    var messageInnerDataId =
+                        typeof $applozic === 'function'
+                            ? $applozic(messageInner).data('mck-id')
+                            : null;
                     currentTabId =
                         messageInner.getAttribute('data-mck-id') ||
                         (messageInner.dataset && messageInner.dataset.mckId) ||
-                        $applozic(messageInner).data('mck-id');
+                        messageInnerDataId;
                 }
                 var isCurrentGroup = messageInner
                     ? messageInner.getAttribute('data-isgroup') === 'true'
@@ -4509,11 +4513,15 @@ const firstVisibleMsg = {
                         var messageInner =
                             typeof document !== 'undefined' &&
                             document.querySelector('#mck-message-cell .mck-message-inner');
+                        var activeConversationDataId =
+                            messageInner && typeof $applozic === 'function'
+                                ? $applozic(messageInner).data('mck-id')
+                                : null;
                         var activeConversationId =
                             messageInner &&
                             (messageInner.getAttribute('data-mck-id') ||
                                 (messageInner.dataset && messageInner.dataset.mckId) ||
-                                $applozic(messageInner).data('mck-id'));
+                                activeConversationDataId);
                         var sideboxContent =
                             typeof document !== 'undefined' &&
                             document.getElementById('mck-sidebox-content');

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -957,14 +957,10 @@ const firstVisibleMsg = {
                 var messageInner = document.querySelector('#mck-message-cell .mck-message-inner');
                 var currentTabId = null;
                 if (messageInner) {
-                    var messageInnerDataId =
-                        typeof $applozic === 'function'
-                            ? $applozic(messageInner).data('mck-id')
-                            : null;
                     currentTabId =
                         messageInner.getAttribute('data-mck-id') ||
                         (messageInner.dataset && messageInner.dataset.mckId) ||
-                        messageInnerDataId;
+                        $applozic(messageInner).data('mck-id');
                 }
                 var isCurrentGroup = messageInner
                     ? messageInner.getAttribute('data-isgroup') === 'true'
@@ -4513,15 +4509,11 @@ const firstVisibleMsg = {
                         var messageInner =
                             typeof document !== 'undefined' &&
                             document.querySelector('#mck-message-cell .mck-message-inner');
-                        var activeConversationDataId =
-                            messageInner && typeof $applozic === 'function'
-                                ? $applozic(messageInner).data('mck-id')
-                                : null;
                         var activeConversationId =
                             messageInner &&
                             (messageInner.getAttribute('data-mck-id') ||
                                 (messageInner.dataset && messageInner.dataset.mckId) ||
-                                activeConversationDataId);
+                                $applozic(messageInner).data('mck-id'));
                         var sideboxContent =
                             typeof document !== 'undefined' &&
                             document.getElementById('mck-sidebox-content');

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -955,13 +955,7 @@ const firstVisibleMsg = {
                 }
                 // Voice socket topic lifecycle on connect (safe lookup, no scoped jquery dependency).
                 var messageInner = document.querySelector('#mck-message-cell .mck-message-inner');
-                var currentTabId = null;
-                if (messageInner) {
-                    currentTabId =
-                        messageInner.getAttribute('data-mck-id') ||
-                        (messageInner.dataset && messageInner.dataset.mckId) ||
-                        $applozic(messageInner).data('mck-id');
-                }
+                var currentTabId = messageInner ? messageInner.getAttribute('data-mck-id') : null;
                 var isCurrentGroup = messageInner
                     ? messageInner.getAttribute('data-isgroup') === 'true'
                     : false;
@@ -4512,8 +4506,7 @@ const firstVisibleMsg = {
                         var activeConversationId =
                             messageInner &&
                             (messageInner.getAttribute('data-mck-id') ||
-                                (messageInner.dataset && messageInner.dataset.mckId) ||
-                                $applozic(messageInner).data('mck-id'));
+                                (messageInner.dataset && messageInner.dataset.mckId));
                         var sideboxContent =
                             typeof document !== 'undefined' &&
                             document.getElementById('mck-sidebox-content');

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4500,9 +4500,33 @@ const firstVisibleMsg = {
                             typeof kommunicateCommons !== 'undefined' &&
                             typeof kommunicateCommons.isModernLayoutEnabled === 'function' &&
                             kommunicateCommons.isModernLayoutEnabled();
+                        var messageInner =
+                            typeof document !== 'undefined' &&
+                            document.querySelector('#mck-message-cell .mck-message-inner');
+                        var activeConversationId =
+                            messageInner &&
+                            (messageInner.getAttribute('data-mck-id') ||
+                                (messageInner.dataset && messageInner.dataset.mckId));
+                        var sideboxContent =
+                            typeof document !== 'undefined' &&
+                            document.getElementById('mck-sidebox-content');
+                        var isConversationIndividualActive =
+                            sideboxContent &&
+                            sideboxContent.classList &&
+                            sideboxContent.classList.contains('active-tab-conversations') &&
+                            sideboxContent.classList.contains(
+                                'active-subsection-conversation-individual'
+                            );
+                        var shouldKeepConversationState =
+                            Boolean(activeConversationId) ||
+                            Boolean(isConversationIndividualActive);
 
                         if (isModernLayout) {
-                            bottomTabManager.showEmptyStateTab();
+                            if (shouldKeepConversationState) {
+                                bottomTabManager.hideEmptyStateTab();
+                            } else {
+                                bottomTabManager.showEmptyStateTab();
+                            }
                         } else {
                             console.log('No conversation found, creating a new one.');
                             var conversationDetail = mckGroupLayout.createGroupDefaultSettings();

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -955,7 +955,13 @@ const firstVisibleMsg = {
                 }
                 // Voice socket topic lifecycle on connect (safe lookup, no scoped jquery dependency).
                 var messageInner = document.querySelector('#mck-message-cell .mck-message-inner');
-                var currentTabId = messageInner ? messageInner.getAttribute('data-mck-id') : null;
+                var currentTabId = null;
+                if (messageInner) {
+                    currentTabId =
+                        messageInner.getAttribute('data-mck-id') ||
+                        (messageInner.dataset && messageInner.dataset.mckId) ||
+                        $applozic(messageInner).data('mck-id');
+                }
                 var isCurrentGroup = messageInner
                     ? messageInner.getAttribute('data-isgroup') === 'true'
                     : false;
@@ -4506,7 +4512,8 @@ const firstVisibleMsg = {
                         var activeConversationId =
                             messageInner &&
                             (messageInner.getAttribute('data-mck-id') ||
-                                (messageInner.dataset && messageInner.dataset.mckId));
+                                (messageInner.dataset && messageInner.dataset.mckId) ||
+                                $applozic(messageInner).data('mck-id'));
                         var sideboxContent =
                             typeof document !== 'undefined' &&
                             document.getElementById('mck-sidebox-content');

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4500,16 +4500,14 @@ const firstVisibleMsg = {
                             typeof kommunicateCommons !== 'undefined' &&
                             typeof kommunicateCommons.isModernLayoutEnabled === 'function' &&
                             kommunicateCommons.isModernLayoutEnabled();
-                        var messageInner =
-                            typeof document !== 'undefined' &&
-                            document.querySelector('#mck-message-cell .mck-message-inner');
+                        var messageInner = document.querySelector(
+                            '#mck-message-cell .mck-message-inner'
+                        );
                         var activeConversationId =
                             messageInner &&
                             (messageInner.getAttribute('data-mck-id') ||
                                 (messageInner.dataset && messageInner.dataset.mckId));
-                        var sideboxContent =
-                            typeof document !== 'undefined' &&
-                            document.getElementById('mck-sidebox-content');
+                        var sideboxContent = document.getElementById('mck-sidebox-content');
                         var isConversationIndividualActive =
                             sideboxContent &&
                             sideboxContent.classList &&

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4504,9 +4504,7 @@ const firstVisibleMsg = {
                             '#mck-message-cell .mck-message-inner'
                         );
                         var activeConversationId =
-                            messageInner &&
-                            (messageInner.getAttribute('data-mck-id') ||
-                                (messageInner.dataset && messageInner.dataset.mckId));
+                            messageInner && messageInner.getAttribute('data-mck-id');
                         var sideboxContent = document.getElementById('mck-sidebox-content');
                         var isConversationIndividualActive =
                             sideboxContent &&


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- When Kommunicate.startConversation() is used in the script, the conversation is not displayed in the chat widget and is causing a race condition issue.
https://intentive-ai.slack.com/archives/C0178DHF2RH/p1775069258897659

It should directly open a new conversation in the chat widget.

- On closing the widget, the logo size gets cut when the window is resized.

<img width="404" height="210" alt="image" src="https://github.com/user-attachments/assets/84db455e-17ec-48d6-ab24-19ab15d14863" />

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of conversation state when switching between tabs
  * Enhanced detection and handling of closed chat widget interface states
  * Refined tab navigation behavior for more consistent user experience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->