### PR TITLE
TDH-3797: For churned customer, proper message is not showing in chat widget

### DIFF
--- a/webplugin/css/app/km-sidebox.css
+++ b/webplugin/css/app/km-sidebox.css
@@ -46,6 +46,11 @@
     display: flex !important;
 }
 
+#mck-sidebox.km-churn-active #km-chat-widget-close-button {
+    position: relative;
+    z-index: 31;
+}
+
 #km-churn-customer .km-churn-modal {
     width: 100%;
     max-width: 320px;

--- a/webplugin/css/app/km-sidebox.css
+++ b/webplugin/css/app/km-sidebox.css
@@ -23,8 +23,12 @@
     letter-spacing: 0.01em;
 }
 
-#mck-sidebox.km-churn-active .mck-box-body {
+#mck-sidebox.km-churn-active {
     position: relative;
+}
+
+#mck-sidebox.km-churn-active .mck-box-body {
+    position: static;
 }
 
 #km-churn-customer {
@@ -34,8 +38,8 @@
     justify-content: center;
     padding: 24px 20px 28px;
     background: rgba(0, 0, 0, 0.3);
-    pointer-events: none;
-    z-index: 2;
+    pointer-events: auto;
+    z-index: 30;
 }
 
 #km-churn-customer.vis {

--- a/webplugin/css/app/km-sidebox.css
+++ b/webplugin/css/app/km-sidebox.css
@@ -13,22 +13,71 @@
 }
 .km-churn-banner {
     color: #886026;
-    position: relative;
-    z-index: 999;
-    background: #fbd683;
-    -webkit-box-align: center;
-    padding: 12px 16px;
-    font-size: 14px;
+    background: linear-gradient(135deg, #fbd683 0%, #f6c154 100%);
     display: flex;
-    align-items: flex-start;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 18px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
 }
 
-#km-churn-customer .km-churn-heading {
-    padding-left: 5px;
+#mck-sidebox.km-churn-active .mck-box-body {
+    position: relative;
 }
 
