### PR TITLE
TDH-2919: Show "Suggested Replies" button After user click Setting was not working correctly for a customer

### DIFF
--- a/webplugin/development.js
+++ b/webplugin/development.js
@@ -63,7 +63,9 @@ const minifyPluginContent = (code) => {
 };
 
 const rewriteBundledFontPaths = (cssContent) =>
-    cssContent.replaceAll(BUNDLED_FONT_PATH, VERSIONED_BUNDLED_FONT_PATH);
+    typeof cssContent === 'string'
+        ? cssContent.split(BUNDLED_FONT_PATH).join(VERSIONED_BUNDLED_FONT_PATH)
+        : cssContent;
 
 /**
  *
@@ -124,6 +126,7 @@ const generateCSSBundle = ({ fileName, source, output }) => {
             .map(rewriteBundledFontPaths)
             .join('\n');
 
+        fs.mkdirSync(path.dirname(output), { recursive: true });
         fs.writeFileSync(output, combinedCss);
         console.log(`${fileName}combined successfully`);
     } catch (err) {

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -943,7 +943,8 @@ $applozic.extend(true, Kommunicate, {
             ) {
                 // console.log("don't process the hide post cta last msg");
             } else if (
-                currentMsg.querySelector('.km-cta-multi-button-container') // checking if button container is exist in the message div
+                currentMsg.querySelector('.km-cta-multi-button-container') && // checking if button container is exist in the message div
+                !currentMsg.querySelector('.km-card-message-container')
             ) {
                 var allCTAButtons = currentMsg.querySelectorAll('.km-quick-replies');
 

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -943,16 +943,17 @@ $applozic.extend(true, Kommunicate, {
             ) {
                 // console.log("don't process the hide post cta last msg");
             } else if (
-                currentMsg.querySelector('.km-cta-multi-button-container') && // checking if button container is exist in the message div
-                !currentMsg.querySelector('.km-card-message-container')
+                currentMsg.querySelector('.km-cta-multi-button-container') // checking if button container is exist in the message div
             ) {
                 var allCTAButtons = currentMsg.querySelectorAll('.km-quick-replies');
+                var isCardMessage = currentMsg.querySelector('.km-card-message-container');
 
                 allCTAButtons.forEach(function (cta) {
                     cta.setAttribute('data-hidden', true);
                 });
 
                 allCTAButtons.length &&
+                    !isCardMessage &&
                     currentMsg.classList.contains('contains-quick-replies-only') &&
                     currentMsg.classList.add('km-hide-message');
             } else if (


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Prevent carousel cards from disappearing after a user clicks a carousel quick reply when the "Show Suggested Replies button on click in the chat widget" setting is turned off. Carousel should remain visible regardless of that setting.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-Carousel quick reply buttons were going through the same shared post-click CTA hiding flow used for regular suggested replies.

### In case you fixed a bug then please describe the root cause of it? 
-The root cause was in the shared hidePostCTA handling in kommunicate.js. Messages containing .km-cta-multi-button-container were being treated as normal CTA-only messages and hidden after click. Since carousel cards also contain CTA buttons inside that shared container structure, they were incorrectly matched by the same hide logic and got hidden when suggested replies on click was disabled.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font path handling for bundled assets to ensure proper processing only when applicable
  * Fixed CSS output generation to automatically create necessary directories before writing files
  * Refined quick-reply button visibility logic for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->