### PR TITLE
fallback to voice/text apis if native support is not there

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1784,14 +1784,19 @@ KommunicateUI = {
                 : backButton.classList.add('force-n-vis');
         }
 
-        var startNewButton = document.getElementById('mck-msg-new');
-        if (startNewButton) {
-            if (isWidgetSingleThreaded) {
-                startNewButton.classList.add('force-n-vis');
-            } else {
-                startNewButton.classList.remove('force-n-vis');
+        ['km-start-conversation-actions', 'mck-msg-new', 'km-start-with-voice-cta'].forEach(
+            function (elementId) {
+                var startConversationElement = document.getElementById(elementId);
+                if (!startConversationElement) {
+                    return;
+                }
+                if (isWidgetSingleThreaded) {
+                    startConversationElement.classList.add('force-n-vis');
+                } else {
+                    startConversationElement.classList.remove('force-n-vis');
+                }
             }
-        }
+        );
     },
     updateSingleThreadedClass: function (hasMultipleConversations) {
         var isWidgetSingleThreaded =

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -183,7 +183,7 @@ $applozic.extend(true, Kommunicate, {
                         },
                     },
                     success: function (response) {
-                        console.log(response);
+                        console.debug(response);
                     },
                     error: function (error) {
                         console.log(error);

--- a/webplugin/js/app/labels/default-labels-en.js
+++ b/webplugin/js/app/labels/default-labels-en.js
@@ -22,6 +22,8 @@
         'start.voice': 'Voice',
         'start.with.voice': 'Start with Voice',
         'voice.permission.required': 'Microphone permission is required for voice mode.',
+        'voice.input.unsupported': 'Voice input is not supported in this browser.',
+        'voiceInterface.processingFailed': 'Unable to transcribe the recording. Please try again.',
         'search.contacts': 'Contacts',
         'search.groups': 'Groups',
         'char.limit.warn':

--- a/webplugin/js/app/labels/locales/ar.json
+++ b/webplugin/js/app/labels/locales/ar.json
@@ -216,6 +216,7 @@
   "start.voice": "صوت",
   "start.with.voice": "ابدأ بالصوت",
   "voice.permission.required": "يلزم إذن الميكروفون لوضع الصوت.",
+  "voice.input.unsupported": "الإدخال الصوتي غير مدعوم في هذا المتصفح.",
   "voiceInterface.listening": "جارٍ الاستماع...",
   "voiceInterface.listeningNote": "المساعد الذكي يستمع إليك، فقط تكلّم.",
   "voiceInterface.mutedNote": "تم إيقاف الميكروفون مؤقتًا. اضغط على الميكروفون لاستئناف الإدخال الصوتي.",

--- a/webplugin/js/app/labels/locales/de.json
+++ b/webplugin/js/app/labels/locales/de.json
@@ -216,6 +216,7 @@
   "start.voice": "Sprache",
   "start.with.voice": "Mit Sprache starten",
   "voice.permission.required": "Für den Sprachmodus ist die Mikrofonberechtigung erforderlich.",
+  "voice.input.unsupported": "Spracheingabe wird in diesem Browser nicht unterstützt.",
   "voiceInterface.listening": "Ich höre zu...",
   "voiceInterface.listeningNote": "Der KI-Assistent hört zu. Sprich einfach.",
   "voiceInterface.mutedNote": "Mikrofon pausiert. Tippe auf das Mikrofon, um die Spracheingabe fortzusetzen.",

--- a/webplugin/js/app/labels/locales/es.json
+++ b/webplugin/js/app/labels/locales/es.json
@@ -216,6 +216,7 @@
   "start.voice": "Voz",
   "start.with.voice": "Empezar con voz",
   "voice.permission.required": "Se requiere permiso de micrófono para el modo de voz.",
+  "voice.input.unsupported": "La entrada de voz no es compatible con este navegador.",
   "voiceInterface.listening": "Escuchando...",
   "voiceInterface.listeningNote": "El asistente de IA te está escuchando, solo habla.",
   "voiceInterface.mutedNote": "Micrófono en pausa. Toca el micrófono para reanudar la entrada de voz.",

--- a/webplugin/js/app/labels/locales/fr.json
+++ b/webplugin/js/app/labels/locales/fr.json
@@ -216,6 +216,7 @@
   "start.voice": "Voix",
   "start.with.voice": "Commencer avec la voix",
   "voice.permission.required": "L'autorisation du microphone est requise pour le mode vocal.",
+  "voice.input.unsupported": "La saisie vocale n'est pas prise en charge dans ce navigateur.",
   "voiceInterface.listening": "À l'écoute...",
   "voiceInterface.listeningNote": "L'assistant IA vous écoute, parlez simplement.",
   "voiceInterface.mutedNote": "Microphone en pause. Appuyez sur le micro pour reprendre la saisie vocale.",

--- a/webplugin/js/app/labels/locales/hi.json
+++ b/webplugin/js/app/labels/locales/hi.json
@@ -216,6 +216,7 @@
   "start.voice": "आवाज़",
   "start.with.voice": "आवाज़ से शुरू करें",
   "voice.permission.required": "वॉइस मोड के लिए माइक्रोफ़ोन की अनुमति आवश्यक है।",
+  "voice.input.unsupported": "इस ब्राउज़र में वॉइस इनपुट समर्थित नहीं है।",
   "voiceInterface.listening": "सुन रहा हूँ...",
   "voiceInterface.listeningNote": "एआई सहायक आपकी बात सुन रहा है, बस बोलें।",
   "voiceInterface.mutedNote": "माइक्रोफ़ोन रुका हुआ है। वॉइस इनपुट फिर शुरू करने के लिए माइक्रोफ़ोन पर टैप करें।",

--- a/webplugin/js/app/labels/locales/it.json
+++ b/webplugin/js/app/labels/locales/it.json
@@ -216,6 +216,7 @@
   "start.voice": "Voce",
   "start.with.voice": "Inizia con la voce",
   "voice.permission.required": "È necessaria l'autorizzazione al microfono per la modalità vocale.",
+  "voice.input.unsupported": "L'input vocale non è supportato in questo browser.",
   "voiceInterface.listening": "In ascolto...",
   "voiceInterface.listeningNote": "L'assistente IA ti sta ascoltando, parla pure.",
   "voiceInterface.mutedNote": "Microfono in pausa. Tocca il microfono per riprendere l'input vocale.",

--- a/webplugin/js/app/labels/locales/pt.json
+++ b/webplugin/js/app/labels/locales/pt.json
@@ -216,6 +216,7 @@
   "start.voice": "Voz",
   "start.with.voice": "Começar com voz",
   "voice.permission.required": "A permissão do microfone é necessária para o modo de voz.",
+  "voice.input.unsupported": "A entrada de voz não é compatível com este navegador.",
   "voiceInterface.listening": "Ouvindo...",
   "voiceInterface.listeningNote": "O assistente de IA está ouvindo você, é só falar.",
   "voiceInterface.mutedNote": "Microfone pausado. Toque no microfone para retomar a entrada de voz.",

--- a/webplugin/js/app/labels/locales/sv.json
+++ b/webplugin/js/app/labels/locales/sv.json
@@ -216,6 +216,7 @@
   "start.voice": "Röst",
   "start.with.voice": "Starta med röst",
   "voice.permission.required": "Mikrofonbehörighet krävs för röstläge.",
+  "voice.input.unsupported": "Röstinmatning stöds inte i den här webbläsaren.",
   "voiceInterface.listening": "Lyssnar...",
   "voiceInterface.listeningNote": "AI-assistenten lyssnar på dig, bara prata.",
   "voiceInterface.mutedNote": "Mikrofonen är pausad. Tryck på mikrofonen för att fortsätta röstinmatning.",

--- a/webplugin/js/app/labels/locales/ur.json
+++ b/webplugin/js/app/labels/locales/ur.json
@@ -216,6 +216,7 @@
   "start.voice": "آواز",
   "start.with.voice": "آواز سے شروع کریں",
   "voice.permission.required": "وائس موڈ کے لیے مائیکروفون کی اجازت درکار ہے۔",
+  "voice.input.unsupported": "اس براؤزر میں وائس ان پٹ سپورٹ نہیں ہے۔",
   "voiceInterface.listening": "سن رہا ہوں...",
   "voiceInterface.listeningNote": "اے آئی اسسٹنٹ آپ کی بات سن رہا ہے، بس بولیں۔",
   "voiceInterface.mutedNote": "مائیکروفون موقوف ہے۔ وائس ان پٹ دوبارہ شروع کرنے کے لیے مائیکروفون پر ٹیپ کریں۔",

--- a/webplugin/js/app/labels/locales/zh.json
+++ b/webplugin/js/app/labels/locales/zh.json
@@ -216,6 +216,7 @@
   "start.voice": "语音",
   "start.with.voice": "通过语音开始",
   "voice.permission.required": "语音模式需要麦克风权限。",
+  "voice.input.unsupported": "此浏览器不支持语音输入。",
   "voiceInterface.listening": "正在聆听...",
   "voiceInterface.listeningNote": "AI 助手正在聆听你，请直接说话。",
   "voiceInterface.mutedNote": "麦克风已暂停。点击麦克风可恢复语音输入。",

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -369,7 +369,7 @@ function ApplozicSidebox() {
                 );
             }
 
-            if (options.voiceChat) {
+            if (options.voiceChat || options.voiceInput || options.voiceOutput) {
                 promises.push(
                     loadResourceAsync(THIRD_PARTY_SCRIPTS.voiceChat.js).catch((error) => {
                         options.voiceChat = false;

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -373,6 +373,8 @@ function ApplozicSidebox() {
                 promises.push(
                     loadResourceAsync(THIRD_PARTY_SCRIPTS.voiceChat.js).catch((error) => {
                         options.voiceChat = false;
+                        options.voiceInput = false;
+                        options.voiceOutput = false;
                         console.error(error);
                     })
                 );

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6703,7 +6703,6 @@ const firstVisibleMsg = {
                                     groupPxy.metadata.CONVERSATION_STATUS;
                                 CURRENT_GROUP_DATA.isWaitingQueue = false;
                                 CURRENT_GROUP_DATA.groupMembers = groupPxy.groupUsers;
-                                console.log('groupPxy now checking', groupPxy);
 
                                 CURRENT_GROUP_DATA.createdAt = groupPxy.createdAtTime;
                                 CURRENT_GROUP_DATA.teamId =

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -156,6 +156,7 @@ Kommunicate.mediaService = {
                     'fallback MediaRecorder error',
                     event && event.error ? event.error : event
                 );
+                that.resetFallbackVoiceInputState();
             };
             recorder.onstop = async function () {
                 var audioBlob = new Blob(that.fallbackVoiceInput.chunks, {

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -13,6 +13,7 @@ Kommunicate.mediaService = {
     fallbackVoiceOutput: {
         audio: null,
         url: '',
+        requestId: 0,
     },
     getFallbackVoiceClient: function () {
         return typeof kmVoice !== 'undefined' ? kmVoice : null;
@@ -58,6 +59,14 @@ Kommunicate.mediaService = {
         return (
             (kommunicate && kommunicate._globals && kommunicate._globals.voiceInputSettings) || {}
         );
+    },
+    getFallbackVoiceInputMaxDurationMs: function () {
+        var appOptions = this.appOptions || {};
+        var maxDurationMs = Number(appOptions.fallbackVoiceInputMaxDurationMs);
+        if (!(maxDurationMs > 0)) {
+            maxDurationMs = Number(appOptions.fallbackVoiceInputMaxDuration) * 1000;
+        }
+        return Math.max(maxDurationMs || 10000, 3000);
     },
     getFallbackVoiceInputConstraints: function () {
         var getAudioCaptureConstraints = this.getFallbackVoiceRecorderHelperMethod(
@@ -134,6 +143,7 @@ Kommunicate.mediaService = {
                 Kommunicate.typingAreaService.populateText(
                     this.capitalizeFirstCharacter(transcript)
                 );
+                window.$applozic.fn.applozic('toggleMediaOptions');
             }
         } catch (error) {
             if (error && error.code === 'SILENT_AUDIO') {
@@ -160,10 +170,8 @@ Kommunicate.mediaService = {
             var stream = await navigator.mediaDevices.getUserMedia(constraints);
             var recorder = this.createFallbackVoiceInputRecorder(stream);
             var that = this;
-            var maxRecordingDurationMs = Math.max(
-                Number(that.appOptions.voiceInputTimeout || 10) * 1000,
-                3000
-            );
+            // Fallback recording uses its own max-duration config; voiceInputTimeout remains the silence timeout for native STT.
+            var maxRecordingDurationMs = that.getFallbackVoiceInputMaxDurationMs();
 
             that.fallbackVoiceInput.stream = stream;
             that.fallbackVoiceInput.recorder = recorder;
@@ -266,6 +274,9 @@ Kommunicate.mediaService = {
             URL.revokeObjectURL(this.fallbackVoiceOutput.url);
             this.fallbackVoiceOutput.url = '';
         }
+    },
+    isCurrentFallbackVoiceOutputRequest: function (requestId) {
+        return this.fallbackVoiceOutput.requestId === requestId;
     },
     playFallbackVoiceOutput: function (audioBlob) {
         var that = this;
@@ -414,16 +425,25 @@ Kommunicate.mediaService = {
                 }
             };
 
+            this.stopVoiceOutput();
             speechSynth.speak(utterance);
             return;
         }
 
         if (this.canUseFallbackVoiceOutput()) {
             var textToVoice = this.getFallbackVoiceClientMethod('textToVoice');
+            var fallbackVoiceOutputRequestId;
             this.stopVoiceOutput();
+            fallbackVoiceOutputRequestId = this.fallbackVoiceOutput.requestId;
             textToVoice(textToSpeak)
                 .then(function (audioBlob) {
-                    Kommunicate.mediaService.playFallbackVoiceOutput(audioBlob);
+                    if (
+                        Kommunicate.mediaService.isCurrentFallbackVoiceOutputRequest(
+                            fallbackVoiceOutputRequestId
+                        )
+                    ) {
+                        Kommunicate.mediaService.playFallbackVoiceOutput(audioBlob);
+                    }
                 })
                 .catch(function (error) {
                     console.error('Error while converting the message to voice:', error);
@@ -435,6 +455,7 @@ Kommunicate.mediaService = {
         if (speechSynth) {
             speechSynth.cancel();
         }
+        this.fallbackVoiceOutput.requestId += 1;
         this.clearFallbackVoiceOutput();
     },
     initRecorder: function () {

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -15,23 +15,6 @@ Kommunicate.mediaService = {
         url: '',
         requestId: 0,
     },
-    getFallbackVoiceClient: function () {
-        return typeof kmVoice !== 'undefined' ? kmVoice : null;
-    },
-    getFallbackVoiceRecorderHelper: function () {
-        return typeof mckVoice !== 'undefined' ? mckVoice : null;
-    },
-    getBoundFallbackMethod: function (fallbackClient, methodName) {
-        return fallbackClient && fallbackClient[methodName]
-            ? fallbackClient[methodName].bind(fallbackClient)
-            : null;
-    },
-    getFallbackVoiceClientMethod: function (methodName) {
-        return this.getBoundFallbackMethod(this.getFallbackVoiceClient(), methodName);
-    },
-    getFallbackVoiceRecorderHelperMethod: function (methodName) {
-        return this.getBoundFallbackMethod(this.getFallbackVoiceRecorderHelper(), methodName);
-    },
     getSpeechRecognition: function () {
         return window.SpeechRecognition || window.webkitSpeechRecognition || null;
     },
@@ -43,7 +26,7 @@ Kommunicate.mediaService = {
     },
     canUseFallbackVoiceInput: function () {
         return Boolean(
-            this.getFallbackVoiceClientMethod('voiceToText') &&
+            kmVoice.voiceToText &&
                 window.MediaRecorder &&
                 navigator.mediaDevices &&
                 navigator.mediaDevices.getUserMedia &&
@@ -52,7 +35,7 @@ Kommunicate.mediaService = {
         );
     },
     canUseFallbackVoiceOutput: function () {
-        return Boolean(this.getFallbackVoiceClientMethod('textToVoice'));
+        return Boolean(kmVoice.textToVoice);
     },
     getFallbackVoiceInputConfig: function () {
         return (
@@ -68,27 +51,10 @@ Kommunicate.mediaService = {
         return Math.max(maxDurationMs || 10000, 3000);
     },
     getFallbackVoiceInputConstraints: function () {
-        var getAudioCaptureConstraints = this.getFallbackVoiceRecorderHelperMethod(
-            'getAudioCaptureConstraints'
-        );
-        if (getAudioCaptureConstraints) {
-            return getAudioCaptureConstraints();
-        }
-        return {
-            audio: {
-                echoCancellation: true,
-                noiseSuppression: true,
-                autoGainControl: true,
-                channelCount: 1,
-            },
-        };
+        return mckVoice.getAudioCaptureConstraints();
     },
     createFallbackVoiceInputRecorder: function (stream) {
-        var createMediaRecorder = this.getFallbackVoiceRecorderHelperMethod('createMediaRecorder');
-        if (createMediaRecorder) {
-            return createMediaRecorder(stream);
-        }
-        return new MediaRecorder(stream);
+        return mckVoice.createMediaRecorder(stream);
     },
     clearFallbackVoiceInputStopTimer: function () {
         if (this.fallbackVoiceInput.stopTimer) {
@@ -130,9 +96,8 @@ Kommunicate.mediaService = {
             return;
         }
         try {
-            var voiceToText = this.getFallbackVoiceClientMethod('voiceToText');
             var voiceInputSettings = this.getFallbackVoiceInputConfig();
-            var response = await voiceToText(audioBlob, {
+            var response = await kmVoice.voiceToText(audioBlob, {
                 ucid: voiceInputSettings.ucid,
                 sttMode: 'recognize',
             });
@@ -430,11 +395,11 @@ Kommunicate.mediaService = {
         }
 
         if (this.canUseFallbackVoiceOutput()) {
-            var textToVoice = this.getFallbackVoiceClientMethod('textToVoice');
             var fallbackVoiceOutputRequestId;
             this.stopVoiceOutput();
             fallbackVoiceOutputRequestId = this.fallbackVoiceOutput.requestId;
-            textToVoice(textToSpeak)
+            kmVoice
+                .textToVoice(textToSpeak)
                 .then(function (audioBlob) {
                     if (
                         Kommunicate.mediaService.isCurrentFallbackVoiceOutputRequest(

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -140,11 +140,14 @@ Kommunicate.mediaService = {
             that.fallbackVoiceInput.stream = stream;
             that.fallbackVoiceInput.recorder = recorder;
             that.fallbackVoiceInput.chunks = [];
-            that.fallbackVoiceInput.mimeType = recorder.mimeType || 'audio/webm';
+            that.fallbackVoiceInput.mimeType = recorder.mimeType || '';
             that.fallbackVoiceInput.stopping = false;
 
             recorder.ondataavailable = function (event) {
                 if (event.data && event.data.size > 0) {
+                    if (!that.fallbackVoiceInput.mimeType && event.data.type) {
+                        that.fallbackVoiceInput.mimeType = event.data.type;
+                    }
                     that.fallbackVoiceInput.chunks.push(event.data);
                 }
             };
@@ -156,7 +159,7 @@ Kommunicate.mediaService = {
             };
             recorder.onstop = async function () {
                 var audioBlob = new Blob(that.fallbackVoiceInput.chunks, {
-                    type: that.fallbackVoiceInput.mimeType,
+                    type: that.fallbackVoiceInput.mimeType || 'audio/webm',
                 });
                 that.resetFallbackVoiceInputState();
                 await that.processFallbackVoiceInputTranscript(audioBlob);

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -2,6 +2,208 @@ Kommunicate.mediaService = {
     browserLocale: window.navigator.language || window.navigator.userLanguage || 'en-US',
     appOptions: appOptionSession.getPropertyDataFromSession('appOptions') || applozic._globals,
     userInActiveSec: 0,
+    fallbackVoiceInput: {
+        recorder: null,
+        stream: null,
+        chunks: [],
+        mimeType: 'audio/webm',
+        stopTimer: null,
+        stopping: false,
+    },
+    fallbackVoiceOutput: {
+        audio: null,
+        url: '',
+    },
+    getFallbackVoiceClient: function () {
+        return typeof kmVoice !== 'undefined' ? kmVoice : null;
+    },
+    getFallbackVoiceRecorderHelper: function () {
+        return typeof mckVoice !== 'undefined' ? mckVoice : null;
+    },
+    getFallbackVoiceClientMethod: function (methodName) {
+        var fallbackVoiceClient = this.getFallbackVoiceClient();
+        return fallbackVoiceClient
+            ? fallbackVoiceClient[methodName].bind(fallbackVoiceClient)
+            : null;
+    },
+    getFallbackVoiceRecorderHelperMethod: function (methodName) {
+        var fallbackVoiceRecorderHelper = this.getFallbackVoiceRecorderHelper();
+        return fallbackVoiceRecorderHelper
+            ? fallbackVoiceRecorderHelper[methodName].bind(fallbackVoiceRecorderHelper)
+            : null;
+    },
+    getSpeechRecognition: function () {
+        return window.SpeechRecognition || window.webkitSpeechRecognition || null;
+    },
+    getSpeechSynthesis: function () {
+        return window.speechSynthesis || null;
+    },
+    supportsVoiceInput: function () {
+        return Boolean(this.getSpeechRecognition() || this.canUseFallbackVoiceInput());
+    },
+    canUseFallbackVoiceInput: function () {
+        return Boolean(
+            this.getFallbackVoiceClientMethod('voiceToText') &&
+                window.MediaRecorder &&
+                navigator.mediaDevices &&
+                navigator.mediaDevices.getUserMedia &&
+                (window.AudioContext || window.webkitAudioContext) &&
+                window.isSecureContext !== false
+        );
+    },
+    canUseFallbackVoiceOutput: function () {
+        return Boolean(this.getFallbackVoiceClientMethod('textToVoice'));
+    },
+    getFallbackVoiceInputConfig: function () {
+        return (
+            (kommunicate && kommunicate._globals && kommunicate._globals.voiceInputSettings) || {}
+        );
+    },
+    getFallbackVoiceInputConstraints: function () {
+        var getAudioCaptureConstraints = this.getFallbackVoiceRecorderHelperMethod(
+            'getAudioCaptureConstraints'
+        );
+        if (getAudioCaptureConstraints) {
+            return getAudioCaptureConstraints();
+        }
+        return {
+            audio: {
+                echoCancellation: true,
+                noiseSuppression: true,
+                autoGainControl: true,
+                channelCount: 1,
+            },
+        };
+    },
+    createFallbackVoiceInputRecorder: function (stream) {
+        var createMediaRecorder = this.getFallbackVoiceRecorderHelperMethod('createMediaRecorder');
+        if (createMediaRecorder) {
+            return createMediaRecorder(stream);
+        }
+        return new MediaRecorder(stream);
+    },
+    clearFallbackVoiceInputStopTimer: function () {
+        if (this.fallbackVoiceInput.stopTimer) {
+            clearTimeout(this.fallbackVoiceInput.stopTimer);
+            this.fallbackVoiceInput.stopTimer = null;
+        }
+    },
+    stopFallbackVoiceInputStream: function () {
+        if (this.fallbackVoiceInput.stream) {
+            this.fallbackVoiceInput.stream.getTracks().forEach(function (track) {
+                track.stop();
+            });
+            this.fallbackVoiceInput.stream = null;
+        }
+    },
+    resetFallbackVoiceInputState: function () {
+        this.clearFallbackVoiceInputStopTimer();
+        this.fallbackVoiceInput.recorder = null;
+        this.fallbackVoiceInput.chunks = [];
+        this.fallbackVoiceInput.mimeType = 'audio/webm';
+        this.fallbackVoiceInput.stopping = false;
+        this.stopFallbackVoiceInputStream();
+        Kommunicate.typingAreaService.hideMiceRecordingAnimation();
+    },
+    stopFallbackVoiceInputRecording: function () {
+        if (
+            !this.fallbackVoiceInput.recorder ||
+            this.fallbackVoiceInput.stopping ||
+            this.fallbackVoiceInput.recorder.state === 'inactive'
+        ) {
+            return;
+        }
+        this.fallbackVoiceInput.stopping = true;
+        this.clearFallbackVoiceInputStopTimer();
+        this.fallbackVoiceInput.recorder.stop();
+    },
+    processFallbackVoiceInputTranscript: async function (audioBlob) {
+        if (!audioBlob || !audioBlob.size) {
+            return;
+        }
+        try {
+            var voiceToText = this.getFallbackVoiceClientMethod('voiceToText');
+            var voiceInputSettings = this.getFallbackVoiceInputConfig();
+            var response = await voiceToText(audioBlob, {
+                ucid: voiceInputSettings.ucid,
+                sttMode: 'recognize',
+            });
+            var transcript =
+                response && typeof response.text === 'string' ? response.text.trim() : '';
+            if (transcript) {
+                Kommunicate.typingAreaService.populateText(
+                    this.capitalizeFirstCharacter(transcript)
+                );
+            }
+        } catch (error) {
+            if (error && error.code === 'SILENT_AUDIO') {
+                return;
+            }
+            console.error('error while fallback speech recognition:', error);
+            alert('Could not process voice input. Please try again.');
+        }
+    },
+    startFallbackVoiceInputRecording: async function () {
+        if (!this.canUseFallbackVoiceInput()) {
+            alert('browser do not support speech recognition');
+            return;
+        }
+        if (
+            this.fallbackVoiceInput.recorder &&
+            this.fallbackVoiceInput.recorder.state !== 'inactive'
+        ) {
+            this.stopFallbackVoiceInputRecording();
+            return;
+        }
+        try {
+            var constraints = this.getFallbackVoiceInputConstraints();
+            var stream = await navigator.mediaDevices.getUserMedia(constraints);
+            var recorder = this.createFallbackVoiceInputRecorder(stream);
+            var that = this;
+            var maxRecordingDurationMs = Math.max(
+                Number(that.appOptions.voiceInputTimeout || 10) * 1000,
+                3000
+            );
+
+            that.fallbackVoiceInput.stream = stream;
+            that.fallbackVoiceInput.recorder = recorder;
+            that.fallbackVoiceInput.chunks = [];
+            that.fallbackVoiceInput.mimeType = recorder.mimeType || 'audio/webm';
+            that.fallbackVoiceInput.stopping = false;
+
+            recorder.ondataavailable = function (event) {
+                if (event.data && event.data.size > 0) {
+                    that.fallbackVoiceInput.chunks.push(event.data);
+                }
+            };
+            recorder.onerror = function (event) {
+                console.error(
+                    'fallback MediaRecorder error',
+                    event && event.error ? event.error : event
+                );
+            };
+            recorder.onstop = async function () {
+                var audioBlob = new Blob(that.fallbackVoiceInput.chunks, {
+                    type: that.fallbackVoiceInput.mimeType,
+                });
+                that.resetFallbackVoiceInputState();
+                await that.processFallbackVoiceInputTranscript(audioBlob);
+            };
+
+            recorder.start(250);
+            Kommunicate.typingAreaService.showMicRcordingAnimation();
+            that.clearFallbackVoiceInputStopTimer();
+            that.fallbackVoiceInput.stopTimer = setTimeout(function () {
+                that.stopFallbackVoiceInputRecording();
+            }, maxRecordingDurationMs);
+        } catch (error) {
+            this.resetFallbackVoiceInputState();
+            console.error('error while starting fallback voice input:', error);
+            alert(
+                'Could not access your microphone. Please allow microphone access and try again.'
+            );
+        }
+    },
     isAppleDevice: function () {
         var isIOSDevice = KommunicateUtils.isIOSDevice();
         var isMacSafari = KommunicateUtils.isSafariBrowser();
@@ -34,9 +236,65 @@ Kommunicate.mediaService = {
             return m.toUpperCase();
         });
     },
+    getVoiceOutputText: function (message) {
+        var textToSpeak = '';
+        if (message.hasOwnProperty('fileMeta')) {
+            textToSpeak += MCK_LABELS['voice.output'].attachment;
+            textToSpeak += message.fileMeta.name;
+        } else if (message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION) {
+            var coord = JSON.parse(message.message);
+            textToSpeak += MCK_LABELS['voice.output'].location.init;
+            textToSpeak +=
+                MCK_LABELS['voice.output'].location.lat + Math.round(coord.lat * 100) / 100;
+            textToSpeak +=
+                MCK_LABELS['voice.output'].location.lon + Math.round(coord.lon * 100) / 100;
+        } else if (
+            message.message &&
+            message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT
+        ) {
+            textToSpeak += message.message;
+        }
+        return textToSpeak;
+    },
+    clearFallbackVoiceOutput: function () {
+        if (this.fallbackVoiceOutput.audio) {
+            this.fallbackVoiceOutput.audio.pause();
+            this.fallbackVoiceOutput.audio.src = '';
+            this.fallbackVoiceOutput.audio = null;
+        }
+        if (this.fallbackVoiceOutput.url) {
+            URL.revokeObjectURL(this.fallbackVoiceOutput.url);
+            this.fallbackVoiceOutput.url = '';
+        }
+    },
+    playFallbackVoiceOutput: function (audioBlob) {
+        var that = this;
+        var audio = new Audio();
+        var objectUrl = URL.createObjectURL(audioBlob);
+        that.fallbackVoiceOutput.audio = audio;
+        that.fallbackVoiceOutput.url = objectUrl;
+        audio.src = objectUrl;
+        audio.onended = function () {
+            that.stopVoiceOutput();
+        };
+        audio.onerror = function (error) {
+            console.error('Error while converting the message to voice:', error);
+            that.stopVoiceOutput();
+        };
+        audio.play().catch(function (error) {
+            console.error('Error while playing voice output:', error);
+            that.stopVoiceOutput();
+        });
+    },
     processVoiceInputClickedEvent: function () {
+        var mediaService = Kommunicate.mediaService;
+        var Recognition = mediaService.getSpeechRecognition();
         kmWidgetEvents.eventTracking(eventMapping.onVoiceIconClick);
-        if (!('webkitSpeechRecognition' in window)) {
+        if (!Recognition) {
+            if (mediaService.canUseFallbackVoiceInput()) {
+                mediaService.startFallbackVoiceInputRecording();
+                return;
+            }
             alert('browser do not support speech recognition');
         } else {
             //As of April 2023, works only in chrome, edge and safari(limited support)
@@ -45,7 +303,7 @@ Kommunicate.mediaService = {
             var isAppleProduct = Kommunicate.mediaService.isAppleDevice();
             var appOptions = Kommunicate.mediaService.appOptions;
 
-            var recognition = new webkitSpeechRecognition();
+            var recognition = new Recognition();
             recognition.continuous = isAppleProduct; // DO NOT CHANGE, ELSE WILL BREAK IN SAFARI
             recognition.interimResults = true; // The default value for interimResults is false, meaning that the only results returned by the recognizer are final and will not change. Set it to true so we get early, interim results that may change.
             recognition.lang = appOptions.language || Kommunicate.mediaService.browserLocale;
@@ -100,95 +358,84 @@ Kommunicate.mediaService = {
         }
     },
     voiceOutputIncomingMessage: function (message, offSpeech) {
-        //Text to Speech
+        var speechSynth = this.getSpeechSynthesis();
+        var appOptions =
+            appOptionSession.getPropertyDataFromSession('appOptions') || applozic._globals;
+        var textToSpeak;
 
-        if ('speechSynthesis' in window) {
-            var speechSynth = window.speechSynthesis;
+        if (offSpeech) {
+            this.stopVoiceOutput();
+            return;
+        }
 
-            if (offSpeech) {
-                speechSynth.cancel();
-                return;
+        if (!appOptions || !appOptions.voiceOutput || !Kommunicate.visibleMessage(message)) {
+            return;
+        }
+
+        textToSpeak = this.getVoiceOutputText(message);
+        if (!textToSpeak) {
+            return;
+        }
+
+        if (speechSynth) {
+            var skipForEach = false;
+            var utterance = new SpeechSynthesisUtterance(textToSpeak);
+            utterance.lang = appOptions.language || 'en-US';
+            utterance.rate = appOptions.voiceRate || 1;
+            utterance.text = textToSpeak;
+
+            function updateVoiceName(voice) {
+                utterance.voice = voice;
+                skipForEach = true;
             }
 
-            // get appOptions from widget script
-            var appOptions =
-                appOptionSession.getPropertyDataFromSession('appOptions') || applozic._globals;
+            if (appOptions.voiceName) {
+                AVAILABLE_VOICES_FOR_TTS.forEach(function (voice) {
+                    if (skipForEach) return;
 
-            // If the message isn't part of the UI, it's not included in voice output either
-            if (!appOptions || !Kommunicate.visibleMessage(message)) return;
-
-            // if voiceOutput is enabled
-            if (appOptions.voiceOutput) {
-                var textToSpeak = '';
-
-                if (message.hasOwnProperty('fileMeta')) {
-                    textToSpeak += MCK_LABELS['voice.output'].attachment;
-                    textToSpeak += message.fileMeta.name;
-                } else if (
-                    message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.LOCATION
-                ) {
-                    coord = JSON.parse(message.message);
-                    textToSpeak += MCK_LABELS['voice.output'].location.init;
-                    textToSpeak +=
-                        MCK_LABELS['voice.output'].location.lat + Math.round(coord.lat * 100) / 100;
-                    textToSpeak +=
-                        MCK_LABELS['voice.output'].location.lon + Math.round(coord.lon * 100) / 100;
-                } else if (
-                    message.message &&
-                    message.contentType == KommunicateConstants.MESSAGE_CONTENT_TYPE.DEFAULT
-                ) {
-                    textToSpeak += message.message;
-                }
-
-                if (textToSpeak) {
-                    var skipForEach = false;
-                    var utterance = new SpeechSynthesisUtterance(textToSpeak);
-                    utterance.lang = appOptions.language || 'en-US';
-                    utterance.rate = appOptions.voiceRate || 1;
-                    utterance.text = textToSpeak;
-
-                    function updateVoiceName(voice) {
-                        utterance.voice = voice;
-                        skipForEach = true;
-                    }
-
-                    if (appOptions.voiceName) {
-                        AVAILABLE_VOICES_FOR_TTS.forEach(function (voice) {
-                            if (skipForEach) return;
-
-                            if (Array.isArray(appOptions.voiceName)) {
-                                appOptions.voiceName.forEach(function (voiceName) {
-                                    if (voice.name === voiceName.trim()) {
-                                        updateVoiceName(voice);
-                                    }
-                                });
-                            } else if (voice.name === appOptions.voiceName.trim()) {
+                    if (Array.isArray(appOptions.voiceName)) {
+                        appOptions.voiceName.forEach(function (voiceName) {
+                            if (voice.name === voiceName.trim()) {
                                 updateVoiceName(voice);
                             }
                         });
+                    } else if (voice.name === appOptions.voiceName.trim()) {
+                        updateVoiceName(voice);
                     }
-                    utterance.onerror = function (event) {
-                        if (event.error === 'interrupted') {
-                            console.debug(
-                                'Speech was interrupted. This is expected if speech is canceled or a new utterance is started.'
-                            );
-                        } else {
-                            console.error(
-                                'Error while converting the message to voice:',
-                                event.error
-                            );
-                        }
-                    };
-
-                    speechSynth.speak(utterance);
-                }
+                });
             }
+            utterance.onerror = function (event) {
+                if (event.error === 'interrupted') {
+                    console.debug(
+                        'Speech was interrupted. This is expected if speech is canceled or a new utterance is started.'
+                    );
+                } else {
+                    console.error('Error while converting the message to voice:', event.error);
+                }
+            };
+
+            speechSynth.speak(utterance);
+            return;
+        }
+
+        if (this.canUseFallbackVoiceOutput()) {
+            var textToVoice = this.getFallbackVoiceClientMethod('textToVoice');
+            this.stopVoiceOutput();
+            textToVoice(textToSpeak)
+                .then(function (audioBlob) {
+                    Kommunicate.mediaService.playFallbackVoiceOutput(audioBlob);
+                })
+                .catch(function (error) {
+                    console.error('Error while converting the message to voice:', error);
+                });
         }
     },
     stopVoiceOutput: function () {
-        if ('speechSynthesis' in window) {
-            window.speechSynthesis.cancel();
+        var speechSynth = this.getSpeechSynthesis();
+        if (speechSynth) {
+            speechSynth.cancel();
         }
+        this.clearFallbackVoiceOutput();
     },
     initRecorder: function () {
         const LIVE_OUTPUT = false; // a feature to live output the recording voice to the speaker

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -21,17 +21,16 @@ Kommunicate.mediaService = {
     getFallbackVoiceRecorderHelper: function () {
         return typeof mckVoice !== 'undefined' ? mckVoice : null;
     },
-    getFallbackVoiceClientMethod: function (methodName) {
-        var fallbackVoiceClient = this.getFallbackVoiceClient();
-        return fallbackVoiceClient
-            ? fallbackVoiceClient[methodName].bind(fallbackVoiceClient)
+    getBoundFallbackMethod: function (fallbackClient, methodName) {
+        return fallbackClient && fallbackClient[methodName]
+            ? fallbackClient[methodName].bind(fallbackClient)
             : null;
     },
+    getFallbackVoiceClientMethod: function (methodName) {
+        return this.getBoundFallbackMethod(this.getFallbackVoiceClient(), methodName);
+    },
     getFallbackVoiceRecorderHelperMethod: function (methodName) {
-        var fallbackVoiceRecorderHelper = this.getFallbackVoiceRecorderHelper();
-        return fallbackVoiceRecorderHelper
-            ? fallbackVoiceRecorderHelper[methodName].bind(fallbackVoiceRecorderHelper)
-            : null;
+        return this.getBoundFallbackMethod(this.getFallbackVoiceRecorderHelper(), methodName);
     },
     getSpeechRecognition: function () {
         return window.SpeechRecognition || window.webkitSpeechRecognition || null;

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -9,6 +9,9 @@ Kommunicate.mediaService = {
         mimeType: 'audio/webm',
         stopTimer: null,
         stopping: false,
+        starting: false,
+        startToken: 0,
+        requestId: 0,
     },
     fallbackVoiceOutput: {
         audio: null,
@@ -56,6 +59,24 @@ Kommunicate.mediaService = {
     createFallbackVoiceInputRecorder: function (stream) {
         return mckVoice.createMediaRecorder(stream);
     },
+    getFallbackVoiceInputComposerText: function () {
+        var textbox = document.getElementById('mck-text-box');
+        return textbox ? textbox.textContent || '' : '';
+    },
+    getNextFallbackVoiceInputRequestId: function () {
+        this.fallbackVoiceInput.requestId += 1;
+        return this.fallbackVoiceInput.requestId;
+    },
+    isCurrentFallbackVoiceInputRequest: function (requestId) {
+        return this.fallbackVoiceInput.requestId === requestId;
+    },
+    getNextFallbackVoiceInputStartToken: function () {
+        this.fallbackVoiceInput.startToken += 1;
+        return this.fallbackVoiceInput.startToken;
+    },
+    isCurrentFallbackVoiceInputStart: function (startToken) {
+        return this.fallbackVoiceInput.startToken === startToken;
+    },
     clearFallbackVoiceInputStopTimer: function () {
         if (this.fallbackVoiceInput.stopTimer) {
             clearTimeout(this.fallbackVoiceInput.stopTimer);
@@ -76,6 +97,8 @@ Kommunicate.mediaService = {
         this.fallbackVoiceInput.chunks = [];
         this.fallbackVoiceInput.mimeType = 'audio/webm';
         this.fallbackVoiceInput.stopping = false;
+        this.fallbackVoiceInput.starting = false;
+        this.getNextFallbackVoiceInputStartToken();
         this.stopFallbackVoiceInputStream();
         Kommunicate.typingAreaService.hideMiceRecordingAnimation();
     },
@@ -91,16 +114,26 @@ Kommunicate.mediaService = {
         this.clearFallbackVoiceInputStopTimer();
         this.fallbackVoiceInput.recorder.stop();
     },
-    processFallbackVoiceInputTranscript: async function (audioBlob) {
+    processFallbackVoiceInputTranscript: async function (audioBlob, requestId) {
         if (!audioBlob || !audioBlob.size) {
             return;
         }
+        if (!this.isCurrentFallbackVoiceInputRequest(requestId)) {
+            return;
+        }
+        var composerTextBeforeRequest = this.getFallbackVoiceInputComposerText();
         try {
             var voiceInputSettings = this.getFallbackVoiceInputConfig();
             var response = await kmVoice.voiceToText(audioBlob, {
                 ucid: voiceInputSettings.ucid,
                 sttMode: 'recognize',
             });
+            if (
+                !this.isCurrentFallbackVoiceInputRequest(requestId) ||
+                this.getFallbackVoiceInputComposerText() !== composerTextBeforeRequest
+            ) {
+                return;
+            }
             var transcript =
                 response && typeof response.text === 'string' ? response.text.trim() : '';
             if (transcript) {
@@ -110,6 +143,12 @@ Kommunicate.mediaService = {
                 window.$applozic.fn.applozic('toggleMediaOptions');
             }
         } catch (error) {
+            if (
+                !this.isCurrentFallbackVoiceInputRequest(requestId) ||
+                this.getFallbackVoiceInputComposerText() !== composerTextBeforeRequest
+            ) {
+                return;
+            }
             if (error && error.code === 'SILENT_AUDIO') {
                 return;
             }
@@ -122,6 +161,9 @@ Kommunicate.mediaService = {
             alert('browser do not support speech recognition');
             return;
         }
+        if (this.fallbackVoiceInput.starting) {
+            return;
+        }
         if (
             this.fallbackVoiceInput.recorder &&
             this.fallbackVoiceInput.recorder.state !== 'inactive'
@@ -129,19 +171,37 @@ Kommunicate.mediaService = {
             this.stopFallbackVoiceInputRecording();
             return;
         }
+        var stream = null;
+        var startToken = null;
         try {
             var constraints = this.getFallbackVoiceInputConstraints();
-            var stream = await navigator.mediaDevices.getUserMedia(constraints);
+            this.fallbackVoiceInput.starting = true;
+            startToken = this.getNextFallbackVoiceInputStartToken();
+            stream = await navigator.mediaDevices.getUserMedia(constraints);
+            if (
+                !this.fallbackVoiceInput.starting ||
+                !this.isCurrentFallbackVoiceInputStart(startToken) ||
+                (this.fallbackVoiceInput.recorder &&
+                    this.fallbackVoiceInput.recorder.state !== 'inactive')
+            ) {
+                stream.getTracks().forEach(function (track) {
+                    track.stop();
+                });
+                return;
+            }
             var recorder = this.createFallbackVoiceInputRecorder(stream);
             var that = this;
             // Fallback recording uses its own max-duration config; voiceInputTimeout remains the silence timeout for native STT.
             var maxRecordingDurationMs = that.getFallbackVoiceInputMaxDurationMs();
+            var fallbackVoiceInputRequestId = that.getNextFallbackVoiceInputRequestId();
 
             that.fallbackVoiceInput.stream = stream;
             that.fallbackVoiceInput.recorder = recorder;
             that.fallbackVoiceInput.chunks = [];
             that.fallbackVoiceInput.mimeType = recorder.mimeType || '';
             that.fallbackVoiceInput.stopping = false;
+            that.fallbackVoiceInput.starting = false;
+            stream = null;
 
             recorder.ondataavailable = function (event) {
                 if (event.data && event.data.size > 0) {
@@ -156,6 +216,7 @@ Kommunicate.mediaService = {
                     'fallback MediaRecorder error',
                     event && event.error ? event.error : event
                 );
+                that.getNextFallbackVoiceInputRequestId();
                 that.resetFallbackVoiceInputState();
             };
             recorder.onstop = async function () {
@@ -163,7 +224,10 @@ Kommunicate.mediaService = {
                     type: that.fallbackVoiceInput.mimeType || 'audio/webm',
                 });
                 that.resetFallbackVoiceInputState();
-                await that.processFallbackVoiceInputTranscript(audioBlob);
+                await that.processFallbackVoiceInputTranscript(
+                    audioBlob,
+                    fallbackVoiceInputRequestId
+                );
             };
 
             recorder.start(250);
@@ -173,11 +237,20 @@ Kommunicate.mediaService = {
                 that.stopFallbackVoiceInputRecording();
             }, maxRecordingDurationMs);
         } catch (error) {
+            if (stream) {
+                stream.getTracks().forEach(function (track) {
+                    track.stop();
+                });
+            }
             this.resetFallbackVoiceInputState();
             console.error('error while starting fallback voice input:', error);
             alert(
                 'Could not access your microphone. Please allow microphone access and try again.'
             );
+        } finally {
+            if (this.isCurrentFallbackVoiceInputStart(startToken)) {
+                this.fallbackVoiceInput.starting = false;
+            }
         }
     },
     isAppleDevice: function () {

--- a/webplugin/js/app/media/media-service.js
+++ b/webplugin/js/app/media/media-service.js
@@ -12,6 +12,7 @@ Kommunicate.mediaService = {
         starting: false,
         startToken: 0,
         requestId: 0,
+        errorTimer: null,
     },
     fallbackVoiceOutput: {
         audio: null,
@@ -44,6 +45,26 @@ Kommunicate.mediaService = {
         return (
             (kommunicate && kommunicate._globals && kommunicate._globals.voiceInputSettings) || {}
         );
+    },
+    showVoiceInputErrorMessage: function (message) {
+        var errorElement = document.getElementById('mck-msg-error');
+        if (!errorElement) {
+            console.warn(message);
+            return;
+        }
+        if (this.fallbackVoiceInput.errorTimer) {
+            clearTimeout(this.fallbackVoiceInput.errorTimer);
+            this.fallbackVoiceInput.errorTimer = null;
+        }
+        var that = this;
+        errorElement.textContent = message;
+        errorElement.classList.add('mck-no-mb');
+        kommunicateCommons.show(errorElement);
+        this.fallbackVoiceInput.errorTimer = setTimeout(function () {
+            kommunicateCommons.hide(errorElement);
+            errorElement.classList.remove('mck-no-mb');
+            that.fallbackVoiceInput.errorTimer = null;
+        }, 5000);
     },
     getFallbackVoiceInputMaxDurationMs: function () {
         var appOptions = this.appOptions || {};
@@ -153,12 +174,22 @@ Kommunicate.mediaService = {
                 return;
             }
             console.error('error while fallback speech recognition:', error);
-            alert('Could not process voice input. Please try again.');
+            this.showVoiceInputErrorMessage(
+                kommunicateCommons.getLocalizedLabel(
+                    'voiceInterface.processingFailed',
+                    'Could not process voice input. Please try again.'
+                )
+            );
         }
     },
     startFallbackVoiceInputRecording: async function () {
         if (!this.canUseFallbackVoiceInput()) {
-            alert('browser do not support speech recognition');
+            this.showVoiceInputErrorMessage(
+                kommunicateCommons.getLocalizedLabel(
+                    'voice.input.unsupported',
+                    'Voice input is not supported in this browser.'
+                )
+            );
             return;
         }
         if (this.fallbackVoiceInput.starting) {
@@ -244,8 +275,11 @@ Kommunicate.mediaService = {
             }
             this.resetFallbackVoiceInputState();
             console.error('error while starting fallback voice input:', error);
-            alert(
-                'Could not access your microphone. Please allow microphone access and try again.'
+            this.showVoiceInputErrorMessage(
+                kommunicateCommons.getLocalizedLabel(
+                    'voice.permission.required',
+                    'Microphone permission is required for voice mode.'
+                )
             );
         } finally {
             if (this.isCurrentFallbackVoiceInputStart(startToken)) {
@@ -347,7 +381,12 @@ Kommunicate.mediaService = {
                 mediaService.startFallbackVoiceInputRecording();
                 return;
             }
-            alert('browser do not support speech recognition');
+            mediaService.showVoiceInputErrorMessage(
+                kommunicateCommons.getLocalizedLabel(
+                    'voice.input.unsupported',
+                    'Voice input is not supported in this browser.'
+                )
+            );
         } else {
             //As of April 2023, works only in chrome, edge and safari(limited support)
             var lastListeningEventTime = 0;

--- a/webplugin/js/app/media/typing-area-dom-service.js
+++ b/webplugin/js/app/media/typing-area-dom-service.js
@@ -45,7 +45,7 @@ Kommunicate.typingAreaService = {
                 this.showMicButton();
             }
         } else if (appOption && appOption.voiceInput && !appOption.voiceNote) {
-            if (!window.hasOwnProperty('webkitSpeechRecognition')) {
+            if (!Kommunicate.mediaService.supportsVoiceInput()) {
                 console.log('browser do not support speech recognition');
                 this.hideMicButton();
             } else {
@@ -56,7 +56,7 @@ Kommunicate.typingAreaService = {
             }
         } else if (appOption && appOption.voiceInput && appOption.voiceNote) {
             if (
-                !window.hasOwnProperty('webkitSpeechRecognition') ||
+                !Kommunicate.mediaService.supportsVoiceInput() ||
                 !window.hasOwnProperty('MediaRecorder')
             ) {
                 console.log('browser do not support speech recognition or media recording');

--- a/webplugin/js/app/voice/index.js
+++ b/webplugin/js/app/voice/index.js
@@ -1071,8 +1071,6 @@ class Voice {
         const resolvedUcid = this.resolveVoiceSessionUcid(ucid);
         const { state } = this.getVoiceLanguageState(activeConversationUcid);
         const sttLanguageCode = this.getSessionVoiceLanguageCode(state);
-        const shouldSendAlternativeLanguageCodes =
-            !sttLanguageCode && state && state.hasSentVoiceToTextRequest;
 
         const payload = {
             bitsPerSample: this._OMNICHANNEL_STT_AUDIO_CONFIG.bitsPerSample,
@@ -1084,15 +1082,6 @@ class Voice {
         if (sttLanguageCode) {
             payload.languageCode = sttLanguageCode;
         }
-        // if (shouldSendAlternativeLanguageCodes) {
-        //     const firstRequestAlternatives = this.getFirstSttAlternativeLanguageCodes(
-        //         sttLanguageCode,
-        //         activeConversationUcid
-        //     );
-        //     if (firstRequestAlternatives.length) {
-        //         payload.alternativeLanguageCodes = firstRequestAlternatives;
-        //     }
-        // }
         if (resolvedUcid !== undefined && resolvedUcid !== null && resolvedUcid !== '') {
             payload.ucid = String(resolvedUcid);
         }

--- a/webplugin/js/app/voice/index.js
+++ b/webplugin/js/app/voice/index.js
@@ -1063,15 +1063,6 @@ class Voice {
         const sampleRate = Number(sampleRateOverride) || this.getVoiceToTextSampleRate();
         const samples = await this.resolveVoiceToTextSamples(audioInput, sampleRate);
         const audioMetrics = this.evaluatePcmInt16Quality(samples);
-        console.debug('Voice STT audio metrics', {
-            sampleRate,
-            sampleCount: audioMetrics.sampleCount,
-            nonZeroRatio: audioMetrics.nonZeroRatio,
-            rms: audioMetrics.rms,
-            peakAbs: audioMetrics.peakAbs,
-            zcr: audioMetrics.zcr,
-            isSilent: audioMetrics.isSilent,
-        });
         if (audioMetrics.isSilent) {
             const silentAudioError = this.createSilentAudioError(audioMetrics);
             throw silentAudioError;

--- a/webplugin/js/app/voice/index.js
+++ b/webplugin/js/app/voice/index.js
@@ -1063,6 +1063,15 @@ class Voice {
         const sampleRate = Number(sampleRateOverride) || this.getVoiceToTextSampleRate();
         const samples = await this.resolveVoiceToTextSamples(audioInput, sampleRate);
         const audioMetrics = this.evaluatePcmInt16Quality(samples);
+        console.debug('Voice STT audio metrics', {
+            sampleRate,
+            sampleCount: audioMetrics.sampleCount,
+            nonZeroRatio: audioMetrics.nonZeroRatio,
+            rms: audioMetrics.rms,
+            peakAbs: audioMetrics.peakAbs,
+            zcr: audioMetrics.zcr,
+            isSilent: audioMetrics.isSilent,
+        });
         if (audioMetrics.isSilent) {
             const silentAudioError = this.createSilentAudioError(audioMetrics);
             throw silentAudioError;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- For voiceInput and voiceOutput settings, fallback to voice/text apis if native support is not there eg: Firefox browser is missing the support

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MediaRecorder-based fallback for voice input when native recognition is unavailable, with recording lifecycle and transcript processing.
  * Fallback voice output (TTS) playback when native synthesis is unavailable, with safe request tracking to avoid stale audio.
  * Mic visibility logic improved to show/hide mic controls more accurately across browsers and configurations.
  * STT audio quality metrics are now logged for diagnostics.

* **Bug Fixes**
  * Voice chat now initializes when voice input or voice output is enabled individually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->