### PR TITLE
TDH-3614 : Chat widget misc issues

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -2195,3 +2195,41 @@ KommunicateUI = {
 
     window.addEventListener('beforeunload', teardownYoutubeOriginFix);
 })();
+
+(function initMessageCopyTrim() {
+    function getNodeWithinMessageCell(node) {
+        if (!node) {
+            return null;
+        }
+        var elementNode = node.nodeType === 1 ? node : node.parentElement;
+        return elementNode && elementNode.closest
+            ? elementNode.closest('#mck-message-cell .mck-message-inner')
+            : null;
+    }
+
+    document.addEventListener('copy', function (event) {
+        var selection = window.getSelection && window.getSelection();
+        if (!selection || !selection.rangeCount) {
+            return;
+        }
+
+        var range = selection.getRangeAt(0);
+        var selectedMessageCell = getNodeWithinMessageCell(range.commonAncestorContainer);
+        if (!selectedMessageCell) {
+            return;
+        }
+
+        var copiedText = selection.toString();
+        if (!copiedText) {
+            return;
+        }
+
+        var normalizedText = copiedText.replace(/(?:\r?\n)+$/, '');
+        if (normalizedText === copiedText) {
+            return;
+        }
+
+        event.preventDefault();
+        event.clipboardData.setData('text/plain', normalizedText);
+    });
+})();


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix the extra trailing line that sometimes gets copied when users copy text from chat widget messages, especially with double-click based selection.


### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-The issue depended on how the browser created the text selection. Double-click based selection was more likely to include the message container boundary and add a trailing newline during clipboard serialization.

### In case you fixed a bug then please describe the root cause of it? 
-Root cause was browser clipboard serialization for widget message selections. In some cases, especially when the text was selected via double-click, the selection included block-level message DOM boundaries, which caused an extra trailing newline to be copied. The fix trims only the trailing copied newline(s) at clipboard time for selections inside widget messages, without changing rendered message content.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message text copying: trailing newline characters are automatically removed when copying message content, providing cleaner text for pasting into other applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->