### PR TITLE
IOS-issue

### DIFF
--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -514,7 +514,8 @@ function addKommunicatePluginToIframe() {
     addableWindow.KM_RELEASE_HASH = KM_RELEASE_HASH;
     addableWindow.THIRD_PARTY_SCRIPTS = THIRD_PARTY_SCRIPTS;
 
-    var options = addableWindow.applozic._globals;
+    var options = addableWindow.applozic._globals || {};
+    addableWindow.applozic._globals = options;
     options.__KM_PLUGIN_VERSION = MCK_PLUGIN_VERSION;
     options.KM_VER = MCK_PLUGIN_VERSION === 'v3' ? 'v2' : MCK_PLUGIN_VERSION;
     if (typeof options !== 'undefined') {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix iOS Chrome widget crash caused by applozic._globals being undefined during plugin init.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin initialization stability by ensuring configuration objects are always properly initialized before properties are assigned, preventing runtime errors when optional global settings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->