### PR TITLE
TDH-3506: Fix auto-indent and spacing issue in welcome message for Malaysia Airports

### DIFF
--- a/webplugin/js/app/km-utils.js
+++ b/webplugin/js/app/km-utils.js
@@ -664,7 +664,12 @@ KommunicateUtils = {
         return text
             .replace(/\r\n/g, '\n') // Normalize line endings
             .split('\n')
-            .map((line) => line.replace(/^\s*-\s*/, '- ').trimEnd()) // Trim right-side spaces
+            .map((line) =>
+                line
+                    .replace(/^(\s*\d+)([.)])(\s+)/, '$1\\$2$3')
+                    .replace(/^\s*-\s*/, '- ')
+                    .trimEnd()
+            ) // Trim right-side spaces
             .filter((line) => line !== '') // Remove empty lines
             .join('\n\n');
     },


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Prevent plain text starting with 1. or 1) from being rendered as an indented ordered list while keeping the existing markdown pipeline intact.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Locally

### What new thing you came across while writing this code? 
-marked interprets both 1. and 1) at the start of a line as ordered-list syntax, so this could affect plain text messages even when users did not intend to send a list.

### In case you fixed a bug then please describe the root cause of it? 
-The root cause was in normalizeMarkdown() before markdown parsing. Lines beginning with numeric markers like 1. or 1) were passed directly into marked, which treated them as ordered lists and added list indentation. Escaping the marker during normalization preserves the text as literal content.

### Screenshot
- 
<img width="1512" height="908" alt="image" src="https://github.com/user-attachments/assets/b29b8dfb-3e0d-4b30-b5a6-39deb96c051c" />


NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced markdown normalization to properly format numbered lists in addition to bulleted lists, improving consistency when processing and displaying formatted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->