### PR TITLE
Fix answer feedback button

### DIFF
--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -1213,6 +1213,24 @@ input[type=number]::-webkit-outer-spin-button {
   border: 0px solid #dcdcdc;
 }
 
+.mck-msg-content {
+  max-width: 100%;
+  min-width: 0;
+}
+.mck-msg-content pre,
+.mck-msg-content code[class*=language-] {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.mck-msg-content pre code {
+  display: inline;
+  white-space: inherit;
+  overflow-wrap: inherit;
+}
+
 #mck-message-cell .mck-m-b:focus-visible {
   outline: none;
   box-shadow: inset 0 0 0 2px rgba(95, 70, 248, 0.35);

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -1278,7 +1278,7 @@ input[type=number]::-webkit-outer-spin-button {
 
 .km-answer-feedback {
   position: absolute;
-  bottom: 5px;
+  bottom: 2px;
   left: 75%;
   display: flex !important;
   justify-content: flex-end;
@@ -1333,12 +1333,12 @@ input[type=number]::-webkit-outer-spin-button {
   align-items: center;
   justify-content: center;
   position: absolute;
-  height: 30px;
-  width: 30px;
-  right: 0;
+  height: 22px;
+  width: 22px;
+  right: -20px;
   background: black;
   border-radius: 50%;
-  bottom: -25px;
+  bottom: -11px;
 }
 .mck-msg-feedback-sticker svg path {
   fill: #ffffff;

--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -1301,7 +1301,6 @@ input[type=number]::-webkit-outer-spin-button {
   display: flex !important;
   justify-content: flex-end;
   align-items: center;
-  gap: 6px;
 }
 .km-answer-feedback svg {
   stroke: #1c1c1c;

--- a/webplugin/scss/components/_km-message-area.scss
+++ b/webplugin/scss/components/_km-message-area.scss
@@ -74,6 +74,28 @@
     border: 0px solid $input-border-color;
 }
 
+.mck-msg-content {
+    max-width: 100%;
+    min-width: 0;
+
+    pre,
+    code[class*='language-'] {
+        display: block;
+        max-width: 100%;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+    }
+
+    pre {
+        code {
+            display: inline;
+            white-space: inherit;
+            overflow-wrap: inherit;
+        }
+    }
+}
+
 #mck-message-cell .mck-m-b:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 2px rgba($primary-color, 0.35);

--- a/webplugin/scss/components/_km-message-area.scss
+++ b/webplugin/scss/components/_km-message-area.scss
@@ -164,7 +164,6 @@
     display: flex !important;
     justify-content: flex-end;
     align-items: center;
-    gap: 6px;
 
     & svg {
         stroke: $text-primary-color;

--- a/webplugin/scss/components/_km-message-area.scss
+++ b/webplugin/scss/components/_km-message-area.scss
@@ -137,7 +137,7 @@
 
 .km-answer-feedback {
     position: absolute;
-    bottom: 5px;
+    bottom: 2px;
     left: 75%;
     display: flex !important;
     justify-content: flex-end;
@@ -194,12 +194,12 @@
     align-items: center;
     justify-content: center;
     position: absolute;
-    height: 30px;
-    width: 30px;
-    right: 0;
+    height: 22px;
+    width: 22px;
+    right: -20px;
     background: black;
     border-radius: 50%;
-    bottom: -25px;
+    bottom: -11px;
 
     & svg {
         path {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- ### Feedback thumb icon is not displaying properly.
<img width="451" height="448" alt="image" src="https://github.com/user-attachments/assets/1ed908bb-fca9-4650-b749-ecd61091f847" />

- ### Added CSS for code blocks.
Currently, the code block is overflowing outside the message container.

<img width="451" height="548" alt="image" src="https://github.com/user-attachments/assets/326c281d-7814-4b96-b448-5f36d688d603" />

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Constrained message content to prevent layout breaks from long code or preformatted text; improved wrapping and enabled horizontal scrolling for bounded code blocks.
  * Tweaked feedback UI: nudged the feedback label upward and resized/repositioned the feedback sticker for a cleaner, less obtrusive appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kommunicate-io/Kommunicate-Web-SDK/pull/1527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->