### PR TITLE
[codex] Add pre-chat regex validation support

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -4363,7 +4363,10 @@ const firstVisibleMsg = {
                 var mck_text_box = document.getElementById('mck-text-box');
                 mck_text_box.addEventListener('paste', function (e) {
                     e.preventDefault();
-                    const text = (e.clipboardData || window.clipboardData).getData('text');
+                    const text = (e.clipboardData || window.clipboardData)
+                        .getData('text')
+                        .replace(/\r\n/g, '\n')
+                        .replace(/\n+$/, '');
                     document.execCommand('insertText', false, text);
                 });
 
@@ -7505,6 +7508,19 @@ const firstVisibleMsg = {
                 }
             };
 
+            _this.sortMessagesByCreatedAt = function (messages, descending) {
+                if (!Array.isArray(messages)) {
+                    return messages;
+                }
+                return messages.slice().sort(function (firstMessage, secondMessage) {
+                    var firstCreatedAt = Number(firstMessage && firstMessage.createdAtTime) || 0;
+                    var secondCreatedAt = Number(secondMessage && secondMessage.createdAtTime) || 0;
+                    return descending
+                        ? secondCreatedAt - firstCreatedAt
+                        : firstCreatedAt - secondCreatedAt;
+                });
+            };
+
             _this.processMessageList = function (data, scroll, isValidated, append, allowReload) {
                 // allowReload parameter is using to reload chat widget when the socket connect
                 var showMoreDateTime;
@@ -7522,6 +7538,9 @@ const firstVisibleMsg = {
                 var contact = isGroup
                     ? mckGroupUtils.getGroup(tabId)
                     : mckMessageLayout.fetchContact(tabId);
+                if (data && Array.isArray(data.message)) {
+                    data.message = _this.sortMessagesByCreatedAt(data.message, !append);
+                }
                 scroll &&
                     $mck_msg_inner.data(
                         'last-message-received-time',
@@ -7529,7 +7548,9 @@ const firstVisibleMsg = {
                     );
                 if (allowReload) {
                     scroll = false;
-                    data && data.message && (data.message = data.message.reverse());
+                    data &&
+                        data.message &&
+                        (data.message = _this.sortMessagesByCreatedAt(data.message, false));
                 }
                 if (typeof data.message.length === 'undefined') {
                     var messageArray = [];

--- a/webplugin/js/app/prechat/km-prechat.js
+++ b/webplugin/js/app/prechat/km-prechat.js
@@ -365,7 +365,9 @@ var KMPreChat = (function () {
                 return null;
             }
             var regex = validation.regex;
+            var flags = '';
             if (regex instanceof RegExp) {
+                flags = regex.flags;
                 regex = regex.source;
             }
             if (typeof regex !== 'string') {
@@ -373,6 +375,7 @@ var KMPreChat = (function () {
             }
             return {
                 regex: regex,
+                flags: flags,
                 errorText:
                     validation.errorText || getLeadCollectionLabel('commonErrorMsg', ''),
             };
@@ -385,6 +388,7 @@ var KMPreChat = (function () {
             input.setAttribute('pattern', validation.regex);
             input.setAttribute('title', validation.errorText || '');
             input.setAttribute('data-km-validation-regex', validation.regex);
+            input.setAttribute('data-km-validation-flags', validation.flags || '');
             input.setAttribute('data-km-validation-error', validation.errorText || '');
             input.setAttribute(
                 'oninvalid',
@@ -682,6 +686,7 @@ var KMPreChat = (function () {
             var emailField = document.getElementById('km-email');
             var phoneField = document.getElementById('km-phone');
             var submitBtn = document.getElementById('km-submit-chat-login');
+            var chatLoginForm = document.getElementById('km-form-chat-login');
             var customValidationFields = Array.prototype.slice.call(
                 document.querySelectorAll('[data-km-validation-regex]')
             );
@@ -702,6 +707,7 @@ var KMPreChat = (function () {
 
             var validateCustomField = function (field) {
                 var regexText = field.getAttribute('data-km-validation-regex');
+                var regexFlags = field.getAttribute('data-km-validation-flags') || '';
                 var errorText =
                     field.getAttribute('data-km-validation-error') ||
                     getLeadCollectionLabel('commonErrorMsg', '');
@@ -713,13 +719,14 @@ var KMPreChat = (function () {
                     return true;
                 }
                 try {
-                    if (!new RegExp(regexText).test(value)) {
+                    if (!new RegExp(regexText, regexFlags).test(value)) {
                         setError(errorText);
                         return false;
                     }
                 } catch (error) {
                     console.error('Invalid pre-chat validation regex', error);
-                    return true;
+                    setError(errorText);
+                    return false;
                 }
                 return true;
             };
@@ -733,7 +740,6 @@ var KMPreChat = (function () {
                         return false;
                     }
                 }
-                setError('');
                 return true;
             };
 
@@ -809,17 +815,27 @@ var KMPreChat = (function () {
                 });
             }
 
+            var handleSubmitValidation = function (event) {
+                formSubmitted = true;
+                if (
+                    !handleCustomValidation() ||
+                    (handleEmailValidation && !handleEmailValidation()) ||
+                    (handlePhoneValidation && !handlePhoneValidation())
+                ) {
+                    if (event && typeof event.preventDefault === 'function') {
+                        event.preventDefault();
+                    }
+                    return false;
+                }
+                setError('');
+                return true;
+            };
+
             if (submitBtn) {
-                submitBtn.addEventListener('click', function () {
-                    formSubmitted = true;
-                    if (!handleCustomValidation()) {
-                        return;
-                    }
-                    if (handleEmailValidation && !handleEmailValidation()) {
-                        return;
-                    }
-                    handlePhoneValidation && handlePhoneValidation();
-                });
+                submitBtn.addEventListener('click', handleSubmitValidation);
+            }
+            if (chatLoginForm) {
+                chatLoginForm.addEventListener('submit', handleSubmitValidation);
             }
         };
 

--- a/webplugin/js/app/prechat/km-prechat.js
+++ b/webplugin/js/app/prechat/km-prechat.js
@@ -359,6 +359,40 @@ var KMPreChat = (function () {
             }
         }
 
+        var getCustomValidation = function (preLeadCollection) {
+            var validation = preLeadCollection && preLeadCollection.validation;
+            if (!validation || !validation.regex) {
+                return null;
+            }
+            var regex = validation.regex;
+            if (regex instanceof RegExp) {
+                regex = regex.source;
+            }
+            if (typeof regex !== 'string') {
+                return null;
+            }
+            return {
+                regex: regex,
+                errorText:
+                    validation.errorText || getLeadCollectionLabel('commonErrorMsg', ''),
+            };
+        };
+
+        var setValidationAttributes = function (input, validation) {
+            if (!input || !validation || !validation.regex) {
+                return;
+            }
+            input.setAttribute('pattern', validation.regex);
+            input.setAttribute('title', validation.errorText || '');
+            input.setAttribute('data-km-validation-regex', validation.regex);
+            input.setAttribute('data-km-validation-error', validation.errorText || '');
+            input.setAttribute(
+                'oninvalid',
+                "setCustomValidity(this.getAttribute('data-km-validation-error') || '')"
+            );
+            input.setAttribute('oninput', "setCustomValidity('')");
+        };
+
         target.createInputField = function (preLeadCollection) {
             var rawField = (preLeadCollection.field || '').toString();
             var normalizedField = rawField.toLowerCase().replace(/\s+/g, '');
@@ -427,7 +461,10 @@ var KMPreChat = (function () {
                 kmChatInput.setAttribute('type', preLeadCollection.type || 'text');
                 kmChatInput.setAttribute('placeholder', preLeadCollection.placeholder || '');
                 kmChatInput.setAttribute('aria-label', preLeadCollection.field);
-                if (preLeadCollection.type === 'email') {
+                var customValidation = getCustomValidation(preLeadCollection);
+                if (customValidation) {
+                    setValidationAttributes(kmChatInput, customValidation);
+                } else if (preLeadCollection.type === 'email') {
                     kmChatInput.setAttribute('pattern', '^[^\\s@]+@[^\\s@]+\\.[^\\s@]{2,}$');
                     kmChatInput.setAttribute('title', '');
                     kmChatInput.setAttribute(
@@ -645,6 +682,9 @@ var KMPreChat = (function () {
             var emailField = document.getElementById('km-email');
             var phoneField = document.getElementById('km-phone');
             var submitBtn = document.getElementById('km-submit-chat-login');
+            var customValidationFields = Array.prototype.slice.call(
+                document.querySelectorAll('[data-km-validation-regex]')
+            );
             var formSubmitted = false;
 
             var setError = function (message) {
@@ -660,24 +700,72 @@ var KMPreChat = (function () {
                 }
             };
 
+            var validateCustomField = function (field) {
+                var regexText = field.getAttribute('data-km-validation-regex');
+                var errorText =
+                    field.getAttribute('data-km-validation-error') ||
+                    getLeadCollectionLabel('commonErrorMsg', '');
+                if (!regexText) {
+                    return true;
+                }
+                var value = field.value || '';
+                if (!value && !field.hasAttribute('required')) {
+                    return true;
+                }
+                try {
+                    if (!new RegExp(regexText).test(value)) {
+                        setError(errorText);
+                        return false;
+                    }
+                } catch (error) {
+                    console.error('Invalid pre-chat validation regex', error);
+                    return true;
+                }
+                return true;
+            };
+
+            var handleCustomValidation = function () {
+                if (!formSubmitted) {
+                    return true;
+                }
+                for (var i = 0; i < customValidationFields.length; i++) {
+                    if (!validateCustomField(customValidationFields[i])) {
+                        return false;
+                    }
+                }
+                setError('');
+                return true;
+            };
+
+            customValidationFields.forEach(function (field) {
+                field.addEventListener('input', function () {
+                    handleCustomValidation();
+                });
+                field.addEventListener('blur', function () {
+                    handleCustomValidation();
+                });
+            });
+
             if (emailField) {
                 var isValidEmail = function (value) {
                     return KommunicateUI.isValidEmail(value);
                 };
                 var handleEmailValidation = function () {
                     if (!formSubmitted) {
-                        return;
+                        return true;
                     }
                     var value = (emailField.value || '').toLowerCase();
                     if (!value) {
                         setError('');
-                        return;
+                        return true;
                     }
                     if (!isValidEmail(value)) {
                         setError(getLeadCollectionLabel('errorEmail', ''));
+                        return false;
                     } else {
                         setError('');
                     }
+                    return true;
                 };
                 emailField.addEventListener('input', function () {
                     handleEmailValidation();
@@ -690,12 +778,12 @@ var KMPreChat = (function () {
             if (phoneField) {
                 var handlePhoneValidation = function () {
                     if (!formSubmitted) {
-                        return;
+                        return true;
                     }
                     var value = phoneField.value || '';
                     if (!value) {
                         setError('');
-                        return;
+                        return true;
                     }
                     var isValid = true;
                     var intlInstance = deps.getIntlTelInstance();
@@ -707,9 +795,11 @@ var KMPreChat = (function () {
                     }
                     if (!isValid) {
                         setError(getLeadCollectionLabel('commonErrorMsg', ''));
+                        return false;
                     } else {
                         setError('');
                     }
+                    return true;
                 };
                 phoneField.addEventListener('input', function () {
                     handlePhoneValidation();
@@ -722,7 +812,12 @@ var KMPreChat = (function () {
             if (submitBtn) {
                 submitBtn.addEventListener('click', function () {
                     formSubmitted = true;
-                    handleEmailValidation && handleEmailValidation();
+                    if (!handleCustomValidation()) {
+                        return;
+                    }
+                    if (handleEmailValidation && !handleEmailValidation()) {
+                        return;
+                    }
                     handlePhoneValidation && handlePhoneValidation();
                 });
             }


### PR DESCRIPTION
## Summary
- support preLeadCollection validation.regex and validation.errorText from widget script config
- wire the regex into browser pattern validation and the existing inline pre-chat error area
- keep existing email and phone validation behavior when no custom regex is configured
- trim trailing clipboard newlines when pasting copied widget messages back into the composer
- sort loaded widget messages by createdAtTime before rendering so welcome-message parts keep a deterministic order

## Jira
- TDH-3656
- TDH-3614
- TDH-3449

## Validation
- node --check webplugin/js/app/prechat/km-prechat.js
- node --check webplugin/js/app/mck-sidebox-1.0.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable field validation in pre-chat forms with real-time validation feedback and error messaging.

* **Bug Fixes**
  * Fixed text pasting in chat composer to properly handle line breaks and formatting.
  * Improved message ordering consistency during reload flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kommunicate-io/Kommunicate-Web-SDK/pull/1522)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->