### PR TITLE
TDH-3885:Fix broken autosuggestions payload implementation

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -9478,6 +9478,10 @@ const firstVisibleMsg = {
             });
 
             _this.populateAutoSuggest = function (params) {
+                var existingTypeahead = $mck_autosuggest_search_input.data('mcktypeahead');
+                if (existingTypeahead && existingTypeahead.$menu) {
+                    existingTypeahead.$menu.removeClass('n-vis');
+                }
                 $mck_autosuggest_search_input.mcktypeahead({
                     order: 'desc',
                     hint: false,

--- a/webplugin/lib/js/mck-ui-widget.min.js
+++ b/webplugin/lib/js/mck-ui-widget.min.js
@@ -672,16 +672,16 @@
                 return this.$menu.css({
                     bottom: 50 + 'px',
                     left: 0 + 'px'
-                }),this.$menu.show(), this.shown = !0, this
+                }).removeClass("n-vis").show(), this.shown = !0, this
             }else{
                 return this.$menu.css({
                     top: t.top + t.height,
                     left: t.left
-                }),this.$menu.show(), this.shown = !0, this
+                }).removeClass("n-vis").show(), this.shown = !0, this
             }  
         },
         hide: function() {
-            return this.$menu.hide(), this.shown = !1, this
+            return this.$menu.addClass("n-vis").hide(), this.shown = !1, this
         },
         lookup: function(t) {
             var n;

--- a/webplugin/lib/js/mck-ui-widget.min.js
+++ b/webplugin/lib/js/mck-ui-widget.min.js
@@ -672,16 +672,16 @@
                 return this.$menu.css({
                     bottom: 50 + 'px',
                     left: 0 + 'px'
-                }).removeClass("n-vis").show(), this.shown = !0, this
+                }),this.$menu.show(), this.shown = !0, this
             }else{
                 return this.$menu.css({
                     top: t.top + t.height,
                     left: t.left
-                }).removeClass("n-vis").show(), this.shown = !0, this
+                }),this.$menu.show(), this.shown = !0, this
             }  
         },
         hide: function() {
-            return this.$menu.addClass("n-vis").hide(), this.shown = !1, this
+            return this.$menu.hide(), this.shown = !1, this
         },
         lookup: function(t) {
             var n;


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix the Web SDK autosuggestion dropdown so it appears correctly.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-The autosuggestion dropdown menu was reused across prompts and was being hidden with the n-vis class after the first interaction. On the next autosuggestion prompt, the typeahead show() flow called .show() but did not remove n-vis, so the menu stayed hidden even though suggestions were rendered and the component considered itself open.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where search suggestions dropdown menu would not display properly when the autosuggest feature was re-initialized on input fields with existing typeahead instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->