### PR TITLE
Fix-iframe-height-issue.

### DIFF
--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -149,6 +149,11 @@ function KommunicateCommons() {
         var baseHeight =
             computedStyle && computedStyle.height ? parseInt(computedStyle.height, 10) : NaN;
 
+        var iframeBottomOffset =
+            computedStyle && computedStyle.bottom ? parseFloat(computedStyle.bottom) : NaN;
+        if (isNaN(iframeBottomOffset)) {
+            iframeBottomOffset = IFRAME_BOTTOM_OFFSET; // fallback, currently 120 or default 15
+        }
         if (isNaN(baseHeight)) {
             return;
         }
@@ -158,7 +163,9 @@ function KommunicateCommons() {
             navHeight = DEFAULT_BOTTOM_NAV_HEIGHT;
         }
         var navAdjustedIframeHeight = baseHeight - navHeight;
-        var finalIframeHeight = navAdjustedIframeHeight > 0 ? navAdjustedIframeHeight : baseHeight;
+        var finalIframeHeight =
+            (navAdjustedIframeHeight > 0 ? navAdjustedIframeHeight : baseHeight) -
+            iframeBottomOffset;
         var shouldEnforceTopGap =
             iframeElement.classList &&
             iframeElement.classList.contains('km-iframe-dimension-with-popup');
@@ -167,7 +174,7 @@ function KommunicateCommons() {
                 heightSourceWindow && heightSourceWindow.innerHeight
                     ? heightSourceWindow.innerHeight
                     : window.innerHeight;
-            var maxIframeHeightWithTopGap = viewportHeight - MIN_TOP_CTA_GAP - IFRAME_BOTTOM_OFFSET;
+            var maxIframeHeightWithTopGap = viewportHeight - MIN_TOP_CTA_GAP - iframeBottomOffset;
             if (!isNaN(maxIframeHeightWithTopGap) && maxIframeHeightWithTopGap > 0) {
                 finalIframeHeight = Math.max(finalIframeHeight, maxIframeHeightWithTopGap);
             }

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -149,15 +149,14 @@ function KommunicateCommons() {
         var baseHeight =
             computedStyle && computedStyle.height ? parseInt(computedStyle.height, 10) : NaN;
 
-        var iframeBottomOffset =
-            computedStyle && computedStyle.bottom ? parseFloat(computedStyle.bottom) : NaN;
-        if (isNaN(iframeBottomOffset)) {
-            iframeBottomOffset = IFRAME_BOTTOM_OFFSET; // fallback, currently 120 or default 15
-        }
         if (isNaN(baseHeight)) {
             return;
         }
-
+        var iframeBottomOffset =
+            computedStyle && computedStyle.bottom ? parseFloat(computedStyle.bottom) : NaN;
+        if (isNaN(iframeBottomOffset)) {
+            iframeBottomOffset = IFRAME_BOTTOM_OFFSET;
+        }
         var navHeight = getBottomNavHeight(iframeElement);
         if (isNaN(navHeight) || navHeight <= 0) {
             navHeight = DEFAULT_BOTTOM_NAV_HEIGHT;

--- a/webplugin/plugin.js
+++ b/webplugin/plugin.js
@@ -75,6 +75,7 @@ var kmCustomIframe =
     '.kommunicate-custom-iframe.km-iframe-dimension-no-popup { ' +
     '   width: 100% !important;' +
     '   min-width: 0 !important;' +
+    '   max-width: 100% !important;' +
     '   left: 0 !important;' +
     '   right: 0 !important;' +
     '   bottom: 0 !important;' +


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix iframe height adjustment when users add custom CSS for the iframe bottom section. Previously, the iframe height was calculated using a fixed value, which caused layout issues. Updated the implementation to dynamically calculate and use the actual iframe height.

Reference: https://intentive-ai.slack.com/archives/C067K8P3NRE/p1778227269088869

- Update widget behavior for small screen devices. If the screen size is `<= 600px`, the widget should open in full-screen mode.
Currently: <img width="664" height="681" alt="image" src="https://github.com/user-attachments/assets/f2b1f5c1-fab2-46c6-89f6-10880222e427" />

(widget is not fully covering the full screen (height is full but width is not))

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iframe height calculation for better layout accuracy and spacing
  * Enhanced mobile layout display by enforcing proper width constraints on iframe elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->