### PR TITLE
TDH-3621-Duplicate-user-with-same-email

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5026,13 +5026,13 @@ const firstVisibleMsg = {
                     }
                     var normalizedEmail = email ? $applozic.trim(email).toLowerCase() : null;
                     if (normalizedEmail) {
-                        const userIdForCookie = anonymousUserIdForPreChatLead
+                        const userIdForLocalStorage = anonymousUserIdForPreChatLead
                             ? userId
                             : normalizedEmail;
-                        userId = userIdForCookie;
+                        userId = userIdForLocalStorage;
                         kmLocalStorage.setLocalStorage({
                             name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,
-                            value: userIdForCookie,
+                            value: userIdForLocalStorage,
                             expiresInDays: 30,
                         });
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5024,11 +5024,12 @@ const firstVisibleMsg = {
                             userId = contactNumber;
                         }
                     }
-                    if (email) {
-                        const userIdForCookie = anonymousUserIdForPreChatLead ? userId : email;
-
+                    var normalizedEmail = email ? $applozic.trim(email).toLowerCase() : null;
+                    if (normalizedEmail) {
+                        const userIdForCookie = anonymousUserIdForPreChatLead
+                            ? userId
+                            : normalizedEmail;
                         userId = userIdForCookie;
-
                         kmLocalStorage.setLocalStorage({
                             name: KommunicateConstants.COOKIES.KOMMUNICATE_LOGGED_IN_ID,
                             value: userIdForCookie,
@@ -5058,8 +5059,8 @@ const firstVisibleMsg = {
                         authenticationTypeId: MCK_AUTHENTICATION_TYPE_ID,
                         enableEncryption: true,
                     };
-                    if (email) {
-                        options.email = email.toLowerCase();
+                    if (normalizedEmail) {
+                        options.email = normalizedEmail;
                     }
                     if (userName) {
                         options.displayName = userName;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- In the Pre-Lead Chat flow, when a user submits a form, we currently normalize the email but not the user_name, even when the user_name is the same as the email.
- For example, if a user enters Ayush@gmail.com, it is saved as Ayush@gmail.com in user_name and ayush@gmail.com in email. Later, if a user enters AYush@gmail.com, it is saved as a different user_name but the same normalized email (ayush@gmail.com).
- Since we check user_name for uniqueness, both values are treated as different, resulting in multiple users being created with the same email.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-chat login email handling by consistently trimming whitespace and converting emails to lowercase.
  * The normalized email is now used for session persistence and for the email value provided during pre-chat initialization, ensuring users are correctly recognized even when emails are entered with extra spaces or different capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->