### PR TITLE
TDH-3659:Chat widget full view is not coming in iPhone, it going beyond the viewable space both horizontally and vertically

### DIFF
--- a/server/config/config-env.js
+++ b/server/config/config-env.js
@@ -6,7 +6,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-test.kommunicate.io',
             omnichannelBaseUrl: 'https://omni-channel-test.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
-            hostUrl: 'http://10.10.24.82:3030',
+            hostUrl: 'http://localhost:3030',
             dashboardUrl: 'https://dashboard-test.kommunicate.io',
         },
         pluginProperties: {

--- a/server/config/config-env.js
+++ b/server/config/config-env.js
@@ -6,7 +6,7 @@ const configEnv = {
             kommunicateBaseUrl: 'https://api-test.kommunicate.io',
             omnichannelBaseUrl: 'https://omni-channel-test.kommunicate.io',
             botPlatformApi: 'https://bots-test.kommunicate.io',
-            hostUrl: 'http://localhost:3030',
+            hostUrl: 'http://10.10.24.82:3030',
             dashboardUrl: 'https://dashboard-test.kommunicate.io',
         },
         pluginProperties: {

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -413,11 +413,11 @@ function attachMobileKeyboardViewportFix(iframeElement) {
         'max-height',
     ];
     var syncFrame = function () {
+        if (!mobileViewport.matches) return;
         if (
             !iframeElement.classList.contains('kommunicate-iframe-enable-media-query') ||
             iframeElement.classList.contains('km-iframe-closed') ||
-            iframeElement.getAttribute('data-km-widget-container') === 'true' ||
-            !mobileViewport.matches
+            iframeElement.getAttribute('data-km-widget-container') === 'true'
         ) {
             frameProperties.forEach(function (property) {
                 iframeElement.style.removeProperty(property);

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -397,7 +397,6 @@ function attachMobileKeyboardViewportFix(iframeElement) {
     if (!window.visualViewport) {
         return;
     }
-
     var viewport = window.visualViewport;
     var mobileViewport = window.matchMedia('(max-width: 600px)');
     var frameProperties = [
@@ -410,7 +409,6 @@ function attachMobileKeyboardViewportFix(iframeElement) {
         'max-width',
         'max-height',
     ];
-
     var syncFrame = function () {
         if (
             !iframeElement.classList.contains('kommunicate-iframe-enable-media-query') ||
@@ -423,7 +421,6 @@ function attachMobileKeyboardViewportFix(iframeElement) {
             });
             return;
         }
-
         [
             ['top', viewport.offsetTop + 'px'],
             ['left', viewport.offsetLeft + 'px'],
@@ -449,7 +446,6 @@ function attachMobileKeyboardViewportFix(iframeElement) {
     });
     syncFrame();
 }
-
 // Create element iframe for kommunicate widget
 function createKommunicateIframe() {
     if (document.getElementById(kmCustomElements.iframe.id)) {

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -393,7 +393,7 @@ function isIOSWebKitBrowser(userAgent) {
     return isIOSDevice(ua) && /AppleWebKit/i.test(ua);
 }
 
-function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
+function attachMobileKeyboardViewportFix(iframeElement) {
     if (!window.visualViewport) {
         return;
     }
@@ -510,7 +510,7 @@ function createKommunicateIframe() {
         document.body.appendChild(kommunicateIframe);
     }
     kommunicateIframe.contentWindow.kommunicate = window.kommunicate;
-    attachIOSKeyboardViewportFix(kommunicateIframe, userAgent);
+    attachMobileKeyboardViewportFix(kommunicateIframe);
     attemptContainerAutoLaunch(kommunicateIframe);
 
     if (!iframeSupportsSrcdoc) {

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -412,18 +412,16 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
     ];
 
     var syncFrame = function () {
-        var isOpenMobileWidget =
-            iframeElement.classList.contains('kommunicate-iframe-enable-media-query') &&
-            !iframeElement.classList.contains('km-iframe-closed') &&
-            iframeElement.getAttribute('data-km-widget-container') !== 'true' &&
-            mobileViewport.matches;
-
-        if (!isOpenMobileWidget) {
-            if (iframeElement.classList.contains('km-iframe-closed')) {
+        if (
+            !iframeElement.classList.contains('kommunicate-iframe-enable-media-query') ||
+            iframeElement.classList.contains('km-iframe-closed') ||
+            iframeElement.getAttribute('data-km-widget-container') === 'true' ||
+            !mobileViewport.matches
+        ) {
+            iframeElement.classList.contains('km-iframe-closed') &&
                 frameProperties.forEach(function (property) {
                     iframeElement.style.removeProperty(property);
                 });
-            }
             return;
         }
 
@@ -440,7 +438,6 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
             iframeElement.style.setProperty(entry[0], entry[1], 'important');
         });
     };
-
     var onViewportChange = function () {
         window.requestAnimationFrame(syncFrame);
     };

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -394,7 +394,7 @@ function isIOSWebKitBrowser(userAgent) {
 }
 
 function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
-    if (!isIOSWebKitBrowser(userAgent) || !window.visualViewport) {
+    if (!window.visualViewport) {
         return;
     }
 
@@ -418,10 +418,9 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
             iframeElement.getAttribute('data-km-widget-container') === 'true' ||
             !mobileViewport.matches
         ) {
-            iframeElement.classList.contains('km-iframe-closed') &&
-                frameProperties.forEach(function (property) {
-                    iframeElement.style.removeProperty(property);
-                });
+            frameProperties.forEach(function (property) {
+                iframeElement.style.removeProperty(property);
+            });
             return;
         }
 

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -400,6 +400,16 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
 
     var viewport = window.visualViewport;
     var mobileViewport = window.matchMedia('(max-width: 600px)');
+    var frameProperties = [
+        'top',
+        'left',
+        'right',
+        'bottom',
+        'width',
+        'height',
+        'max-width',
+        'max-height',
+    ];
 
     var syncFrame = function () {
         var isOpenMobileWidget =
@@ -409,18 +419,11 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
             mobileViewport.matches;
 
         if (!isOpenMobileWidget) {
-            [
-                'top',
-                'left',
-                'right',
-                'bottom',
-                'width',
-                'height',
-                'max-width',
-                'max-height',
-            ].forEach(function (property) {
-                iframeElement.style.removeProperty(property);
-            });
+            if (iframeElement.classList.contains('km-iframe-closed')) {
+                frameProperties.forEach(function (property) {
+                    iframeElement.style.removeProperty(property);
+                });
+            }
             return;
         }
 

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -8,9 +8,6 @@ var PRODUCT_ID = ':PRODUCT_ID';
 var KM_RELEASE_HASH = ':KM_RELEASE_HASH';
 var THIRD_PARTY_SCRIPTS = JSON.parse(':THIRD_PARTY_SCRIPTS');
 var MCK_ENV_DETAILS = JSON.parse(':MCK_ENV_DETAILS');
-var KM_VERSIONED_BUILD_RESOURCE_PATH = MCK_STATICPATH + '/build/' + KM_RELEASE_HASH + '/resources';
-var KM_VERSIONED_KOMMUNICATE_JS =
-    KM_VERSIONED_BUILD_RESOURCE_PATH + '/kommunicate.' + KM_RELEASE_HASH + '.min.js';
 
 var kmCustomElements = {
     iframe: {
@@ -47,10 +44,7 @@ var kmCustomIframe =
     '   top: 0;' +
     '   left: 0px !important;' +
     '   border-radius: 0px;' +
-    '   height: 100dvh !important;' +
     '   width: 100vw !important;' +
-    '   max-height: 100dvh !important;' +
-    '   max-width: 100vw !important;' +
     '} } \n' +
     '.km-iframe-notification{ ' +
     '    height:80px; ' +
@@ -283,10 +277,6 @@ function removeKommunicateScripts() {
             commons.cleanupIframeResizeListener(kommunicateIframe);
         }
     }
-    if (kommunicateIframe && kommunicateIframe.__kmCleanupViewportFix) {
-        kommunicateIframe.__kmCleanupViewportFix();
-        kommunicateIframe.__kmCleanupViewportFix = null;
-    }
     // delete iframe, kommunicate style sheet, image view modal, origin file
     removeElementFromHtmlById([
         kmCustomElements.imageModal.styleSheetId,
@@ -410,13 +400,6 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
 
     var viewport = window.visualViewport;
     var mobileViewport = window.matchMedia('(max-width: 600px)');
-    var resetFrame = function () {
-        ['top', 'left', 'right', 'bottom', 'width', 'height', 'max-width', 'max-height'].forEach(
-            function (property) {
-                iframeElement.style.removeProperty(property);
-            }
-        );
-    };
 
     var syncFrame = function () {
         var isOpenMobileWidget =
@@ -426,7 +409,18 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
             mobileViewport.matches;
 
         if (!isOpenMobileWidget) {
-            resetFrame();
+            [
+                'top',
+                'left',
+                'right',
+                'bottom',
+                'width',
+                'height',
+                'max-width',
+                'max-height',
+            ].forEach(function (property) {
+                iframeElement.style.removeProperty(property);
+            });
             return;
         }
 
@@ -447,17 +441,14 @@ function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
     var onViewportChange = function () {
         window.requestAnimationFrame(syncFrame);
     };
-    var classObserver = new MutationObserver(syncFrame);
 
     viewport.addEventListener('resize', onViewportChange);
     viewport.addEventListener('scroll', onViewportChange);
-    classObserver.observe(iframeElement, { attributes: true, attributeFilter: ['class'] });
-    iframeElement.__kmCleanupViewportFix = function () {
-        viewport.removeEventListener('resize', onViewportChange);
-        viewport.removeEventListener('scroll', onViewportChange);
-        classObserver.disconnect();
-        resetFrame();
-    };
+    new MutationObserver(syncFrame).observe(iframeElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+    });
+    syncFrame();
 }
 
 // Create element iframe for kommunicate widget
@@ -626,7 +617,7 @@ function addKommunicatePluginToIframe() {
     var imported = addableDocument.createElement('script');
     imported.async = false;
     imported.type = 'text/javascript';
-    imported.src = KM_VERSIONED_KOMMUNICATE_JS;
+    imported.src = KOMMUNICATE_MIN_JS;
     addableDocument.head.appendChild(imported);
     addFullviewImageModal();
 }

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -277,6 +277,9 @@ function removeKommunicateScripts() {
             commons.cleanupIframeResizeListener(kommunicateIframe);
         }
     }
+    kommunicateIframe &&
+        kommunicateIframe.__kmDetachViewportFix &&
+        kommunicateIframe.__kmDetachViewportFix();
     // delete iframe, kommunicate style sheet, image view modal, origin file
     removeElementFromHtmlById([
         kmCustomElements.imageModal.styleSheetId,
@@ -437,13 +440,18 @@ function attachMobileKeyboardViewportFix(iframeElement) {
     var onViewportChange = function () {
         window.requestAnimationFrame(syncFrame);
     };
-
+    var observer = new MutationObserver(syncFrame);
     viewport.addEventListener('resize', onViewportChange);
     viewport.addEventListener('scroll', onViewportChange);
-    new MutationObserver(syncFrame).observe(iframeElement, {
+    observer.observe(iframeElement, {
         attributes: true,
         attributeFilter: ['class'],
     });
+    iframeElement.__kmDetachViewportFix = function () {
+        viewport.removeEventListener('resize', onViewportChange);
+        viewport.removeEventListener('scroll', onViewportChange);
+        observer.disconnect();
+    };
     syncFrame();
 }
 // Create element iframe for kommunicate widget

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -8,6 +8,9 @@ var PRODUCT_ID = ':PRODUCT_ID';
 var KM_RELEASE_HASH = ':KM_RELEASE_HASH';
 var THIRD_PARTY_SCRIPTS = JSON.parse(':THIRD_PARTY_SCRIPTS');
 var MCK_ENV_DETAILS = JSON.parse(':MCK_ENV_DETAILS');
+var KM_VERSIONED_BUILD_RESOURCE_PATH = MCK_STATICPATH + '/build/' + KM_RELEASE_HASH + '/resources';
+var KM_VERSIONED_KOMMUNICATE_JS =
+    KM_VERSIONED_BUILD_RESOURCE_PATH + '/kommunicate.' + KM_RELEASE_HASH + '.min.js';
 
 var kmCustomElements = {
     iframe: {
@@ -44,9 +47,10 @@ var kmCustomIframe =
     '   top: 0;' +
     '   left: 0px !important;' +
     '   border-radius: 0px;' +
-    '   height: 100% !important;' +
-    '   width: 100% !important;' +
-    '   max-height: 100% !important;' +
+    '   height: 100dvh !important;' +
+    '   width: 100vw !important;' +
+    '   max-height: 100dvh !important;' +
+    '   max-width: 100vw !important;' +
     '} } \n' +
     '.km-iframe-notification{ ' +
     '    height:80px; ' +
@@ -73,11 +77,14 @@ var kmCustomIframe =
     '@media only screen and (max-width:600px) { ' +
     '.kommunicate-custom-iframe.km-iframe-dimension-with-popup, ' +
     '.kommunicate-custom-iframe.km-iframe-dimension-no-popup { ' +
-    '   width: 100% !important;' +
+    '   width: 100vw !important;' +
     '   min-width: 0 !important;' +
     '   left: 0 !important;' +
     '   right: 0 !important;' +
     '   bottom: 0 !important;' +
+    '   height: 100dvh !important;' +
+    '   max-height: 100dvh !important;' +
+    '   max-width: 100vw !important;' +
     '} ' +
     '} \n' +
     '.km-iframe-closed{ ' +
@@ -276,6 +283,10 @@ function removeKommunicateScripts() {
             commons.cleanupIframeResizeListener(kommunicateIframe);
         }
     }
+    if (kommunicateIframe && kommunicateIframe.__kmCleanupViewportFix) {
+        kommunicateIframe.__kmCleanupViewportFix();
+        kommunicateIframe.__kmCleanupViewportFix = null;
+    }
     // delete iframe, kommunicate style sheet, image view modal, origin file
     removeElementFromHtmlById([
         kmCustomElements.imageModal.styleSheetId,
@@ -392,6 +403,63 @@ function isIOSWebKitBrowser(userAgent) {
     return isIOSDevice(ua) && /AppleWebKit/i.test(ua);
 }
 
+function attachIOSKeyboardViewportFix(iframeElement, userAgent) {
+    if (!isIOSWebKitBrowser(userAgent) || !window.visualViewport) {
+        return;
+    }
+
+    var viewport = window.visualViewport;
+    var mobileViewport = window.matchMedia('(max-width: 600px)');
+    var resetFrame = function () {
+        ['top', 'left', 'right', 'bottom', 'width', 'height', 'max-width', 'max-height'].forEach(
+            function (property) {
+                iframeElement.style.removeProperty(property);
+            }
+        );
+    };
+
+    var syncFrame = function () {
+        var isOpenMobileWidget =
+            iframeElement.classList.contains('kommunicate-iframe-enable-media-query') &&
+            !iframeElement.classList.contains('km-iframe-closed') &&
+            iframeElement.getAttribute('data-km-widget-container') !== 'true' &&
+            mobileViewport.matches;
+
+        if (!isOpenMobileWidget) {
+            resetFrame();
+            return;
+        }
+
+        [
+            ['top', viewport.offsetTop + 'px'],
+            ['left', viewport.offsetLeft + 'px'],
+            ['right', 'auto'],
+            ['bottom', 'auto'],
+            ['width', viewport.width + 'px'],
+            ['height', viewport.height + 'px'],
+            ['max-width', viewport.width + 'px'],
+            ['max-height', viewport.height + 'px'],
+        ].forEach(function (entry) {
+            iframeElement.style.setProperty(entry[0], entry[1], 'important');
+        });
+    };
+
+    var onViewportChange = function () {
+        window.requestAnimationFrame(syncFrame);
+    };
+    var classObserver = new MutationObserver(syncFrame);
+
+    viewport.addEventListener('resize', onViewportChange);
+    viewport.addEventListener('scroll', onViewportChange);
+    classObserver.observe(iframeElement, { attributes: true, attributeFilter: ['class'] });
+    iframeElement.__kmCleanupViewportFix = function () {
+        viewport.removeEventListener('resize', onViewportChange);
+        viewport.removeEventListener('scroll', onViewportChange);
+        classObserver.disconnect();
+        resetFrame();
+    };
+}
+
 // Create element iframe for kommunicate widget
 function createKommunicateIframe() {
     if (document.getElementById(kmCustomElements.iframe.id)) {
@@ -452,6 +520,7 @@ function createKommunicateIframe() {
         document.body.appendChild(kommunicateIframe);
     }
     kommunicateIframe.contentWindow.kommunicate = window.kommunicate;
+    attachIOSKeyboardViewportFix(kommunicateIframe, userAgent);
     attemptContainerAutoLaunch(kommunicateIframe);
 
     if (!iframeSupportsSrcdoc) {
@@ -557,7 +626,7 @@ function addKommunicatePluginToIframe() {
     var imported = addableDocument.createElement('script');
     imported.async = false;
     imported.type = 'text/javascript';
-    imported.src = KOMMUNICATE_MIN_JS;
+    imported.src = KM_VERSIONED_KOMMUNICATE_JS;
     addableDocument.head.appendChild(imported);
     addFullviewImageModal();
 }

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -44,7 +44,9 @@ var kmCustomIframe =
     '   top: 0;' +
     '   left: 0px !important;' +
     '   border-radius: 0px;' +
-    '   width: 100vw !important;' +
+    '   height: 100% !important;' +
+    '   width: 100% !important;' +
+    '   max-height: 100% !important;' +
     '} } \n' +
     '.km-iframe-notification{ ' +
     '    height:80px; ' +
@@ -71,14 +73,11 @@ var kmCustomIframe =
     '@media only screen and (max-width:600px) { ' +
     '.kommunicate-custom-iframe.km-iframe-dimension-with-popup, ' +
     '.kommunicate-custom-iframe.km-iframe-dimension-no-popup { ' +
-    '   width: 100vw !important;' +
+    '   width: 100% !important;' +
     '   min-width: 0 !important;' +
     '   left: 0 !important;' +
     '   right: 0 !important;' +
     '   bottom: 0 !important;' +
-    '   height: 100dvh !important;' +
-    '   max-height: 100dvh !important;' +
-    '   max-width: 100vw !important;' +
     '} ' +
     '} \n' +
     '.km-iframe-closed{ ' +
@@ -396,8 +395,8 @@ function isIOSWebKitBrowser(userAgent) {
     return isIOSDevice(ua) && /AppleWebKit/i.test(ua);
 }
 
-function attachMobileKeyboardViewportFix(iframeElement) {
-    if (!window.visualViewport) {
+function attachMobileKeyboardViewportFix(iframeElement, userAgent) {
+    if (!isIOSWebKitBrowser(userAgent) || !window.visualViewport) {
         return;
     }
     var viewport = window.visualViewport;
@@ -412,8 +411,17 @@ function attachMobileKeyboardViewportFix(iframeElement) {
         'max-width',
         'max-height',
     ];
+    var viewportFixApplied = false;
     var syncFrame = function () {
-        if (!mobileViewport.matches) return;
+        if (!mobileViewport.matches) {
+            if (viewportFixApplied) {
+                frameProperties.forEach(function (property) {
+                    iframeElement.style.removeProperty(property);
+                });
+                viewportFixApplied = false;
+            }
+            return;
+        }
         if (
             !iframeElement.classList.contains('kommunicate-iframe-enable-media-query') ||
             iframeElement.classList.contains('km-iframe-closed') ||
@@ -422,6 +430,7 @@ function attachMobileKeyboardViewportFix(iframeElement) {
             frameProperties.forEach(function (property) {
                 iframeElement.style.removeProperty(property);
             });
+            viewportFixApplied = false;
             return;
         }
         [
@@ -436,6 +445,7 @@ function attachMobileKeyboardViewportFix(iframeElement) {
         ].forEach(function (entry) {
             iframeElement.style.setProperty(entry[0], entry[1], 'important');
         });
+        viewportFixApplied = true;
     };
     var onViewportChange = function () {
         window.requestAnimationFrame(syncFrame);
@@ -514,7 +524,7 @@ function createKommunicateIframe() {
         document.body.appendChild(kommunicateIframe);
     }
     kommunicateIframe.contentWindow.kommunicate = window.kommunicate;
-    attachMobileKeyboardViewportFix(kommunicateIframe);
+    attachMobileKeyboardViewportFix(kommunicateIframe, userAgent);
     attemptContainerAutoLaunch(kommunicateIframe);
 
     if (!iframeSupportsSrcdoc) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix the mobile chat widget layout on iPhone so that when the keyboard opens, the widget stays aligned to the visible viewport and does not overflow off-screen.


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-Tested locally on iPhone

### What new thing you came across while writing this code? 
-On iPhone/mobile browsers, opening the keyboard changes the visual viewport dynamically, so relying only on static CSS sizing is not enough for the widget iframe to stay aligned.

### In case you fixed a bug then please describe the root cause of it? 
-The widget iframe was not syncing with the mobile browser’s visible viewport when the keyboard opened, which caused incorrect iframe dimensions/positioning and made the widget overflow outside the screen on iPhone.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iframe sizing and display on mobile/fullscreen by keeping its dimensions in sync with the visual viewport.
  * Prevented iframe removal issues by ensuring teardown stops viewport tracking when closed.

* **Improvements**
  * Improved compatibility with iOS/WebKit on mobile keyboards by dynamically updating iframe position and size during viewport changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->