### PR TITLE
TDH-3614: Trim copied widget message text

### DIFF
--- a/webplugin/js/app/km-post-initialization.js
+++ b/webplugin/js/app/km-post-initialization.js
@@ -7,6 +7,7 @@
 Kommunicate.postPluginInitialization = function (err, data) {
     // get the third party settings
     KommunicateKB.init(Kommunicate.getBaseUrl());
+    KommunicateUI.bindMessageCopyHandler();
     var categoryName;
     var primaryCTA = kommunicate?._globals?.primaryCTA;
 

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -23,6 +23,43 @@ KommunicateUI = {
     faqSVGImage:
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><circle class="km-custom-widget-fill" cx="12" cy="12" r="12" fill="#5553B7" fill-rule="nonzero" opacity=".654"/><g transform="translate(6.545 5.818)"><polygon fill="#FFF" points=".033 2.236 .033 12.057 10.732 12.057 10.732 .02 3.324 .02"/><rect class="km-custom-widget-fill" width="6.433" height="1" x="2.144" y="5.468" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><rect class="km-custom-widget-fill" width="4.289" height="1" x="2.144" y="8.095" fill="#5553B7" fill-rule="nonzero" opacity=".65" rx=".5"/><polygon class="km-custom-widget-fill" fill="#5553B7" points="2.656 .563 3.384 2.487 1.162 3.439" opacity=".65" transform="rotate(26 2.273 2.001)"/></g></g></svg>',
     CONSTS: {},
+    isMessageCopyHandlerBound: false,
+    normalizeCopiedMessageText: function (text) {
+        return (text || '').replace(/[ \t]+\n/g, '\n').replace(/\n[ \t]*$/g, '');
+    },
+    isNodeInsideMessageCell: function (node) {
+        while (node) {
+            if (node.id === 'mck-message-cell') {
+                return true;
+            }
+            node = node.parentNode;
+        }
+        return false;
+    },
+    bindMessageCopyHandler: function () {
+        if (KommunicateUI.isMessageCopyHandlerBound || !document.addEventListener) {
+            return;
+        }
+        KommunicateUI.isMessageCopyHandlerBound = true;
+        document.addEventListener('copy', function (event) {
+            var selection = window.getSelection && window.getSelection();
+            if (!selection || selection.rangeCount === 0 || !event.clipboardData) {
+                return;
+            }
+
+            var range = selection.getRangeAt(0);
+            if (!KommunicateUI.isNodeInsideMessageCell(range.commonAncestorContainer)) {
+                return;
+            }
+
+            var selectedText = selection.toString();
+            var normalizedText = KommunicateUI.normalizeCopiedMessageText(selectedText);
+            if (selectedText !== normalizedText) {
+                event.clipboardData.setData('text/plain', normalizedText);
+                event.preventDefault();
+            }
+        });
+    },
     updateScroll: function (element) {
         element.scrollTop = element.scrollHeight;
     },


### PR DESCRIPTION
## Summary
- [TDH-3614](https://kommunicate.atlassian.net/browse/TDH-3614): Remove the extra trailing line when copying text from chat widget messages.
- Add a scoped copy handler that only normalizes clipboard text when the selection is inside the widget message cell.
- Leave rendered message text untouched.

## Validation
- node --check webplugin/js/app/kommunicate-ui.js
- node --check webplugin/js/app/km-post-initialization.js
- git diff --check

[TDH-3614]: https://kommunicate.atlassian.net/browse/TDH-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