-#deactivate-link {
-    color: #886026;
+#km-churn-customer {
+    position: absolute;
+    inset: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 20px 28px;
+    background: rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    z-index: 2;
+}
+
+#km-churn-customer.vis {
+    display: flex !important;
+}
+
+#km-churn-customer .km-churn-modal {
+    width: 100%;
+    max-width: 320px;
+    overflow: hidden;
+    border: 1px solid #f3dfb4;
+    border-radius: 24px;
+    background: #fff;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    pointer-events: auto;
+}
+
+#km-churn-customer .km-churn-content {
+    padding: 20px;
+}
+
+#km-churn-customer .km-churn-message {
+    margin: 0;
+    color: #5b6472;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+#km-churn-customer .km-churn-icon {
+    display: inline-flex;
+    flex: 0 0 auto;
+}
+
+#km-churn-customer .km-churn-message a {
+    color: #2563eb;
+    font-weight: 500;
+    text-decoration: underline;
+}
+
+#km-churn-customer .km-churn-message a:hover,
+#km-churn-customer .km-churn-message a:focus {
+    color: #1d4ed8;
 }
 
 #km-business-hour-box {

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -103,6 +103,29 @@ KommunicateUI = {
     setTopBarManager: function (manager) {
         topBarManagerRef = manager;
     },
+    getChurnCustomerUrl: function () {
+        var kommunicateIframe =
+            parent.document && parent.document.getElementById('kommunicate-widget-iframe');
+        var utmSourceUrl = kommunicateIframe
+            ? kommunicateIframe.getAttribute('data-url') || parent.window.location.href
+            : window.location.href;
+        return (
+            'https://www.kommunicate.io/poweredby?utm_source=' +
+            utmSourceUrl +
+            '&utm_medium=webplugin&utm_campaign=deactivation'
+        );
+    },
+    showChurnCustomerModal: function () {
+        var sidebox = document.getElementById('mck-sidebox');
+        var linkForChurn = document.getElementById('deactivate-link');
+        var churnCustomerModal = document.getElementById('km-churn-customer');
+
+        sidebox.classList.add('km-churn-active');
+        linkForChurn.setAttribute('href', KommunicateUI.getChurnCustomerUrl());
+        kommunicateCommons.hide('#mck-contact-loading');
+        kommunicateCommons.show('#km-churn-customer');
+        churnCustomerModal.focus();
+    },
     updateScroll: function (element) {
         element.scrollTop = element.scrollHeight;
     },

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -111,7 +111,7 @@ KommunicateUI = {
             : window.location.href;
         return (
             'https://www.kommunicate.io/poweredby?utm_source=' +
-            utmSourceUrl +
+            encodeURIComponent(utmSourceUrl) +
             '&utm_medium=webplugin&utm_campaign=deactivation'
         );
     },

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -263,12 +263,9 @@ function KommunicateCommons() {
         return _this.getDaysCount() > TRIAL_PERIOD;
     };
 
-    // The inactive-account modal should appear only for expired startup and trial accounts.
+    // The inactive-account modal should appear only for expired trial accounts.
     _this.shouldShowInactiveAccountModal = function (data) {
-        return (
-            _this.isAccountExpired() &&
-            (_this.isStartupPlan(data) || _this.isTrialPlan(data.pricingPackage))
-        );
+        return _this.isAccountExpired() && _this.isTrialPlan(data.pricingPackage);
     };
 
     _this.getDaysCount = function () {

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -3,6 +3,7 @@
 function KommunicateCommons() {
     var _this = this;
     var CUSTOMER_CREATED_AT;
+    var TRIAL_PERIOD;
     var USE_BRANDING;
     var WIDGET_SETTINGS;
     var iframeResizeListeners = typeof WeakMap === 'function' ? new WeakMap() : null;
@@ -10,6 +11,7 @@ function KommunicateCommons() {
     KommunicateCommons.IS_WIDGET_OPEN = false;
     _this.init = function (optns) {
         CUSTOMER_CREATED_AT = optns.customerCreatedAt;
+        TRIAL_PERIOD = Number(optns.trialPeriod);
         USE_BRANDING = typeof optns.useBranding == 'boolean' ? optns.useBranding : true;
         WIDGET_SETTINGS = optns.widgetSettings;
         KommunicateCommons.CONNECT_SOCKET_ON_WIDGET_CLICK = true;
@@ -254,14 +256,18 @@ function KommunicateCommons() {
     // This shared helper is intentionally limited to startup-plan expiry because
     // other plan/branding checks already depend on that narrower behavior.
     _this.isKommunicatePlanExpired = function (data) {
-        return _this.getDaysCount() > 31 && _this.isStartupPlan(data);
+        return _this.getDaysCount() > TRIAL_PERIOD && _this.isStartupPlan(data);
     };
 
-    // The inactive-account modal should appear for expired startup and expired trial accounts.
+    _this.isAccountExpired = function () {
+        return _this.getDaysCount() > TRIAL_PERIOD;
+    };
+
+    // The inactive-account modal should appear only for expired startup and trial accounts.
     _this.shouldShowInactiveAccountModal = function (data) {
         return (
-            _this.isKommunicatePlanExpired(data) ||
-            (_this.getDaysCount() > 31 && _this.isTrialPlan(data.pricingPackage))
+            _this.isAccountExpired() &&
+            (_this.isStartupPlan(data) || _this.isTrialPlan(data.pricingPackage))
         );
     };
 

--- a/webplugin/js/app/kommunicateCommons.js
+++ b/webplugin/js/app/kommunicateCommons.js
@@ -251,8 +251,18 @@ function KommunicateCommons() {
         }
     };
 
+    // This shared helper is intentionally limited to startup-plan expiry because
+    // other plan/branding checks already depend on that narrower behavior.
     _this.isKommunicatePlanExpired = function (data) {
         return _this.getDaysCount() > 31 && _this.isStartupPlan(data);
+    };
+
+    // The inactive-account modal should appear for expired startup and expired trial accounts.
+    _this.shouldShowInactiveAccountModal = function (data) {
+        return (
+            _this.isKommunicatePlanExpired(data) ||
+            (_this.getDaysCount() > 31 && _this.isTrialPlan(data.pricingPackage))
+        );
     };
 
     _this.getDaysCount = function () {

--- a/webplugin/js/app/labels/default-labels-en.js
+++ b/webplugin/js/app/labels/default-labels-en.js
@@ -171,6 +171,9 @@
             'Error while syncing messages. Check your firewall settings or try again after some time.',
         'business-hour.msg':
             'You have reached us outside our business hours. Our bot will handle your queries until the team is back online.',
+        'account.churned.banner': 'Account inactive',
+        'account.churned.notice':
+            'Messaging via <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate chatbot</a> is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
         'local.file.warning.description':
             'Conversation will not be updated in real-time as you are running the installation script from your local file system.',
         'local.file.warning.learnMore': 'Learn more about this',

--- a/webplugin/js/app/labels/default-labels-en.js
+++ b/webplugin/js/app/labels/default-labels-en.js
@@ -173,7 +173,7 @@
             'You have reached us outside our business hours. Our bot will handle your queries until the team is back online.',
         'account.churned.banner': 'Account inactive',
         'account.churned.notice':
-            'Messaging via <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate chatbot</a> is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+            'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}.',
         'local.file.warning.description':
             'Conversation will not be updated in real-time as you are running the installation script from your local file system.',
         'local.file.warning.learnMore': 'Learn more about this',

--- a/webplugin/js/app/labels/default-labels-en.js
+++ b/webplugin/js/app/labels/default-labels-en.js
@@ -173,7 +173,7 @@
             'You have reached us outside our business hours. Our bot will handle your queries until the team is back online.',
         'account.churned.banner': 'Account inactive',
         'account.churned.notice':
-            'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}.',
+            'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}',
         'local.file.warning.description':
             'Conversation will not be updated in real-time as you are running the installation script from your local file system.',
         'local.file.warning.learnMore': 'Learn more about this',

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -172,15 +172,41 @@ class KMLabel {
                 value.indexOf('{{supportEmailLink}}') !== -1
                     ? value
                     : fallbackTemplate;
-            node.innerHTML = template
-                .replace(
-                    /\{\{deactivateLink\}\}/g,
-                    '<a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate chatbot</a>'
-                )
-                .replace(
-                    /\{\{supportEmailLink\}\}/g,
-                    '<a href="mailto:support@kommunicate.io">support@kommunicate.io</a>'
+            var createDeactivateLink = function () {
+                var link = document.createElement('a');
+                link.id = 'deactivate-link';
+                link.href = 'https://www.kommunicate.io/poweredby';
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                link.appendChild(document.createTextNode('Kommunicate chatbot'));
+                return link;
+            };
+            var createSupportEmailLink = function () {
+                var link = document.createElement('a');
+                link.href = 'mailto:support@kommunicate.io';
+                link.appendChild(document.createTextNode('support@kommunicate.io'));
+                return link;
+            };
+            var appendText = function (text) {
+                if (text) {
+                    node.appendChild(document.createTextNode(text));
+                }
+            };
+            var tokenRegex = /\{\{(deactivateLink|supportEmailLink)\}\}/g;
+            var cursor = 0;
+            var match;
+
+            node.textContent = '';
+            while ((match = tokenRegex.exec(template)) !== null) {
+                appendText(template.slice(cursor, match.index));
+                node.appendChild(
+                    match[1] === 'deactivateLink'
+                        ? createDeactivateLink()
+                        : createSupportEmailLink()
                 );
+                cursor = tokenRegex.lastIndex;
+            }
+            appendText(template.slice(cursor));
         };
 
         [{ selector: '#mck-conversation-title', path: 'conversations.title' }].forEach(function (

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -312,6 +312,7 @@ class KMLabel {
             starInput.setAttribute('title', label);
         });
         var htmlBindings = {
+            'km-churn-notice': 'account.churned.notice',
             'mck-no-faq-found': 'looking.for.something.else',
             'km-internet-disconnect-msg': 'offline.msg',
             'km-socket-disconnect-msg': 'socket-disconnect.msg',
@@ -338,6 +339,7 @@ class KMLabel {
             'km-bottom-tab-faq-text': 'modern.nav.faqs',
             'km-bottom-tab-whatsnew-text': 'modern.nav.whatsnew',
             'km-bottom-tab-empty-text': 'modern.nav.empty',
+            'km-churn-banner-text': 'account.churned.banner',
             'km-conversations-empty-title': 'empty.conversations',
             'km-conversations-empty-subtitle': 'mck.empty.welcome.subtitle',
             'km-empty-conversation-eyebrow': 'mck.empty.welcome.eyebrow',

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -165,7 +165,7 @@ class KMLabel {
                 return;
             }
             var fallbackTemplate =
-                'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}.';
+                'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}';
             var template =
                 typeof value === 'string' &&
                 value.indexOf('{{deactivateLink}}') !== -1 &&

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -158,6 +158,30 @@ class KMLabel {
                 node.setAttribute('aria-label', value);
             });
         };
+        var renderChurnNotice = function () {
+            var node = document.getElementById('km-churn-notice');
+            var value = resolveLabel('account.churned.notice');
+            if (!node || value === null || typeof value === 'undefined') {
+                return;
+            }
+            var fallbackTemplate =
+                'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}.';
+            var template =
+                typeof value === 'string' &&
+                value.indexOf('{{deactivateLink}}') !== -1 &&
+                value.indexOf('{{supportEmailLink}}') !== -1
+                    ? value
+                    : fallbackTemplate;
+            node.innerHTML = template
+                .replace(
+                    /\{\{deactivateLink\}\}/g,
+                    '<a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate chatbot</a>'
+                )
+                .replace(
+                    /\{\{supportEmailLink\}\}/g,
+                    '<a href="mailto:support@kommunicate.io">support@kommunicate.io</a>'
+                );
+        };
 
         [{ selector: '#mck-conversation-title', path: 'conversations.title' }].forEach(function (
             binding
@@ -312,7 +336,6 @@ class KMLabel {
             starInput.setAttribute('title', label);
         });
         var htmlBindings = {
-            'km-churn-notice': 'account.churned.notice',
             'mck-no-faq-found': 'looking.for.something.else',
             'km-internet-disconnect-msg': 'offline.msg',
             'km-socket-disconnect-msg': 'socket-disconnect.msg',
@@ -362,6 +385,7 @@ class KMLabel {
         Object.keys(htmlBindings).forEach(function (id) {
             setLabel(id, htmlBindings[id], 'html');
         });
+        renderChurnNotice();
         Object.keys(textBindings).forEach(function (id) {
             setLabel(id, textBindings[id], 'text');
         });

--- a/webplugin/js/app/labels/generated-labels-locales.js
+++ b/webplugin/js/app/labels/generated-labels-locales.js
@@ -123,7 +123,7 @@
             'business-hour.msg':
                 'لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.',
             'account.churned.notice':
-                'تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}.',
+                'تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName أنشأ المجموعة :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName أزال :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName أضاف :userName',
@@ -332,7 +332,7 @@
             'business-hour.msg':
                 'Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.',
             'account.churned.notice':
-                'Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}.',
+                'Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName hat die Gruppe :groupName erstellt',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName hat :userName entfernt',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName hat :userName hinzugefügt',
@@ -545,7 +545,7 @@
             'business-hour.msg':
                 'Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.',
             'account.churned.notice':
-                'La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}.',
+                'La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName creó el grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName eliminó a :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName añadió a :userName',
@@ -760,7 +760,7 @@
             'business-hour.msg':
                 "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
             'account.churned.notice':
-                'La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}.',
+                'La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName a créé le groupe :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName a supprimé :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName a ajouté :userName',
@@ -1191,7 +1191,7 @@
             'business-hour.msg':
                 'Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.',
             'account.churned.notice':
-                'La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}.',
+                'La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ha creato il gruppo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ha rimosso :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ha aggiunto :userName',
@@ -1406,7 +1406,7 @@
             'business-hour.msg':
                 'Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.',
             'account.churned.notice':
-                'As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}.',
+                'As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName criou o grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName removeu :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName adicionou :userName',
@@ -1618,7 +1618,7 @@
             'business-hour.msg':
                 'Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.',
             'account.churned.notice':
-                'Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}.',
+                'Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName skapade gruppen :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName tog bort :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName lade till :userName',

--- a/webplugin/js/app/labels/generated-labels-locales.js
+++ b/webplugin/js/app/labels/generated-labels-locales.js
@@ -122,6 +122,8 @@
                 'خطأ أثناء مزامنة الرسائل. تحقق من جدار الحماية أو حاول مرة أخرى لاحقًا.',
             'business-hour.msg':
                 'لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.',
+            'account.churned.notice':
+                'تم تعطيل المراسلة عبر <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">روبوت Kommunicate للدردشة</a> لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName أنشأ المجموعة :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName أزال :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName أضاف :userName',
@@ -329,6 +331,8 @@
                 'Fehler beim Synchronisieren der Nachrichten. Prüfen Sie Ihre Firewall oder versuchen Sie es später erneut.',
             'business-hour.msg':
                 'Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.',
+            'account.churned.notice':
+                'Das Versenden von Nachrichten über den <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate-Chatbot</a> ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName hat die Gruppe :groupName erstellt',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName hat :userName entfernt',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName hat :userName hinzugefügt',
@@ -540,6 +544,8 @@
                 'Error al sincronizar mensajes. Revisa tu firewall o intenta de nuevo más tarde.',
             'business-hour.msg':
                 'Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.',
+            'account.churned.notice':
+                'La mensajería a través del <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot de Kommunicate</a> está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName creó el grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName eliminó a :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName añadió a :userName',
@@ -753,6 +759,8 @@
                 'Erreur lors de la synchronisation des messages. Vérifiez votre pare-feu ou réessayez plus tard.',
             'business-hour.msg':
                 "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
+            'account.churned.notice':
+                'La messagerie via le <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot Kommunicate</a> est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName a créé le groupe :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName a supprimé :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName a ajouté :userName',
@@ -969,6 +977,8 @@
                 'संदेशों को सिंक करते समय त्रुटि हुई। अपने फ़ायरवॉल सेटिंग्स की जांच करें या कुछ समय बाद पुनः प्रयास करें।',
             'business-hour.msg':
                 'आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।',
+            'account.churned.notice':
+                'इस खाते के लिए <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate चैटबॉट</a> के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो <a href="mailto:support@kommunicate.io">support@kommunicate.io</a> पर हमसे संपर्क करें।',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ने समूह :groupName बनाया',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ने :userName को हटा दिया',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ने :userName को जोड़ा',
@@ -1180,6 +1190,8 @@
                 'Errore durante la sincronizzazione dei messaggi. Controlla il firewall o riprova più tardi.',
             'business-hour.msg':
                 'Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.',
+            'account.churned.notice':
+                'La messaggistica tramite il <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot di Kommunicate</a> è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ha creato il gruppo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ha rimosso :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ha aggiunto :userName',
@@ -1393,6 +1405,8 @@
                 'Erro ao sincronizar mensagens. Verifique o firewall ou tente novamente mais tarde.',
             'business-hour.msg':
                 'Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.',
+            'account.churned.notice':
+                'As mensagens via <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot da Kommunicate</a> estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName criou o grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName removeu :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName adicionou :userName',
@@ -1603,6 +1617,8 @@
                 'Fel vid synkronisering av meddelanden. Kontrollera brandväggen eller försök igen senare.',
             'business-hour.msg':
                 'Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.',
+            'account.churned.notice':
+                'Meddelanden via <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate-chatboten</a> är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName skapade gruppen :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName tog bort :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName lade till :userName',
@@ -1812,6 +1828,8 @@
                 'پیغامات کی مطابقت پذیری میں خرابی ہوئی۔ اپنے فائر وال کی ترتیبات چیک کریں یا کچھ دیر بعد دوبارہ کوشش کریں.',
             'business-hour.msg':
                 'آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.',
+            'account.churned.notice':
+                'اس اکاؤنٹ کے لیے <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate چیٹ بوٹ</a> کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو <a href="mailto:support@kommunicate.io">support@kommunicate.io</a> پر ہم سے رابطہ کریں۔',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName نے گروپ :groupName بنایا',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName نے :userName کو ہٹایا',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName نے :userName کو شامل کیا',
@@ -2020,6 +2038,8 @@
             'socket-disconnect.msg': '同步消息时出错，请检查防火墙或稍后再试。',
             'business-hour.msg':
                 '您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。',
+            'account.churned.notice':
+                '此账户已禁用通过 <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate 聊天机器人</a> 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 <a href="mailto:support@kommunicate.io">support@kommunicate.io</a> 与我们联系。',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName 创建了群组 :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName 移除了 :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName 添加了 :userName',

--- a/webplugin/js/app/labels/generated-labels-locales.js
+++ b/webplugin/js/app/labels/generated-labels-locales.js
@@ -123,7 +123,7 @@
             'business-hour.msg':
                 'لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.',
             'account.churned.notice':
-                'تم تعطيل المراسلة عبر <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">روبوت Kommunicate للدردشة</a> لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName أنشأ المجموعة :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName أزال :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName أضاف :userName',
@@ -332,7 +332,7 @@
             'business-hour.msg':
                 'Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.',
             'account.churned.notice':
-                'Das Versenden von Nachrichten über den <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate-Chatbot</a> ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName hat die Gruppe :groupName erstellt',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName hat :userName entfernt',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName hat :userName hinzugefügt',
@@ -545,7 +545,7 @@
             'business-hour.msg':
                 'Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.',
             'account.churned.notice':
-                'La mensajería a través del <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot de Kommunicate</a> está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName creó el grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName eliminó a :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName añadió a :userName',
@@ -760,7 +760,7 @@
             'business-hour.msg':
                 "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
             'account.churned.notice':
-                'La messagerie via le <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot Kommunicate</a> est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName a créé le groupe :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName a supprimé :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName a ajouté :userName',
@@ -978,7 +978,7 @@
             'business-hour.msg':
                 'आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।',
             'account.churned.notice':
-                'इस खाते के लिए <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate चैटबॉट</a> के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो <a href="mailto:support@kommunicate.io">support@kommunicate.io</a> पर हमसे संपर्क करें।',
+                'इस खाते के लिए {{deactivateLink}} के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो {{supportEmailLink}} पर हमसे संपर्क करें।',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ने समूह :groupName बनाया',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ने :userName को हटा दिया',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ने :userName को जोड़ा',
@@ -1191,7 +1191,7 @@
             'business-hour.msg':
                 'Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.',
             'account.churned.notice':
-                'La messaggistica tramite il <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot di Kommunicate</a> è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ha creato il gruppo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ha rimosso :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ha aggiunto :userName',
@@ -1406,7 +1406,7 @@
             'business-hour.msg':
                 'Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.',
             'account.churned.notice':
-                'As mensagens via <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">chatbot da Kommunicate</a> estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName criou o grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName removeu :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName adicionou :userName',
@@ -1618,7 +1618,7 @@
             'business-hour.msg':
                 'Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.',
             'account.churned.notice':
-                'Meddelanden via <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate-chatboten</a> är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.',
+                'Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName skapade gruppen :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName tog bort :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName lade till :userName',
@@ -1829,7 +1829,7 @@
             'business-hour.msg':
                 'آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.',
             'account.churned.notice':
-                'اس اکاؤنٹ کے لیے <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate چیٹ بوٹ</a> کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو <a href="mailto:support@kommunicate.io">support@kommunicate.io</a> پر ہم سے رابطہ کریں۔',
+                'اس اکاؤنٹ کے لیے {{deactivateLink}} کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو {{supportEmailLink}} پر ہم سے رابطہ کریں۔',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName نے گروپ :groupName بنایا',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName نے :userName کو ہٹایا',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName نے :userName کو شامل کیا',
@@ -2039,7 +2039,7 @@
             'business-hour.msg':
                 '您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。',
             'account.churned.notice':
-                '此账户已禁用通过 <a id="deactivate-link" href="https://www.kommunicate.io/poweredby" target="_blank" rel="noopener noreferrer">Kommunicate 聊天机器人</a> 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 <a href="mailto:support@kommunicate.io">support@kommunicate.io</a> 与我们联系。',
+                '此账户已禁用通过 {{deactivateLink}} 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 {{supportEmailLink}} 与我们联系。',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName 创建了群组 :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName 移除了 :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName 添加了 :userName',

--- a/webplugin/js/app/labels/locales/ar.json
+++ b/webplugin/js/app/labels/locales/ar.json
@@ -110,6 +110,7 @@
   "offline.msg": "عذراً! لا يوجد اتصال بالإنترنت. تحقق من الشبكة وحاول مرة أخرى.",
   "socket-disconnect.msg": "خطأ أثناء مزامنة الرسائل. تحقق من جدار الحماية أو حاول مرة أخرى لاحقًا.",
   "business-hour.msg": "لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.",
+  "account.churned.notice": "تم تعطيل المراسلة عبر <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">روبوت Kommunicate للدردشة</a> لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName أنشأ المجموعة :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName أزال :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName أضاف :userName",

--- a/webplugin/js/app/labels/locales/ar.json
+++ b/webplugin/js/app/labels/locales/ar.json
@@ -110,7 +110,7 @@
   "offline.msg": "عذراً! لا يوجد اتصال بالإنترنت. تحقق من الشبكة وحاول مرة أخرى.",
   "socket-disconnect.msg": "خطأ أثناء مزامنة الرسائل. تحقق من جدار الحماية أو حاول مرة أخرى لاحقًا.",
   "business-hour.msg": "لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.",
-  "account.churned.notice": "تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}.",
+  "account.churned.notice": "تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName أنشأ المجموعة :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName أزال :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName أضاف :userName",

--- a/webplugin/js/app/labels/locales/ar.json
+++ b/webplugin/js/app/labels/locales/ar.json
@@ -110,7 +110,7 @@
   "offline.msg": "عذراً! لا يوجد اتصال بالإنترنت. تحقق من الشبكة وحاول مرة أخرى.",
   "socket-disconnect.msg": "خطأ أثناء مزامنة الرسائل. تحقق من جدار الحماية أو حاول مرة أخرى لاحقًا.",
   "business-hour.msg": "لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.",
-  "account.churned.notice": "تم تعطيل المراسلة عبر <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">روبوت Kommunicate للدردشة</a> لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName أنشأ المجموعة :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName أزال :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName أضاف :userName",

--- a/webplugin/js/app/labels/locales/de.json
+++ b/webplugin/js/app/labels/locales/de.json
@@ -110,6 +110,7 @@
   "offline.msg": "Oh nein! Keine Internetverbindung. Prüfen Sie Ihre Netzwerkeinstellungen und versuchen Sie es erneut.",
   "socket-disconnect.msg": "Fehler beim Synchronisieren der Nachrichten. Prüfen Sie Ihre Firewall oder versuchen Sie es später erneut.",
   "business-hour.msg": "Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.",
+  "account.churned.notice": "Das Versenden von Nachrichten über den <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate-Chatbot</a> ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName hat die Gruppe :groupName erstellt",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName hat :userName entfernt",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName hat :userName hinzugefügt",

--- a/webplugin/js/app/labels/locales/de.json
+++ b/webplugin/js/app/labels/locales/de.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh nein! Keine Internetverbindung. Prüfen Sie Ihre Netzwerkeinstellungen und versuchen Sie es erneut.",
   "socket-disconnect.msg": "Fehler beim Synchronisieren der Nachrichten. Prüfen Sie Ihre Firewall oder versuchen Sie es später erneut.",
   "business-hour.msg": "Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.",
-  "account.churned.notice": "Das Versenden von Nachrichten über den <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate-Chatbot</a> ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName hat die Gruppe :groupName erstellt",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName hat :userName entfernt",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName hat :userName hinzugefügt",

--- a/webplugin/js/app/labels/locales/de.json
+++ b/webplugin/js/app/labels/locales/de.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh nein! Keine Internetverbindung. Prüfen Sie Ihre Netzwerkeinstellungen und versuchen Sie es erneut.",
   "socket-disconnect.msg": "Fehler beim Synchronisieren der Nachrichten. Prüfen Sie Ihre Firewall oder versuchen Sie es später erneut.",
   "business-hour.msg": "Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.",
-  "account.churned.notice": "Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}.",
+  "account.churned.notice": "Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName hat die Gruppe :groupName erstellt",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName hat :userName entfernt",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName hat :userName hinzugefügt",

--- a/webplugin/js/app/labels/locales/es.json
+++ b/webplugin/js/app/labels/locales/es.json
@@ -110,7 +110,7 @@
   "offline.msg": "¡Vaya! No hay conexión a internet. Revisa tu red e inténtalo de nuevo.",
   "socket-disconnect.msg": "Error al sincronizar mensajes. Revisa tu firewall o intenta de nuevo más tarde.",
   "business-hour.msg": "Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.",
-  "account.churned.notice": "La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}.",
+  "account.churned.notice": "La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName creó el grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName eliminó a :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName añadió a :userName",

--- a/webplugin/js/app/labels/locales/es.json
+++ b/webplugin/js/app/labels/locales/es.json
@@ -110,6 +110,7 @@
   "offline.msg": "¡Vaya! No hay conexión a internet. Revisa tu red e inténtalo de nuevo.",
   "socket-disconnect.msg": "Error al sincronizar mensajes. Revisa tu firewall o intenta de nuevo más tarde.",
   "business-hour.msg": "Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.",
+  "account.churned.notice": "La mensajería a través del <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot de Kommunicate</a> está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName creó el grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName eliminó a :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName añadió a :userName",

--- a/webplugin/js/app/labels/locales/es.json
+++ b/webplugin/js/app/labels/locales/es.json
@@ -110,7 +110,7 @@
   "offline.msg": "¡Vaya! No hay conexión a internet. Revisa tu red e inténtalo de nuevo.",
   "socket-disconnect.msg": "Error al sincronizar mensajes. Revisa tu firewall o intenta de nuevo más tarde.",
   "business-hour.msg": "Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.",
-  "account.churned.notice": "La mensajería a través del <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot de Kommunicate</a> está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName creó el grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName eliminó a :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName añadió a :userName",

--- a/webplugin/js/app/labels/locales/fr.json
+++ b/webplugin/js/app/labels/locales/fr.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oups ! Pas de connexion Internet. Veuillez vérifier votre réseau et réessayer.",
   "socket-disconnect.msg": "Erreur lors de la synchronisation des messages. Vérifiez votre pare-feu ou réessayez plus tard.",
   "business-hour.msg": "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
-  "account.churned.notice": "La messagerie via le <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot Kommunicate</a> est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName a créé le groupe :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName a supprimé :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName a ajouté :userName",

--- a/webplugin/js/app/labels/locales/fr.json
+++ b/webplugin/js/app/labels/locales/fr.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oups ! Pas de connexion Internet. Veuillez vérifier votre réseau et réessayer.",
   "socket-disconnect.msg": "Erreur lors de la synchronisation des messages. Vérifiez votre pare-feu ou réessayez plus tard.",
   "business-hour.msg": "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
-  "account.churned.notice": "La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}.",
+  "account.churned.notice": "La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName a créé le groupe :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName a supprimé :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName a ajouté :userName",

--- a/webplugin/js/app/labels/locales/fr.json
+++ b/webplugin/js/app/labels/locales/fr.json
@@ -110,6 +110,7 @@
   "offline.msg": "Oups ! Pas de connexion Internet. Veuillez vérifier votre réseau et réessayer.",
   "socket-disconnect.msg": "Erreur lors de la synchronisation des messages. Vérifiez votre pare-feu ou réessayez plus tard.",
   "business-hour.msg": "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
+  "account.churned.notice": "La messagerie via le <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot Kommunicate</a> est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName a créé le groupe :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName a supprimé :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName a ajouté :userName",

--- a/webplugin/js/app/labels/locales/hi.json
+++ b/webplugin/js/app/labels/locales/hi.json
@@ -110,7 +110,7 @@
   "offline.msg": "ओह ओह! इंटरनेट कनेक्शन नहीं है। कृपया अपने नेटवर्क की जाँच करें और पुनः प्रयास करें।",
   "socket-disconnect.msg": "संदेशों को सिंक करते समय त्रुटि हुई। अपने फ़ायरवॉल सेटिंग्स की जांच करें या कुछ समय बाद पुनः प्रयास करें।",
   "business-hour.msg": "आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।",
-  "account.churned.notice": "इस खाते के लिए <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate चैटबॉट</a> के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a> पर हमसे संपर्क करें।",
+  "account.churned.notice": "इस खाते के लिए {{deactivateLink}} के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो {{supportEmailLink}} पर हमसे संपर्क करें।",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ने समूह :groupName बनाया",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ने :userName को हटा दिया",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ने :userName को जोड़ा",

--- a/webplugin/js/app/labels/locales/hi.json
+++ b/webplugin/js/app/labels/locales/hi.json
@@ -110,6 +110,7 @@
   "offline.msg": "ओह ओह! इंटरनेट कनेक्शन नहीं है। कृपया अपने नेटवर्क की जाँच करें और पुनः प्रयास करें।",
   "socket-disconnect.msg": "संदेशों को सिंक करते समय त्रुटि हुई। अपने फ़ायरवॉल सेटिंग्स की जांच करें या कुछ समय बाद पुनः प्रयास करें।",
   "business-hour.msg": "आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।",
+  "account.churned.notice": "इस खाते के लिए <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate चैटबॉट</a> के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a> पर हमसे संपर्क करें।",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ने समूह :groupName बनाया",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ने :userName को हटा दिया",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ने :userName को जोड़ा",

--- a/webplugin/js/app/labels/locales/it.json
+++ b/webplugin/js/app/labels/locales/it.json
@@ -110,6 +110,7 @@
   "offline.msg": "Oh no! Nessuna connessione internet. Controlla la tua rete e riprova.",
   "socket-disconnect.msg": "Errore durante la sincronizzazione dei messaggi. Controlla il firewall o riprova più tardi.",
   "business-hour.msg": "Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.",
+  "account.churned.notice": "La messaggistica tramite il <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot di Kommunicate</a> è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ha creato il gruppo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ha rimosso :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ha aggiunto :userName",

--- a/webplugin/js/app/labels/locales/it.json
+++ b/webplugin/js/app/labels/locales/it.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh no! Nessuna connessione internet. Controlla la tua rete e riprova.",
   "socket-disconnect.msg": "Errore durante la sincronizzazione dei messaggi. Controlla il firewall o riprova più tardi.",
   "business-hour.msg": "Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.",
-  "account.churned.notice": "La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}.",
+  "account.churned.notice": "La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ha creato il gruppo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ha rimosso :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ha aggiunto :userName",

--- a/webplugin/js/app/labels/locales/it.json
+++ b/webplugin/js/app/labels/locales/it.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh no! Nessuna connessione internet. Controlla la tua rete e riprova.",
   "socket-disconnect.msg": "Errore durante la sincronizzazione dei messaggi. Controlla il firewall o riprova più tardi.",
   "business-hour.msg": "Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.",
-  "account.churned.notice": "La messaggistica tramite il <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot di Kommunicate</a> è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ha creato il gruppo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ha rimosso :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ha aggiunto :userName",

--- a/webplugin/js/app/labels/locales/pt.json
+++ b/webplugin/js/app/labels/locales/pt.json
@@ -110,6 +110,7 @@
   "offline.msg": "Poxa! Sem conexão com a internet. Verifique sua rede e tente novamente.",
   "socket-disconnect.msg": "Erro ao sincronizar mensagens. Verifique o firewall ou tente novamente mais tarde.",
   "business-hour.msg": "Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.",
+  "account.churned.notice": "As mensagens via <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot da Kommunicate</a> estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName criou o grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName removeu :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName adicionou :userName",

--- a/webplugin/js/app/labels/locales/pt.json
+++ b/webplugin/js/app/labels/locales/pt.json
@@ -110,7 +110,7 @@
   "offline.msg": "Poxa! Sem conexão com a internet. Verifique sua rede e tente novamente.",
   "socket-disconnect.msg": "Erro ao sincronizar mensagens. Verifique o firewall ou tente novamente mais tarde.",
   "business-hour.msg": "Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.",
-  "account.churned.notice": "As mensagens via <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">chatbot da Kommunicate</a> estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName criou o grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName removeu :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName adicionou :userName",

--- a/webplugin/js/app/labels/locales/pt.json
+++ b/webplugin/js/app/labels/locales/pt.json
@@ -110,7 +110,7 @@
   "offline.msg": "Poxa! Sem conexão com a internet. Verifique sua rede e tente novamente.",
   "socket-disconnect.msg": "Erro ao sincronizar mensagens. Verifique o firewall ou tente novamente mais tarde.",
   "business-hour.msg": "Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.",
-  "account.churned.notice": "As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}.",
+  "account.churned.notice": "As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName criou o grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName removeu :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName adicionou :userName",

--- a/webplugin/js/app/labels/locales/sv.json
+++ b/webplugin/js/app/labels/locales/sv.json
@@ -110,6 +110,7 @@
   "offline.msg": "Aj då! Ingen internetanslutning. Kontrollera nätverket och försök igen.",
   "socket-disconnect.msg": "Fel vid synkronisering av meddelanden. Kontrollera brandväggen eller försök igen senare.",
   "business-hour.msg": "Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.",
+  "account.churned.notice": "Meddelanden via <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate-chatboten</a> är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName skapade gruppen :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName tog bort :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName lade till :userName",

--- a/webplugin/js/app/labels/locales/sv.json
+++ b/webplugin/js/app/labels/locales/sv.json
@@ -110,7 +110,7 @@
   "offline.msg": "Aj då! Ingen internetanslutning. Kontrollera nätverket och försök igen.",
   "socket-disconnect.msg": "Fel vid synkronisering av meddelanden. Kontrollera brandväggen eller försök igen senare.",
   "business-hour.msg": "Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.",
-  "account.churned.notice": "Meddelanden via <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate-chatboten</a> är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a>.",
+  "account.churned.notice": "Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName skapade gruppen :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName tog bort :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName lade till :userName",

--- a/webplugin/js/app/labels/locales/sv.json
+++ b/webplugin/js/app/labels/locales/sv.json
@@ -110,7 +110,7 @@
   "offline.msg": "Aj då! Ingen internetanslutning. Kontrollera nätverket och försök igen.",
   "socket-disconnect.msg": "Fel vid synkronisering av meddelanden. Kontrollera brandväggen eller försök igen senare.",
   "business-hour.msg": "Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.",
-  "account.churned.notice": "Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}.",
+  "account.churned.notice": "Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName skapade gruppen :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName tog bort :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName lade till :userName",

--- a/webplugin/js/app/labels/locales/ur.json
+++ b/webplugin/js/app/labels/locales/ur.json
@@ -110,7 +110,7 @@
   "offline.msg": "اوہ اوہ! انٹرنیٹ کنیکشن موجود نہیں۔ براہ کرم اپنا نیٹ ورک چیک کریں اور دوبارہ کوشش کریں.",
   "socket-disconnect.msg": "پیغامات کی مطابقت پذیری میں خرابی ہوئی۔ اپنے فائر وال کی ترتیبات چیک کریں یا کچھ دیر بعد دوبارہ کوشش کریں.",
   "business-hour.msg": "آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.",
-  "account.churned.notice": "اس اکاؤنٹ کے لیے <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate چیٹ بوٹ</a> کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a> پر ہم سے رابطہ کریں۔",
+  "account.churned.notice": "اس اکاؤنٹ کے لیے {{deactivateLink}} کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو {{supportEmailLink}} پر ہم سے رابطہ کریں۔",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName نے گروپ :groupName بنایا",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName نے :userName کو ہٹایا",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName نے :userName کو شامل کیا",

--- a/webplugin/js/app/labels/locales/ur.json
+++ b/webplugin/js/app/labels/locales/ur.json
@@ -110,6 +110,7 @@
   "offline.msg": "اوہ اوہ! انٹرنیٹ کنیکشن موجود نہیں۔ براہ کرم اپنا نیٹ ورک چیک کریں اور دوبارہ کوشش کریں.",
   "socket-disconnect.msg": "پیغامات کی مطابقت پذیری میں خرابی ہوئی۔ اپنے فائر وال کی ترتیبات چیک کریں یا کچھ دیر بعد دوبارہ کوشش کریں.",
   "business-hour.msg": "آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.",
+  "account.churned.notice": "اس اکاؤنٹ کے لیے <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate چیٹ بوٹ</a> کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a> پر ہم سے رابطہ کریں۔",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName نے گروپ :groupName بنایا",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName نے :userName کو ہٹایا",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName نے :userName کو شامل کیا",

--- a/webplugin/js/app/labels/locales/zh.json
+++ b/webplugin/js/app/labels/locales/zh.json
@@ -110,7 +110,7 @@
   "offline.msg": "哎呀！暂无网络连接，请检查后再试。",
   "socket-disconnect.msg": "同步消息时出错，请检查防火墙或稍后再试。",
   "business-hour.msg": "您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。",
-  "account.churned.notice": "此账户已禁用通过 <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate 聊天机器人</a> 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a> 与我们联系。",
+  "account.churned.notice": "此账户已禁用通过 {{deactivateLink}} 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 {{supportEmailLink}} 与我们联系。",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName 创建了群组 :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName 移除了 :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName 添加了 :userName",

--- a/webplugin/js/app/labels/locales/zh.json
+++ b/webplugin/js/app/labels/locales/zh.json
@@ -110,6 +110,7 @@
   "offline.msg": "哎呀！暂无网络连接，请检查后再试。",
   "socket-disconnect.msg": "同步消息时出错，请检查防火墙或稍后再试。",
   "business-hour.msg": "您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。",
+  "account.churned.notice": "此账户已禁用通过 <a id=\"deactivate-link\" href=\"https://www.kommunicate.io/poweredby\" target=\"_blank\" rel=\"noopener noreferrer\">Kommunicate 聊天机器人</a> 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 <a href=\"mailto:support@kommunicate.io\">support@kommunicate.io</a> 与我们联系。",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName 创建了群组 :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName 移除了 :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName 添加了 :userName",

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -520,20 +520,7 @@ function ApplozicSidebox() {
 
             //to check if the customer has been churned then show the churn banner
             if (data.currentActivatedPlan == 'churn') {
-                var kommunicateIframe = parent.document.getElementById('kommunicate-widget-iframe');
-                var utmSourceUrl = kommunicateIframe
-                    ? kommunicateIframe.getAttribute('data-url') || parent.window.location.href
-                    : w.location.href;
-                var poweredByUrl =
-                    'https://www.kommunicate.io/poweredby?utm_source=' +
-                    utmSourceUrl +
-                    '&utm_medium=webplugin&utm_campaign=deactivation';
-                var linkForChurn = document.getElementById('deactivate-link');
-                var churnCust = document.getElementById('km-churn-customer');
-                if (churnCust) {
-                    linkForChurn && linkForChurn.setAttribute('href', poweredByUrl);
-                    churnCust.classList.remove('n-vis');
-                }
+                KommunicateUI.showChurnCustomerModal();
             }
 
             // Remove scripts if chatwidget is restricted by domains

--- a/webplugin/js/app/mck-app.js
+++ b/webplugin/js/app/mck-app.js
@@ -550,12 +550,16 @@ function ApplozicSidebox() {
                     ? options.sessionTimeout
                     : widgetSettings && widgetSettings.sessionTimeout;
             options['appSettings'] = $applozic.extend(true, data, options.appSettings);
-
             options['agentId'] = options.appSettings.agentId;
             options['agentName'] = options.appSettings.agentName;
             options['widgetSettings'] = widgetSettings;
             applyWidgetCustomPosition(widgetSettings);
-            options['customerCreatedAt'] = options.appSettings.customerCreatedAt;
+            options['customerCreatedAt'] =
+                options.appSettings.createdAt ||
+                options.appSettings.created_at ||
+                options.appSettings.customerCreatedAt;
+            options['trialPeriod'] =
+                options.appSettings.trialPeriod || options.appSettings.trial_period;
             options['collectFeedback'] = options.appSettings.collectFeedback;
             options['isCsatAvailable'] = options.appSettings.isCsatAvailable;
             options['chatPopupMessage'] = options.appSettings.chatPopupMessage;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -10838,6 +10838,11 @@ const firstVisibleMsg = {
                             please add this condition to the below check like this :  && !(data.data[0].autoHumanHandoff)
                         */
                         const res = data.data[0];
+                        if (res?.status === 'expired') {
+                            appOptions.appSettings.currentActivatedPlan = 'churn';
+                            KommunicateUI.showChurnCustomerModal();
+                            return;
+                        }
                         CURRENT_GROUP_DATA.CHAR_CHECK =
                             res?.aiPlatform == KommunicateConstants.BOT_PLATFORM.DIALOGFLOW;
                         !CURRENT_GROUP_DATA.CHAR_CHECK && _this.removeWarningsFromTextBox();

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -2620,6 +2620,11 @@ const firstVisibleMsg = {
                         kommunicateCommons.show(this);
                     }
                 });
+                // Reuse the churned-account UI for inactive startup/trial accounts.
+                if (kommunicateCommons.shouldShowInactiveAccountModal(data)) {
+                    data.currentActivatedPlan = 'churn';
+                    appOptions.appSettings.currentActivatedPlan = 'churn';
+                }
                 MCK_USER_ID = data.userId;
                 USER_DEVICE_KEY = data.deviceKey;
                 MCK_IDLE_TIME_LIMIT = data.websocketIdleTimeLimit;

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -779,8 +779,8 @@ const firstVisibleMsg = {
 
         _this.churnCustomerWidgetChanges = function () {
             mckMessageService.openChatbox();
-            kommunicateCommons.show('.mck-box-form-container');
-            kommunicateCommons.hide('#mck-contact-loading', '#mck-contacts-content');
+            openWidgetIframe();
+            KommunicateUI.showChurnCustomerModal();
         };
 
         function openWidgetIframe() {
@@ -2546,7 +2546,12 @@ const firstVisibleMsg = {
                             }
                             // mckUtils.manageIdleTime();
                         } else if (result == 'CHURNED_CUSTOMER') {
-                            _this.onInitApp({});
+                            appOptions.appSettings.currentActivatedPlan = 'churn';
+                            _this.onInitApp({ currentActivatedPlan: 'churn' });
+                            KommunicateUI.showChurnCustomerModal();
+                            if (typeof onInitCallback === 'function') {
+                                onInitCallback();
+                            }
                         } else {
                             Kommunicate.displayKommunicateWidget(false);
                             if (typeof MCK_ON_PLUGIN_INIT === 'function') {

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -350,6 +350,62 @@
                 </div>
             </div>
             <div class="mck-box-body">
+                <section
+                    id="km-churn-customer"
+                    class="n-vis"
+                    role="alertdialog"
+                    aria-live="assertive"
+                    aria-modal="true"
+                    aria-labelledby="km-churn-banner"
+                    tabindex="-1"
+                >
+                    <div class="km-churn-modal">
+                        <div id="km-churn-banner" class="km-churn-banner">
+                            <span class="km-churn-icon" aria-hidden="true">
+                                <svg
+                                    width="18"
+                                    height="18"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        d="M12 3L21 20H3L12 3Z"
+                                        fill="#8A5B00"
+                                        fill-opacity="0.12"
+                                        stroke="#8A5B00"
+                                        stroke-width="1.5"
+                                        stroke-linejoin="round"
+                                    />
+                                    <path
+                                        d="M12 9V13"
+                                        stroke="#8A5B00"
+                                        stroke-width="1.8"
+                                        stroke-linecap="round"
+                                    />
+                                    <circle cx="12" cy="16.5" r="1" fill="#8A5B00" />
+                                </svg>
+                            </span>
+                            <span id="km-churn-banner-text">Account inactive</span>
+                        </div>
+                        <div class="km-churn-content">
+                            <p id="km-churn-notice" class="km-churn-message">
+                                Messaging via
+                                <a
+                                    id="deactivate-link"
+                                    href="https://www.kommunicate.io/poweredby"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Kommunicate chatbot
+                                </a>
+                                is disabled for this account. To enable, please contact the admin of
+                                the website. If you are the admin, get in touch at
+                                <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.
+                            </p>
+                        </div>
+                    </div>
+                </section>
                 <div id="mck-message-cell" class="mck-tab-cell mck-message-cell">
                     <div class="mck-conversation" tabindex="-1" role="presentation">
                         <div

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -401,7 +401,7 @@
                                 </a>
                                 is disabled for this account. To enable, please contact the admin of
                                 the website. If you are the admin, get in touch at
-                                <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>.
+                                <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix the churned-customer and trial expired widget flow so inactive accounts show the deactivation UI.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 
<img width="595" height="803" alt="image" src="https://github.com/user-attachments/assets/02af94ac-3c60-4a10-a078-d25ff3c2f420" />



NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account inactivity/churn notice dialog that explains chatbot messaging is disabled, with a deactivate link and support contact.
* **UI Improvements**
  * Refreshed the churn sidebox/modal visuals (gradient styling, improved overlay and modal layout) and brought focus to the notice when shown.
* **Localization**
  * Added the “Account inactive” notice text with deactivate/support link templating across English and supported locales (Arabic, German, Spanish, French, Hindi, Italian, Portuguese, Swedish, Urdu, Chinese).
* **Behavior Updates**
  * Enhanced inactive-account handling using a configurable trial-period threshold for expiration decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->