### PR TITLE
Stream empty fix

### DIFF
--- a/webplugin/js/app/conversation/gen-ai-service.js
+++ b/webplugin/js/app/conversation/gen-ai-service.js
@@ -5,6 +5,7 @@ class GenAiService {
         this.currentIndex = -1;
         this.currentMessage = '';
         this.currentStreamKey = '';
+        this.pendingMessages = {};
     }
 
     prepareTokenizedMessage = (msg) => {
@@ -28,21 +29,51 @@ class GenAiService {
             divElement.setAttribute('class', className);
             this.textMsgDiv = divElement;
         }
-        if (this.currentIndex != msg.index - 1) {
-            // if any token is missed then  stop there
+        this.pendingMessages[Number(msg.index)] = msg.message;
+        if (!this.currentElement && !this.textMsgDiv.parentNode) {
+            $textMessage.append(this.textMsgDiv);
+        }
+        if (!this.renderPendingMessages()) {
             return;
         }
-        this.currentIndex = this.currentIndex + 1;
-        this.currentMessage += `${msg.message} `;
+    };
+
+    renderPendingMessages = () => {
+        let messageUpdated = false;
+        let nextIndex = this.currentIndex + 1;
+        while (Object.prototype.hasOwnProperty.call(this.pendingMessages, nextIndex)) {
+            this.currentMessage += `${this.pendingMessages[nextIndex]} `;
+            delete this.pendingMessages[nextIndex];
+            this.currentIndex = nextIndex;
+            nextIndex = this.currentIndex + 1;
+            messageUpdated = true;
+        }
+        if (messageUpdated) {
+            this.renderCurrentMessage();
+        }
+        return messageUpdated;
+    };
+
+    renderRemainingMessages = () => {
+        if (!this.currentMessage && !Object.keys(this.pendingMessages).length) {
+            return;
+        }
+        Object.keys(this.pendingMessages)
+            .map(Number)
+            .sort((firstIndex, secondIndex) => firstIndex - secondIndex)
+            .forEach((index) => {
+                this.currentMessage += `${this.pendingMessages[index]} `;
+            });
+        this.pendingMessages = {};
+        this.renderCurrentMessage();
+    };
+
+    renderCurrentMessage = () => {
         const targetElement = this.currentElement || this.textMsgDiv;
         targetElement.innerHTML = KommunicateUtils.getSanitizedMarkdownMessage(this.currentMessage);
         $applozic(targetElement).linkify({
             target: '_blank',
         });
-
-        if (!this.currentElement) {
-            $textMessage.append(this.textMsgDiv);
-        }
     };
 
     clearActiveStream = () => {
@@ -51,10 +82,12 @@ class GenAiService {
         this.currentIndex = -1;
         this.currentMessage = '';
         this.currentStreamKey = '';
+        this.pendingMessages = {};
     };
 
     completeCurrentStream = (streamKey) => {
         if (!streamKey || streamKey === this.currentStreamKey) {
+            this.renderRemainingMessages();
             this.clearActiveStream();
         }
     };

--- a/webplugin/js/app/kommunicate.js
+++ b/webplugin/js/app/kommunicate.js
@@ -851,11 +851,9 @@ $applozic.extend(true, Kommunicate, {
 
         // genai last message
         if (!msgThroughListAPI) {
-            // Enable the msg area when we got the last token
             if (msg.metadata?.lastToken === 'true') {
                 genAiService.completeCurrentStream(msg.key);
-                genAiService.enableTextArea(true);
-            } else if (!msg.tokenMessage && !genAiService.hasActiveStream()) {
+            } else if (!msg.tokenMessage) {
                 genAiService.clearActiveStream();
                 genAiService.enableTextArea(true);
             }

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7891,8 +7891,7 @@ const firstVisibleMsg = {
                 // GEN AI BOT
 
                 if (msg.tokenMessage && !msgThroughListAPI) {
-                    // message not from the sockets
-                    document.getElementById('mck-text-box').setAttribute('contenteditable', true);
+                    genAiService.enableTextArea(false);
                 }
 
                 if (msg.source == KommunicateConstants.MESSAGE_SOURCE.MAIL_INTERCEPTOR) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Root cause: addTokenizeMsg returned permanently when msg.index was not exactly the next expected index, so later chunks never rendered. Now the service buffers chunks by index, renders contiguous chunks in order, and flushes remaining buffered chunks on stream completion so out-of-order delivery still displays the full received message.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
