### PR TITLE
Remove the external “Kommunicate chatbot” hyperlink

### DIFF
--- a/webplugin/css/app/km-sidebox.css
+++ b/webplugin/css/app/km-sidebox.css
@@ -73,6 +73,20 @@
     line-height: 1.6;
 }
 
+#km-churn-customer .km-churn-message-highlight {
+    display: block;
+    margin-bottom: 10px;
+    color: #334155;
+    font-size: 17px;
+    font-weight: 700;
+    line-height: 1.45;
+}
+
+#km-churn-customer .km-churn-message-label {
+    color: #334155;
+    font-weight: 700;
+}
+
 #km-churn-customer .km-churn-icon {
     display: inline-flex;
     flex: 0 0 auto;

--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -103,25 +103,11 @@ KommunicateUI = {
     setTopBarManager: function (manager) {
         topBarManagerRef = manager;
     },
-    getChurnCustomerUrl: function () {
-        var kommunicateIframe =
-            parent.document && parent.document.getElementById('kommunicate-widget-iframe');
-        var utmSourceUrl = kommunicateIframe
-            ? kommunicateIframe.getAttribute('data-url') || parent.window.location.href
-            : window.location.href;
-        return (
-            'https://www.kommunicate.io/poweredby?utm_source=' +
-            encodeURIComponent(utmSourceUrl) +
-            '&utm_medium=webplugin&utm_campaign=deactivation'
-        );
-    },
     showChurnCustomerModal: function () {
         var sidebox = document.getElementById('mck-sidebox');
-        var linkForChurn = document.getElementById('deactivate-link');
         var churnCustomerModal = document.getElementById('km-churn-customer');
 
         sidebox.classList.add('km-churn-active');
-        linkForChurn.setAttribute('href', KommunicateUI.getChurnCustomerUrl());
         kommunicateCommons.hide('#mck-contact-loading');
         kommunicateCommons.show('#km-churn-customer');
         churnCustomerModal.focus();

--- a/webplugin/js/app/labels/default-labels-en.js
+++ b/webplugin/js/app/labels/default-labels-en.js
@@ -173,7 +173,7 @@
             'You have reached us outside our business hours. Our bot will handle your queries until the team is back online.',
         'account.churned.banner': 'Account inactive',
         'account.churned.notice':
-            '<strong class="km-churn-message-highlight">Chat has been disabled for this website.</strong> <strong class="km-churn-message-label">Visitors:</strong> Please contact the website owner using another contact method. <strong class="km-churn-message-label">Website administrators:</strong> If you need help restoring chat, contact Kommunicate Support.',
+            'Chat has been disabled for this website. Visitors: Please contact the website owner using another contact method. Website administrators: If you need help restoring chat, contact Kommunicate Support.',
         'local.file.warning.description':
             'Conversation will not be updated in real-time as you are running the installation script from your local file system.',
         'local.file.warning.learnMore': 'Learn more about this',

--- a/webplugin/js/app/labels/default-labels-en.js
+++ b/webplugin/js/app/labels/default-labels-en.js
@@ -173,7 +173,7 @@
             'You have reached us outside our business hours. Our bot will handle your queries until the team is back online.',
         'account.churned.banner': 'Account inactive',
         'account.churned.notice':
-            'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}',
+            '<strong class="km-churn-message-highlight">Chat has been disabled for this website.</strong> <strong class="km-churn-message-label">Visitors:</strong> Please contact the website owner using another contact method. <strong class="km-churn-message-label">Website administrators:</strong> If you need help restoring chat, contact Kommunicate Support.',
         'local.file.warning.description':
             'Conversation will not be updated in real-time as you are running the installation script from your local file system.',
         'local.file.warning.learnMore': 'Learn more about this',

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -158,48 +158,67 @@ class KMLabel {
                 node.setAttribute('aria-label', value);
             });
         };
+        var churnNoticeTemplate = [
+            '{{#tokens}}',
+            '{{#isHeadline}}<strong class="km-churn-message-highlight">{{text}}</strong>{{/isHeadline}}',
+            '{{#isLabel}}<strong class="km-churn-message-label">{{text}}</strong>{{/isLabel}}',
+            '{{#isText}}{{text}}{{/isText}}',
+            '{{/tokens}}',
+        ].join('');
         var renderChurnNotice = function () {
             var node = document.getElementById('km-churn-notice');
-            var value = resolveLabel('account.churned.notice');
-            if (!node || value === null || typeof value === 'undefined') {
+            if (!node) {
                 return;
             }
-            var fallbackTemplate =
-                'Chat has been disabled for this website. Visitors: Please contact the website owner using another contact method. Website administrators: If you need help restoring chat, contact Kommunicate Support.';
-            var template = typeof value === 'string' && value.trim() ? value : fallbackTemplate;
+            var value = resolveLabel('account.churned.notice');
+            var fallbackText = node.textContent.trim();
+            var template =
+                typeof value === 'string' && value.trim()
+                    ? value
+                    : typeof fallbackText === 'string' && fallbackText
+                    ? fallbackText
+                    : '';
+            if (!template) {
+                return;
+            }
             var noticeText = template
                 .replace(/\{\{deactivateLink\}\}/g, 'Kommunicate chatbot')
                 .replace(/\{\{supportEmailLink\}\}/g, 'Kommunicate Support');
-            var appendText = function (text) {
-                if (text) {
-                    node.appendChild(document.createTextNode(text));
-                }
-            };
-            var appendStrongText = function (text, className) {
-                if (!text) {
-                    return;
-                }
-                var strongNode = document.createElement('strong');
-                strongNode.className = className;
-                strongNode.appendChild(document.createTextNode(text));
-                node.appendChild(strongNode);
-            };
             var sentenceMatch = noticeText.match(/^(.+?[.!?۔。！？])(\s*.*)?$/);
             var firstSentence = sentenceMatch ? sentenceMatch[1] : noticeText;
             var remainingText = sentenceMatch && sentenceMatch[2] ? sentenceMatch[2] : '';
             var labelRegex = /(^|[.!?۔。！？]\s+)([^.!?۔。！？:：\n][^:：\n]*[:：])/g;
             var cursor = 0;
             var match;
+            var tokens = [
+                {
+                    isHeadline: true,
+                    text: firstSentence,
+                },
+            ];
+            var appendToken = function (text, type) {
+                if (!text) {
+                    return;
+                }
+                tokens.push({
+                    isHeadline: false,
+                    isLabel: type === 'label',
+                    isText: type === 'text',
+                    text: text,
+                });
+            };
 
-            node.textContent = '';
-            appendStrongText(firstSentence, 'km-churn-message-highlight');
+            remainingText = remainingText.replace(/^\s+/, '');
             while ((match = labelRegex.exec(remainingText)) !== null) {
-                appendText(remainingText.slice(cursor, match.index));
-                appendText(match[1]);
-                appendStrongText(match[2], 'km-churn-message-label');
+                appendToken(remainingText.slice(cursor, match.index), 'text');
+                appendToken(match[1], 'text');
+                appendToken(match[2], 'label');
                 cursor = match.index + match[0].length;
             }
-            appendText(remainingText.slice(cursor));
+            appendToken(remainingText.slice(cursor), 'text');
+            node.innerHTML = Mustache.to_html(churnNoticeTemplate, {
+                tokens: tokens,
+            });
         };
 
         [{ selector: '#mck-conversation-title', path: 'conversations.title' }].forEach(function (

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -172,14 +172,11 @@ class KMLabel {
                 value.indexOf('{{supportEmailLink}}') !== -1
                     ? value
                     : fallbackTemplate;
-            var createDeactivateLink = function () {
-                var link = document.createElement('a');
-                link.id = 'deactivate-link';
-                link.href = 'https://www.kommunicate.io/poweredby';
-                link.target = '_blank';
-                link.rel = 'noopener noreferrer';
-                link.appendChild(document.createTextNode('Kommunicate chatbot'));
-                return link;
+            var createDeactivateText = function () {
+                var text = document.createElement('span');
+                text.id = 'deactivate-link';
+                text.appendChild(document.createTextNode('Kommunicate chatbot'));
+                return text;
             };
             var createSupportEmailLink = function () {
                 var link = document.createElement('a');
@@ -201,7 +198,7 @@ class KMLabel {
                 appendText(template.slice(cursor, match.index));
                 node.appendChild(
                     match[1] === 'deactivateLink'
-                        ? createDeactivateLink()
+                        ? createDeactivateText()
                         : createSupportEmailLink()
                 );
                 cursor = tokenRegex.lastIndex;

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -165,12 +165,41 @@ class KMLabel {
                 return;
             }
             var fallbackTemplate =
-                '<strong class="km-churn-message-highlight">Chat has been disabled for this website.</strong> <strong class="km-churn-message-label">Visitors:</strong> Please contact the website owner using another contact method. <strong class="km-churn-message-label">Website administrators:</strong> If you need help restoring chat, contact Kommunicate Support.';
+                'Chat has been disabled for this website. Visitors: Please contact the website owner using another contact method. Website administrators: If you need help restoring chat, contact Kommunicate Support.';
             var template = typeof value === 'string' && value.trim() ? value : fallbackTemplate;
-
-            node.innerHTML = template
+            var noticeText = template
                 .replace(/\{\{deactivateLink\}\}/g, 'Kommunicate chatbot')
                 .replace(/\{\{supportEmailLink\}\}/g, 'Kommunicate Support');
+            var appendText = function (text) {
+                if (text) {
+                    node.appendChild(document.createTextNode(text));
+                }
+            };
+            var appendStrongText = function (text, className) {
+                if (!text) {
+                    return;
+                }
+                var strongNode = document.createElement('strong');
+                strongNode.className = className;
+                strongNode.appendChild(document.createTextNode(text));
+                node.appendChild(strongNode);
+            };
+            var sentenceMatch = noticeText.match(/^(.+?[.!?۔。！？])(\s*.*)?$/);
+            var firstSentence = sentenceMatch ? sentenceMatch[1] : noticeText;
+            var remainingText = sentenceMatch && sentenceMatch[2] ? sentenceMatch[2] : '';
+            var labelRegex = /(^|[.!?۔。！？]\s+)([^.!?۔。！？:：\n][^:：\n]*[:：])/g;
+            var cursor = 0;
+            var match;
+
+            node.textContent = '';
+            appendStrongText(firstSentence, 'km-churn-message-highlight');
+            while ((match = labelRegex.exec(remainingText)) !== null) {
+                appendText(remainingText.slice(cursor, match.index));
+                appendText(match[1]);
+                appendStrongText(match[2], 'km-churn-message-label');
+                cursor = match.index + match[0].length;
+            }
+            appendText(remainingText.slice(cursor));
         };
 
         [{ selector: '#mck-conversation-title', path: 'conversations.title' }].forEach(function (

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -165,45 +165,12 @@ class KMLabel {
                 return;
             }
             var fallbackTemplate =
-                'Messaging via {{deactivateLink}} is disabled for this account. To enable, please contact the admin of the website. If you are the admin, get in touch at {{supportEmailLink}}';
-            var template =
-                typeof value === 'string' &&
-                value.indexOf('{{deactivateLink}}') !== -1 &&
-                value.indexOf('{{supportEmailLink}}') !== -1
-                    ? value
-                    : fallbackTemplate;
-            var createDeactivateText = function () {
-                var text = document.createElement('span');
-                text.id = 'deactivate-link';
-                text.appendChild(document.createTextNode('Kommunicate chatbot'));
-                return text;
-            };
-            var createSupportEmailLink = function () {
-                var link = document.createElement('a');
-                link.href = 'mailto:support@kommunicate.io';
-                link.appendChild(document.createTextNode('support@kommunicate.io'));
-                return link;
-            };
-            var appendText = function (text) {
-                if (text) {
-                    node.appendChild(document.createTextNode(text));
-                }
-            };
-            var tokenRegex = /\{\{(deactivateLink|supportEmailLink)\}\}/g;
-            var cursor = 0;
-            var match;
+                '<strong class="km-churn-message-highlight">Chat has been disabled for this website.</strong> <strong class="km-churn-message-label">Visitors:</strong> Please contact the website owner using another contact method. <strong class="km-churn-message-label">Website administrators:</strong> If you need help restoring chat, contact Kommunicate Support.';
+            var template = typeof value === 'string' && value.trim() ? value : fallbackTemplate;
 
-            node.textContent = '';
-            while ((match = tokenRegex.exec(template)) !== null) {
-                appendText(template.slice(cursor, match.index));
-                node.appendChild(
-                    match[1] === 'deactivateLink'
-                        ? createDeactivateText()
-                        : createSupportEmailLink()
-                );
-                cursor = tokenRegex.lastIndex;
-            }
-            appendText(template.slice(cursor));
+            node.innerHTML = template
+                .replace(/\{\{deactivateLink\}\}/g, 'Kommunicate chatbot')
+                .replace(/\{\{supportEmailLink\}\}/g, 'Kommunicate Support');
         };
 
         [{ selector: '#mck-conversation-title', path: 'conversations.title' }].forEach(function (

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -171,13 +171,13 @@ class KMLabel {
                 return;
             }
             var value = resolveLabel('account.churned.notice');
-            if (typeof value !== 'string' || !value.trim()) {
+            var noticeText = (value || node.textContent).trim();
+            if (!noticeText) {
                 return;
             }
-            var noticeText = value;
             var sentenceMatch = noticeText.match(/^(.+?[.!?۔。！？])(\s*.*)?$/);
             var firstSentence = sentenceMatch ? sentenceMatch[1] : noticeText;
-            var remainingText = sentenceMatch && sentenceMatch[2] ? sentenceMatch[2] : '';
+            var remainingText = sentenceMatch ? sentenceMatch[2] || '' : '';
             var labelRegex = /(^|[.!?۔。！？]\s+)([^.!?۔。！？:：\n][^:：\n]*[:：])/g;
             var cursor = 0;
             var match;

--- a/webplugin/js/app/labels/default-labels.js
+++ b/webplugin/js/app/labels/default-labels.js
@@ -171,19 +171,10 @@ class KMLabel {
                 return;
             }
             var value = resolveLabel('account.churned.notice');
-            var fallbackText = node.textContent.trim();
-            var template =
-                typeof value === 'string' && value.trim()
-                    ? value
-                    : typeof fallbackText === 'string' && fallbackText
-                    ? fallbackText
-                    : '';
-            if (!template) {
+            if (typeof value !== 'string' || !value.trim()) {
                 return;
             }
-            var noticeText = template
-                .replace(/\{\{deactivateLink\}\}/g, 'Kommunicate chatbot')
-                .replace(/\{\{supportEmailLink\}\}/g, 'Kommunicate Support');
+            var noticeText = value;
             var sentenceMatch = noticeText.match(/^(.+?[.!?۔。！？])(\s*.*)?$/);
             var firstSentence = sentenceMatch ? sentenceMatch[1] : noticeText;
             var remainingText = sentenceMatch && sentenceMatch[2] ? sentenceMatch[2] : '';

--- a/webplugin/js/app/labels/generated-labels-locales.js
+++ b/webplugin/js/app/labels/generated-labels-locales.js
@@ -123,7 +123,7 @@
             'business-hour.msg':
                 'لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">تم تعطيل الدردشة لهذا الموقع الإلكتروني.</strong> <strong class="km-churn-message-label">الزوار:</strong> يُرجى التواصل مع مالك الموقع باستخدام وسيلة اتصال أخرى. <strong class="km-churn-message-label">مسؤولو الموقع:</strong> إذا كنتم بحاجة إلى مساعدة لاستعادة الدردشة، فتواصلوا مع دعم Kommunicate.',
+                'تم تعطيل الدردشة لهذا الموقع الإلكتروني. الزوار: يُرجى التواصل مع مالك الموقع باستخدام وسيلة اتصال أخرى. مسؤولو الموقع: إذا كنتم بحاجة إلى مساعدة لاستعادة الدردشة، فتواصلوا مع دعم Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName أنشأ المجموعة :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName أزال :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName أضاف :userName',
@@ -332,7 +332,7 @@
             'business-hour.msg':
                 'Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">Der Chat wurde für diese Website deaktiviert.</strong> <strong class="km-churn-message-label">Besucher:</strong> Bitte kontaktieren Sie den Website-Betreiber über einen anderen Kontaktweg. <strong class="km-churn-message-label">Website-Administratoren:</strong> Wenn Sie Hilfe bei der Wiederherstellung des Chats benötigen, wenden Sie sich an den Kommunicate-Support.',
+                'Der Chat wurde für diese Website deaktiviert. Besucher: Bitte kontaktieren Sie den Website-Betreiber über einen anderen Kontaktweg. Website-Administratoren: Wenn Sie Hilfe bei der Wiederherstellung des Chats benötigen, wenden Sie sich an den Kommunicate-Support.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName hat die Gruppe :groupName erstellt',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName hat :userName entfernt',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName hat :userName hinzugefügt',
@@ -545,7 +545,7 @@
             'business-hour.msg':
                 'Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">El chat se ha deshabilitado para este sitio web.</strong> <strong class="km-churn-message-label">Visitantes:</strong> Pónganse en contacto con el propietario del sitio web mediante otro método de contacto. <strong class="km-churn-message-label">Administradores del sitio web:</strong> Si necesitan ayuda para restaurar el chat, contacten con el soporte de Kommunicate.',
+                'El chat se ha deshabilitado para este sitio web. Visitantes: Pónganse en contacto con el propietario del sitio web mediante otro método de contacto. Administradores del sitio web: Si necesitan ayuda para restaurar el chat, contacten con el soporte de Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName creó el grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName eliminó a :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName añadió a :userName',
@@ -760,7 +760,7 @@
             'business-hour.msg':
                 "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">Le chat a été désactivé pour ce site web.</strong> <strong class="km-churn-message-label">Visiteurs :</strong> veuillez contacter le propriétaire du site en utilisant un autre moyen de contact. <strong class="km-churn-message-label">Administrateurs du site web :</strong> si vous avez besoin d’aide pour rétablir le chat, contactez le support Kommunicate.',
+                'Le chat a été désactivé pour ce site web. Visiteurs : veuillez contacter le propriétaire du site en utilisant un autre moyen de contact. Administrateurs du site web : si vous avez besoin d’aide pour rétablir le chat, contactez le support Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName a créé le groupe :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName a supprimé :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName a ajouté :userName',
@@ -978,7 +978,7 @@
             'business-hour.msg':
                 'आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">इस वेबसाइट के लिए चैट अक्षम कर दी गई है।</strong> <strong class="km-churn-message-label">आगंतुक:</strong> कृपया वेबसाइट के मालिक से किसी अन्य संपर्क माध्यम से संपर्क करें। <strong class="km-churn-message-label">वेबसाइट प्रशासक:</strong> यदि आपको चैट बहाल करने में सहायता चाहिए, तो Kommunicate सहायता टीम से संपर्क करें।',
+                'इस वेबसाइट के लिए चैट अक्षम कर दी गई है। आगंतुक: कृपया वेबसाइट के मालिक से किसी अन्य संपर्क माध्यम से संपर्क करें। वेबसाइट प्रशासक: यदि आपको चैट बहाल करने में सहायता चाहिए, तो Kommunicate सहायता टीम से संपर्क करें।',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ने समूह :groupName बनाया',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ने :userName को हटा दिया',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ने :userName को जोड़ा',
@@ -1191,7 +1191,7 @@
             'business-hour.msg':
                 'Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">La chat è stata disattivata per questo sito web.</strong> <strong class="km-churn-message-label">Visitatori:</strong> contattate il proprietario del sito web utilizzando un altro metodo di contatto. <strong class="km-churn-message-label">Amministratori del sito web:</strong> se avete bisogno di aiuto per ripristinare la chat, contattate il supporto di Kommunicate.',
+                'La chat è stata disattivata per questo sito web. Visitatori: contattate il proprietario del sito web utilizzando un altro metodo di contatto. Amministratori del sito web: se avete bisogno di aiuto per ripristinare la chat, contattate il supporto di Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ha creato il gruppo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ha rimosso :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ha aggiunto :userName',
@@ -1406,7 +1406,7 @@
             'business-hour.msg':
                 'Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">O chat foi desativado para este site.</strong> <strong class="km-churn-message-label">Visitantes:</strong> entrem em contato com o proprietário do site usando outro meio de contato. <strong class="km-churn-message-label">Administradores do site:</strong> se precisarem de ajuda para restaurar o chat, entrem em contato com o suporte da Kommunicate.',
+                'O chat foi desativado para este site. Visitantes: entrem em contato com o proprietário do site usando outro meio de contato. Administradores do site: se precisarem de ajuda para restaurar o chat, entrem em contato com o suporte da Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName criou o grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName removeu :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName adicionou :userName',
@@ -1618,7 +1618,7 @@
             'business-hour.msg':
                 'Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">Chatten har inaktiverats för den här webbplatsen.</strong> <strong class="km-churn-message-label">Besökare:</strong> Kontakta webbplatsens ägare via en annan kontaktväg. <strong class="km-churn-message-label">Webbplatsadministratörer:</strong> Om ni behöver hjälp med att återställa chatten, kontakta Kommunicates support.',
+                'Chatten har inaktiverats för den här webbplatsen. Besökare: Kontakta webbplatsens ägare via en annan kontaktväg. Webbplatsadministratörer: Om ni behöver hjälp med att återställa chatten, kontakta Kommunicates support.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName skapade gruppen :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName tog bort :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName lade till :userName',
@@ -1829,7 +1829,7 @@
             'business-hour.msg':
                 'آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">اس ویب سائٹ کے لیے چیٹ غیر فعال کر دی گئی ہے۔</strong> <strong class="km-churn-message-label">وزیٹرز:</strong> براہ کرم ویب سائٹ کے مالک سے کسی دوسرے رابطے کے ذریعے رابطہ کریں۔ <strong class="km-churn-message-label">ویب سائٹ ایڈمنسٹریٹرز:</strong> اگر آپ کو چیٹ بحال کرنے میں مدد چاہیے تو Kommunicate سپورٹ سے رابطہ کریں۔',
+                'اس ویب سائٹ کے لیے چیٹ غیر فعال کر دی گئی ہے۔ وزیٹرز: براہ کرم ویب سائٹ کے مالک سے کسی دوسرے رابطے کے ذریعے رابطہ کریں۔ ویب سائٹ ایڈمنسٹریٹرز: اگر آپ کو چیٹ بحال کرنے میں مدد چاہیے تو Kommunicate سپورٹ سے رابطہ کریں۔',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName نے گروپ :groupName بنایا',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName نے :userName کو ہٹایا',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName نے :userName کو شامل کیا',
@@ -2039,7 +2039,7 @@
             'business-hour.msg':
                 '您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。',
             'account.churned.notice':
-                '<strong class="km-churn-message-highlight">此网站的聊天功能已被禁用。</strong> <strong class="km-churn-message-label">访客：</strong>请通过其他联系方式联系网站所有者。<strong class="km-churn-message-label">网站管理员：</strong>如果您需要帮助恢复聊天，请联系 Kommunicate 支持团队。',
+                '此网站的聊天功能已被禁用。访客：请通过其他联系方式联系网站所有者。网站管理员：如果您需要帮助恢复聊天，请联系 Kommunicate 支持团队。',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName 创建了群组 :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName 移除了 :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName 添加了 :userName',

--- a/webplugin/js/app/labels/generated-labels-locales.js
+++ b/webplugin/js/app/labels/generated-labels-locales.js
@@ -123,7 +123,7 @@
             'business-hour.msg':
                 'لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.',
             'account.churned.notice':
-                'تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">تم تعطيل الدردشة لهذا الموقع الإلكتروني.</strong> <strong class="km-churn-message-label">الزوار:</strong> يُرجى التواصل مع مالك الموقع باستخدام وسيلة اتصال أخرى. <strong class="km-churn-message-label">مسؤولو الموقع:</strong> إذا كنتم بحاجة إلى مساعدة لاستعادة الدردشة، فتواصلوا مع دعم Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName أنشأ المجموعة :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName أزال :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName أضاف :userName',
@@ -332,7 +332,7 @@
             'business-hour.msg':
                 'Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.',
             'account.churned.notice':
-                'Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">Der Chat wurde für diese Website deaktiviert.</strong> <strong class="km-churn-message-label">Besucher:</strong> Bitte kontaktieren Sie den Website-Betreiber über einen anderen Kontaktweg. <strong class="km-churn-message-label">Website-Administratoren:</strong> Wenn Sie Hilfe bei der Wiederherstellung des Chats benötigen, wenden Sie sich an den Kommunicate-Support.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName hat die Gruppe :groupName erstellt',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName hat :userName entfernt',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName hat :userName hinzugefügt',
@@ -545,7 +545,7 @@
             'business-hour.msg':
                 'Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.',
             'account.churned.notice':
-                'La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">El chat se ha deshabilitado para este sitio web.</strong> <strong class="km-churn-message-label">Visitantes:</strong> Pónganse en contacto con el propietario del sitio web mediante otro método de contacto. <strong class="km-churn-message-label">Administradores del sitio web:</strong> Si necesitan ayuda para restaurar el chat, contacten con el soporte de Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName creó el grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName eliminó a :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName añadió a :userName',
@@ -760,7 +760,7 @@
             'business-hour.msg':
                 "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
             'account.churned.notice':
-                'La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">Le chat a été désactivé pour ce site web.</strong> <strong class="km-churn-message-label">Visiteurs :</strong> veuillez contacter le propriétaire du site en utilisant un autre moyen de contact. <strong class="km-churn-message-label">Administrateurs du site web :</strong> si vous avez besoin d’aide pour rétablir le chat, contactez le support Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName a créé le groupe :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName a supprimé :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName a ajouté :userName',
@@ -978,7 +978,7 @@
             'business-hour.msg':
                 'आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।',
             'account.churned.notice':
-                'इस खाते के लिए {{deactivateLink}} के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो {{supportEmailLink}} पर हमसे संपर्क करें।',
+                '<strong class="km-churn-message-highlight">इस वेबसाइट के लिए चैट अक्षम कर दी गई है।</strong> <strong class="km-churn-message-label">आगंतुक:</strong> कृपया वेबसाइट के मालिक से किसी अन्य संपर्क माध्यम से संपर्क करें। <strong class="km-churn-message-label">वेबसाइट प्रशासक:</strong> यदि आपको चैट बहाल करने में सहायता चाहिए, तो Kommunicate सहायता टीम से संपर्क करें।',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ने समूह :groupName बनाया',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ने :userName को हटा दिया',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ने :userName को जोड़ा',
@@ -1191,7 +1191,7 @@
             'business-hour.msg':
                 'Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.',
             'account.churned.notice':
-                'La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">La chat è stata disattivata per questo sito web.</strong> <strong class="km-churn-message-label">Visitatori:</strong> contattate il proprietario del sito web utilizzando un altro metodo di contatto. <strong class="km-churn-message-label">Amministratori del sito web:</strong> se avete bisogno di aiuto per ripristinare la chat, contattate il supporto di Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName ha creato il gruppo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName ha rimosso :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName ha aggiunto :userName',
@@ -1406,7 +1406,7 @@
             'business-hour.msg':
                 'Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.',
             'account.churned.notice':
-                'As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">O chat foi desativado para este site.</strong> <strong class="km-churn-message-label">Visitantes:</strong> entrem em contato com o proprietário do site usando outro meio de contato. <strong class="km-churn-message-label">Administradores do site:</strong> se precisarem de ajuda para restaurar o chat, entrem em contato com o suporte da Kommunicate.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName criou o grupo :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName removeu :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName adicionou :userName',
@@ -1618,7 +1618,7 @@
             'business-hour.msg':
                 'Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.',
             'account.churned.notice':
-                'Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}',
+                '<strong class="km-churn-message-highlight">Chatten har inaktiverats för den här webbplatsen.</strong> <strong class="km-churn-message-label">Besökare:</strong> Kontakta webbplatsens ägare via en annan kontaktväg. <strong class="km-churn-message-label">Webbplatsadministratörer:</strong> Om ni behöver hjälp med att återställa chatten, kontakta Kommunicates support.',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName skapade gruppen :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName tog bort :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName lade till :userName',
@@ -1829,7 +1829,7 @@
             'business-hour.msg':
                 'آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.',
             'account.churned.notice':
-                'اس اکاؤنٹ کے لیے {{deactivateLink}} کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو {{supportEmailLink}} پر ہم سے رابطہ کریں۔',
+                '<strong class="km-churn-message-highlight">اس ویب سائٹ کے لیے چیٹ غیر فعال کر دی گئی ہے۔</strong> <strong class="km-churn-message-label">وزیٹرز:</strong> براہ کرم ویب سائٹ کے مالک سے کسی دوسرے رابطے کے ذریعے رابطہ کریں۔ <strong class="km-churn-message-label">ویب سائٹ ایڈمنسٹریٹرز:</strong> اگر آپ کو چیٹ بحال کرنے میں مدد چاہیے تو Kommunicate سپورٹ سے رابطہ کریں۔',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName نے گروپ :groupName بنایا',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName نے :userName کو ہٹایا',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName نے :userName کو شامل کیا',
@@ -2039,7 +2039,7 @@
             'business-hour.msg':
                 '您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。',
             'account.churned.notice':
-                '此账户已禁用通过 {{deactivateLink}} 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 {{supportEmailLink}} 与我们联系。',
+                '<strong class="km-churn-message-highlight">此网站的聊天功能已被禁用。</strong> <strong class="km-churn-message-label">访客：</strong>请通过其他联系方式联系网站所有者。<strong class="km-churn-message-label">网站管理员：</strong>如果您需要帮助恢复聊天，请联系 Kommunicate 支持团队。',
             'group.metadata.CREATE_GROUP_MESSAGE': ':adminName 创建了群组 :groupName',
             'group.metadata.REMOVE_MEMBER_MESSAGE': ':adminName 移除了 :userName',
             'group.metadata.ADD_MEMBER_MESSAGE': ':adminName 添加了 :userName',

--- a/webplugin/js/app/labels/locales/ar.json
+++ b/webplugin/js/app/labels/locales/ar.json
@@ -110,7 +110,7 @@
   "offline.msg": "عذراً! لا يوجد اتصال بالإنترنت. تحقق من الشبكة وحاول مرة أخرى.",
   "socket-disconnect.msg": "خطأ أثناء مزامنة الرسائل. تحقق من جدار الحماية أو حاول مرة أخرى لاحقًا.",
   "business-hour.msg": "لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">تم تعطيل الدردشة لهذا الموقع الإلكتروني.</strong> <strong class=\"km-churn-message-label\">الزوار:</strong> يُرجى التواصل مع مالك الموقع باستخدام وسيلة اتصال أخرى. <strong class=\"km-churn-message-label\">مسؤولو الموقع:</strong> إذا كنتم بحاجة إلى مساعدة لاستعادة الدردشة، فتواصلوا مع دعم Kommunicate.",
+  "account.churned.notice": "تم تعطيل الدردشة لهذا الموقع الإلكتروني. الزوار: يُرجى التواصل مع مالك الموقع باستخدام وسيلة اتصال أخرى. مسؤولو الموقع: إذا كنتم بحاجة إلى مساعدة لاستعادة الدردشة، فتواصلوا مع دعم Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName أنشأ المجموعة :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName أزال :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName أضاف :userName",

--- a/webplugin/js/app/labels/locales/ar.json
+++ b/webplugin/js/app/labels/locales/ar.json
@@ -110,7 +110,7 @@
   "offline.msg": "عذراً! لا يوجد اتصال بالإنترنت. تحقق من الشبكة وحاول مرة أخرى.",
   "socket-disconnect.msg": "خطأ أثناء مزامنة الرسائل. تحقق من جدار الحماية أو حاول مرة أخرى لاحقًا.",
   "business-hour.msg": "لقد اتصلت بنا خارج ساعات العمل. سيتولى روبوتنا استفساراتك حتى يعود الفريق.",
-  "account.churned.notice": "تم تعطيل المراسلة عبر {{deactivateLink}} لهذا الحساب. لتمكينها، يرجى التواصل مع مشرف الموقع. إذا كنت أنت المشرف، فتواصل معنا على {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">تم تعطيل الدردشة لهذا الموقع الإلكتروني.</strong> <strong class=\"km-churn-message-label\">الزوار:</strong> يُرجى التواصل مع مالك الموقع باستخدام وسيلة اتصال أخرى. <strong class=\"km-churn-message-label\">مسؤولو الموقع:</strong> إذا كنتم بحاجة إلى مساعدة لاستعادة الدردشة، فتواصلوا مع دعم Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName أنشأ المجموعة :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName أزال :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName أضاف :userName",

--- a/webplugin/js/app/labels/locales/de.json
+++ b/webplugin/js/app/labels/locales/de.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh nein! Keine Internetverbindung. Prüfen Sie Ihre Netzwerkeinstellungen und versuchen Sie es erneut.",
   "socket-disconnect.msg": "Fehler beim Synchronisieren der Nachrichten. Prüfen Sie Ihre Firewall oder versuchen Sie es später erneut.",
   "business-hour.msg": "Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">Der Chat wurde für diese Website deaktiviert.</strong> <strong class=\"km-churn-message-label\">Besucher:</strong> Bitte kontaktieren Sie den Website-Betreiber über einen anderen Kontaktweg. <strong class=\"km-churn-message-label\">Website-Administratoren:</strong> Wenn Sie Hilfe bei der Wiederherstellung des Chats benötigen, wenden Sie sich an den Kommunicate-Support.",
+  "account.churned.notice": "Der Chat wurde für diese Website deaktiviert. Besucher: Bitte kontaktieren Sie den Website-Betreiber über einen anderen Kontaktweg. Website-Administratoren: Wenn Sie Hilfe bei der Wiederherstellung des Chats benötigen, wenden Sie sich an den Kommunicate-Support.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName hat die Gruppe :groupName erstellt",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName hat :userName entfernt",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName hat :userName hinzugefügt",

--- a/webplugin/js/app/labels/locales/de.json
+++ b/webplugin/js/app/labels/locales/de.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh nein! Keine Internetverbindung. Prüfen Sie Ihre Netzwerkeinstellungen und versuchen Sie es erneut.",
   "socket-disconnect.msg": "Fehler beim Synchronisieren der Nachrichten. Prüfen Sie Ihre Firewall oder versuchen Sie es später erneut.",
   "business-hour.msg": "Sie haben uns außerhalb der Geschäftszeiten kontaktiert. Unser Bot kümmert sich um Ihre Fragen, bis das Team zurück ist.",
-  "account.churned.notice": "Das Versenden von Nachrichten über den {{deactivateLink}} ist für dieses Konto deaktiviert. Um es zu aktivieren, wenden Sie sich bitte an den Administrator der Website. Wenn Sie der Administrator sind, kontaktieren Sie {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">Der Chat wurde für diese Website deaktiviert.</strong> <strong class=\"km-churn-message-label\">Besucher:</strong> Bitte kontaktieren Sie den Website-Betreiber über einen anderen Kontaktweg. <strong class=\"km-churn-message-label\">Website-Administratoren:</strong> Wenn Sie Hilfe bei der Wiederherstellung des Chats benötigen, wenden Sie sich an den Kommunicate-Support.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName hat die Gruppe :groupName erstellt",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName hat :userName entfernt",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName hat :userName hinzugefügt",

--- a/webplugin/js/app/labels/locales/es.json
+++ b/webplugin/js/app/labels/locales/es.json
@@ -110,7 +110,7 @@
   "offline.msg": "¡Vaya! No hay conexión a internet. Revisa tu red e inténtalo de nuevo.",
   "socket-disconnect.msg": "Error al sincronizar mensajes. Revisa tu firewall o intenta de nuevo más tarde.",
   "business-hour.msg": "Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">El chat se ha deshabilitado para este sitio web.</strong> <strong class=\"km-churn-message-label\">Visitantes:</strong> Pónganse en contacto con el propietario del sitio web mediante otro método de contacto. <strong class=\"km-churn-message-label\">Administradores del sitio web:</strong> Si necesitan ayuda para restaurar el chat, contacten con el soporte de Kommunicate.",
+  "account.churned.notice": "El chat se ha deshabilitado para este sitio web. Visitantes: Pónganse en contacto con el propietario del sitio web mediante otro método de contacto. Administradores del sitio web: Si necesitan ayuda para restaurar el chat, contacten con el soporte de Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName creó el grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName eliminó a :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName añadió a :userName",

--- a/webplugin/js/app/labels/locales/es.json
+++ b/webplugin/js/app/labels/locales/es.json
@@ -110,7 +110,7 @@
   "offline.msg": "¡Vaya! No hay conexión a internet. Revisa tu red e inténtalo de nuevo.",
   "socket-disconnect.msg": "Error al sincronizar mensajes. Revisa tu firewall o intenta de nuevo más tarde.",
   "business-hour.msg": "Nos contactaste fuera del horario laboral. Nuestro bot manejará tus consultas hasta que el equipo vuelva.",
-  "account.churned.notice": "La mensajería a través del {{deactivateLink}} está deshabilitada para esta cuenta. Para habilitarla, ponte en contacto con el administrador del sitio web. Si eres el administrador, escríbenos a {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">El chat se ha deshabilitado para este sitio web.</strong> <strong class=\"km-churn-message-label\">Visitantes:</strong> Pónganse en contacto con el propietario del sitio web mediante otro método de contacto. <strong class=\"km-churn-message-label\">Administradores del sitio web:</strong> Si necesitan ayuda para restaurar el chat, contacten con el soporte de Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName creó el grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName eliminó a :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName añadió a :userName",

--- a/webplugin/js/app/labels/locales/fr.json
+++ b/webplugin/js/app/labels/locales/fr.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oups ! Pas de connexion Internet. Veuillez vérifier votre réseau et réessayer.",
   "socket-disconnect.msg": "Erreur lors de la synchronisation des messages. Vérifiez votre pare-feu ou réessayez plus tard.",
   "business-hour.msg": "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">Le chat a été désactivé pour ce site web.</strong> <strong class=\"km-churn-message-label\">Visiteurs :</strong> veuillez contacter le propriétaire du site en utilisant un autre moyen de contact. <strong class=\"km-churn-message-label\">Administrateurs du site web :</strong> si vous avez besoin d’aide pour rétablir le chat, contactez le support Kommunicate.",
+  "account.churned.notice": "Le chat a été désactivé pour ce site web. Visiteurs : veuillez contacter le propriétaire du site en utilisant un autre moyen de contact. Administrateurs du site web : si vous avez besoin d’aide pour rétablir le chat, contactez le support Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName a créé le groupe :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName a supprimé :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName a ajouté :userName",

--- a/webplugin/js/app/labels/locales/fr.json
+++ b/webplugin/js/app/labels/locales/fr.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oups ! Pas de connexion Internet. Veuillez vérifier votre réseau et réessayer.",
   "socket-disconnect.msg": "Erreur lors de la synchronisation des messages. Vérifiez votre pare-feu ou réessayez plus tard.",
   "business-hour.msg": "Vous nous avez contactés en dehors de nos heures d'ouverture. Notre bot traitera vos demandes jusqu'au retour de l'équipe.",
-  "account.churned.notice": "La messagerie via le {{deactivateLink}} est désactivée pour ce compte. Pour l’activer, veuillez contacter l’administrateur du site web. Si vous êtes l’administrateur, contactez-nous à {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">Le chat a été désactivé pour ce site web.</strong> <strong class=\"km-churn-message-label\">Visiteurs :</strong> veuillez contacter le propriétaire du site en utilisant un autre moyen de contact. <strong class=\"km-churn-message-label\">Administrateurs du site web :</strong> si vous avez besoin d’aide pour rétablir le chat, contactez le support Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName a créé le groupe :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName a supprimé :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName a ajouté :userName",

--- a/webplugin/js/app/labels/locales/hi.json
+++ b/webplugin/js/app/labels/locales/hi.json
@@ -110,7 +110,7 @@
   "offline.msg": "ओह ओह! इंटरनेट कनेक्शन नहीं है। कृपया अपने नेटवर्क की जाँच करें और पुनः प्रयास करें।",
   "socket-disconnect.msg": "संदेशों को सिंक करते समय त्रुटि हुई। अपने फ़ायरवॉल सेटिंग्स की जांच करें या कुछ समय बाद पुनः प्रयास करें।",
   "business-hour.msg": "आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">इस वेबसाइट के लिए चैट अक्षम कर दी गई है।</strong> <strong class=\"km-churn-message-label\">आगंतुक:</strong> कृपया वेबसाइट के मालिक से किसी अन्य संपर्क माध्यम से संपर्क करें। <strong class=\"km-churn-message-label\">वेबसाइट प्रशासक:</strong> यदि आपको चैट बहाल करने में सहायता चाहिए, तो Kommunicate सहायता टीम से संपर्क करें।",
+  "account.churned.notice": "इस वेबसाइट के लिए चैट अक्षम कर दी गई है। आगंतुक: कृपया वेबसाइट के मालिक से किसी अन्य संपर्क माध्यम से संपर्क करें। वेबसाइट प्रशासक: यदि आपको चैट बहाल करने में सहायता चाहिए, तो Kommunicate सहायता टीम से संपर्क करें।",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ने समूह :groupName बनाया",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ने :userName को हटा दिया",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ने :userName को जोड़ा",

--- a/webplugin/js/app/labels/locales/hi.json
+++ b/webplugin/js/app/labels/locales/hi.json
@@ -110,7 +110,7 @@
   "offline.msg": "ओह ओह! इंटरनेट कनेक्शन नहीं है। कृपया अपने नेटवर्क की जाँच करें और पुनः प्रयास करें।",
   "socket-disconnect.msg": "संदेशों को सिंक करते समय त्रुटि हुई। अपने फ़ायरवॉल सेटिंग्स की जांच करें या कुछ समय बाद पुनः प्रयास करें।",
   "business-hour.msg": "आपने हमें हमारे व्यापारिक घंटों के बाहर संपर्क किया है। जब तक टीम ऑनलाइन नहीं आती, हमारा बॉट आपकी क्वेरी संभालेगा।",
-  "account.churned.notice": "इस खाते के लिए {{deactivateLink}} के माध्यम से मैसेजिंग अक्षम है। इसे सक्षम करने के लिए कृपया वेबसाइट के एडमिन से संपर्क करें। यदि आप एडमिन हैं, तो {{supportEmailLink}} पर हमसे संपर्क करें।",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">इस वेबसाइट के लिए चैट अक्षम कर दी गई है।</strong> <strong class=\"km-churn-message-label\">आगंतुक:</strong> कृपया वेबसाइट के मालिक से किसी अन्य संपर्क माध्यम से संपर्क करें। <strong class=\"km-churn-message-label\">वेबसाइट प्रशासक:</strong> यदि आपको चैट बहाल करने में सहायता चाहिए, तो Kommunicate सहायता टीम से संपर्क करें।",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ने समूह :groupName बनाया",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ने :userName को हटा दिया",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ने :userName को जोड़ा",

--- a/webplugin/js/app/labels/locales/it.json
+++ b/webplugin/js/app/labels/locales/it.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh no! Nessuna connessione internet. Controlla la tua rete e riprova.",
   "socket-disconnect.msg": "Errore durante la sincronizzazione dei messaggi. Controlla il firewall o riprova più tardi.",
   "business-hour.msg": "Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.",
-  "account.churned.notice": "La messaggistica tramite il {{deactivateLink}} è disabilitata per questo account. Per abilitarla, contatta l’amministratore del sito web. Se sei l’amministratore, scrivici a {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">La chat è stata disattivata per questo sito web.</strong> <strong class=\"km-churn-message-label\">Visitatori:</strong> contattate il proprietario del sito web utilizzando un altro metodo di contatto. <strong class=\"km-churn-message-label\">Amministratori del sito web:</strong> se avete bisogno di aiuto per ripristinare la chat, contattate il supporto di Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ha creato il gruppo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ha rimosso :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ha aggiunto :userName",

--- a/webplugin/js/app/labels/locales/it.json
+++ b/webplugin/js/app/labels/locales/it.json
@@ -110,7 +110,7 @@
   "offline.msg": "Oh no! Nessuna connessione internet. Controlla la tua rete e riprova.",
   "socket-disconnect.msg": "Errore durante la sincronizzazione dei messaggi. Controlla il firewall o riprova più tardi.",
   "business-hour.msg": "Ci hai contattato fuori dall’orario di lavoro. Il nostro bot gestirà la tua richiesta finché il team non tornerà online.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">La chat è stata disattivata per questo sito web.</strong> <strong class=\"km-churn-message-label\">Visitatori:</strong> contattate il proprietario del sito web utilizzando un altro metodo di contatto. <strong class=\"km-churn-message-label\">Amministratori del sito web:</strong> se avete bisogno di aiuto per ripristinare la chat, contattate il supporto di Kommunicate.",
+  "account.churned.notice": "La chat è stata disattivata per questo sito web. Visitatori: contattate il proprietario del sito web utilizzando un altro metodo di contatto. Amministratori del sito web: se avete bisogno di aiuto per ripristinare la chat, contattate il supporto di Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName ha creato il gruppo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName ha rimosso :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName ha aggiunto :userName",

--- a/webplugin/js/app/labels/locales/pt.json
+++ b/webplugin/js/app/labels/locales/pt.json
@@ -110,7 +110,7 @@
   "offline.msg": "Poxa! Sem conexão com a internet. Verifique sua rede e tente novamente.",
   "socket-disconnect.msg": "Erro ao sincronizar mensagens. Verifique o firewall ou tente novamente mais tarde.",
   "business-hour.msg": "Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.",
-  "account.churned.notice": "As mensagens via {{deactivateLink}} estão desativadas para esta conta. Para habilitar, entre em contato com o administrador do site. Se você for o administrador, fale conosco em {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">O chat foi desativado para este site.</strong> <strong class=\"km-churn-message-label\">Visitantes:</strong> entrem em contato com o proprietário do site usando outro meio de contato. <strong class=\"km-churn-message-label\">Administradores do site:</strong> se precisarem de ajuda para restaurar o chat, entrem em contato com o suporte da Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName criou o grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName removeu :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName adicionou :userName",

--- a/webplugin/js/app/labels/locales/pt.json
+++ b/webplugin/js/app/labels/locales/pt.json
@@ -110,7 +110,7 @@
   "offline.msg": "Poxa! Sem conexão com a internet. Verifique sua rede e tente novamente.",
   "socket-disconnect.msg": "Erro ao sincronizar mensagens. Verifique o firewall ou tente novamente mais tarde.",
   "business-hour.msg": "Você nos contatou fora do horário comercial. Nosso bot atenderá seu pedido até a equipe voltar.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">O chat foi desativado para este site.</strong> <strong class=\"km-churn-message-label\">Visitantes:</strong> entrem em contato com o proprietário do site usando outro meio de contato. <strong class=\"km-churn-message-label\">Administradores do site:</strong> se precisarem de ajuda para restaurar o chat, entrem em contato com o suporte da Kommunicate.",
+  "account.churned.notice": "O chat foi desativado para este site. Visitantes: entrem em contato com o proprietário do site usando outro meio de contato. Administradores do site: se precisarem de ajuda para restaurar o chat, entrem em contato com o suporte da Kommunicate.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName criou o grupo :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName removeu :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName adicionou :userName",

--- a/webplugin/js/app/labels/locales/sv.json
+++ b/webplugin/js/app/labels/locales/sv.json
@@ -110,7 +110,7 @@
   "offline.msg": "Aj då! Ingen internetanslutning. Kontrollera nätverket och försök igen.",
   "socket-disconnect.msg": "Fel vid synkronisering av meddelanden. Kontrollera brandväggen eller försök igen senare.",
   "business-hour.msg": "Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">Chatten har inaktiverats för den här webbplatsen.</strong> <strong class=\"km-churn-message-label\">Besökare:</strong> Kontakta webbplatsens ägare via en annan kontaktväg. <strong class=\"km-churn-message-label\">Webbplatsadministratörer:</strong> Om ni behöver hjälp med att återställa chatten, kontakta Kommunicates support.",
+  "account.churned.notice": "Chatten har inaktiverats för den här webbplatsen. Besökare: Kontakta webbplatsens ägare via en annan kontaktväg. Webbplatsadministratörer: Om ni behöver hjälp med att återställa chatten, kontakta Kommunicates support.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName skapade gruppen :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName tog bort :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName lade till :userName",

--- a/webplugin/js/app/labels/locales/sv.json
+++ b/webplugin/js/app/labels/locales/sv.json
@@ -110,7 +110,7 @@
   "offline.msg": "Aj då! Ingen internetanslutning. Kontrollera nätverket och försök igen.",
   "socket-disconnect.msg": "Fel vid synkronisering av meddelanden. Kontrollera brandväggen eller försök igen senare.",
   "business-hour.msg": "Du kontaktade oss utanför kontorstid. Vår bot hanterar dina frågor tills teamet är online igen.",
-  "account.churned.notice": "Meddelanden via {{deactivateLink}} är inaktiverade för det här kontot. För att aktivera dem, kontakta webbplatsens administratör. Om du är administratören, kontakta oss på {{supportEmailLink}}",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">Chatten har inaktiverats för den här webbplatsen.</strong> <strong class=\"km-churn-message-label\">Besökare:</strong> Kontakta webbplatsens ägare via en annan kontaktväg. <strong class=\"km-churn-message-label\">Webbplatsadministratörer:</strong> Om ni behöver hjälp med att återställa chatten, kontakta Kommunicates support.",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName skapade gruppen :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName tog bort :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName lade till :userName",

--- a/webplugin/js/app/labels/locales/ur.json
+++ b/webplugin/js/app/labels/locales/ur.json
@@ -110,7 +110,7 @@
   "offline.msg": "اوہ اوہ! انٹرنیٹ کنیکشن موجود نہیں۔ براہ کرم اپنا نیٹ ورک چیک کریں اور دوبارہ کوشش کریں.",
   "socket-disconnect.msg": "پیغامات کی مطابقت پذیری میں خرابی ہوئی۔ اپنے فائر وال کی ترتیبات چیک کریں یا کچھ دیر بعد دوبارہ کوشش کریں.",
   "business-hour.msg": "آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">اس ویب سائٹ کے لیے چیٹ غیر فعال کر دی گئی ہے۔</strong> <strong class=\"km-churn-message-label\">وزیٹرز:</strong> براہ کرم ویب سائٹ کے مالک سے کسی دوسرے رابطے کے ذریعے رابطہ کریں۔ <strong class=\"km-churn-message-label\">ویب سائٹ ایڈمنسٹریٹرز:</strong> اگر آپ کو چیٹ بحال کرنے میں مدد چاہیے تو Kommunicate سپورٹ سے رابطہ کریں۔",
+  "account.churned.notice": "اس ویب سائٹ کے لیے چیٹ غیر فعال کر دی گئی ہے۔ وزیٹرز: براہ کرم ویب سائٹ کے مالک سے کسی دوسرے رابطے کے ذریعے رابطہ کریں۔ ویب سائٹ ایڈمنسٹریٹرز: اگر آپ کو چیٹ بحال کرنے میں مدد چاہیے تو Kommunicate سپورٹ سے رابطہ کریں۔",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName نے گروپ :groupName بنایا",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName نے :userName کو ہٹایا",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName نے :userName کو شامل کیا",

--- a/webplugin/js/app/labels/locales/ur.json
+++ b/webplugin/js/app/labels/locales/ur.json
@@ -110,7 +110,7 @@
   "offline.msg": "اوہ اوہ! انٹرنیٹ کنیکشن موجود نہیں۔ براہ کرم اپنا نیٹ ورک چیک کریں اور دوبارہ کوشش کریں.",
   "socket-disconnect.msg": "پیغامات کی مطابقت پذیری میں خرابی ہوئی۔ اپنے فائر وال کی ترتیبات چیک کریں یا کچھ دیر بعد دوبارہ کوشش کریں.",
   "business-hour.msg": "آپ نے ہمیں کاروباری اوقات کے بعد رابطہ کیا ہے۔ جب تک ٹیم آن لائن نہ آئے، ہمارا بوٹ آپ کی پُرُشوں کا جواب دے گا.",
-  "account.churned.notice": "اس اکاؤنٹ کے لیے {{deactivateLink}} کے ذریعے پیغام رسانی غیر فعال ہے۔ اسے فعال کرنے کے لیے براہ کرم ویب سائٹ کے ایڈمن سے رابطہ کریں۔ اگر آپ ایڈمن ہیں تو {{supportEmailLink}} پر ہم سے رابطہ کریں۔",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">اس ویب سائٹ کے لیے چیٹ غیر فعال کر دی گئی ہے۔</strong> <strong class=\"km-churn-message-label\">وزیٹرز:</strong> براہ کرم ویب سائٹ کے مالک سے کسی دوسرے رابطے کے ذریعے رابطہ کریں۔ <strong class=\"km-churn-message-label\">ویب سائٹ ایڈمنسٹریٹرز:</strong> اگر آپ کو چیٹ بحال کرنے میں مدد چاہیے تو Kommunicate سپورٹ سے رابطہ کریں۔",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName نے گروپ :groupName بنایا",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName نے :userName کو ہٹایا",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName نے :userName کو شامل کیا",

--- a/webplugin/js/app/labels/locales/zh.json
+++ b/webplugin/js/app/labels/locales/zh.json
@@ -110,7 +110,7 @@
   "offline.msg": "哎呀！暂无网络连接，请检查后再试。",
   "socket-disconnect.msg": "同步消息时出错，请检查防火墙或稍后再试。",
   "business-hour.msg": "您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。",
-  "account.churned.notice": "此账户已禁用通过 {{deactivateLink}} 发送消息。如需启用，请联系网站管理员。如果您就是管理员，请通过 {{supportEmailLink}} 与我们联系。",
+  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">此网站的聊天功能已被禁用。</strong> <strong class=\"km-churn-message-label\">访客：</strong>请通过其他联系方式联系网站所有者。<strong class=\"km-churn-message-label\">网站管理员：</strong>如果您需要帮助恢复聊天，请联系 Kommunicate 支持团队。",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName 创建了群组 :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName 移除了 :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName 添加了 :userName",

--- a/webplugin/js/app/labels/locales/zh.json
+++ b/webplugin/js/app/labels/locales/zh.json
@@ -110,7 +110,7 @@
   "offline.msg": "哎呀！暂无网络连接，请检查后再试。",
   "socket-disconnect.msg": "同步消息时出错，请检查防火墙或稍后再试。",
   "business-hour.msg": "您在我们的工作时间之外联系，机器人会处理您的问题，直至客服重新上线。",
-  "account.churned.notice": "<strong class=\"km-churn-message-highlight\">此网站的聊天功能已被禁用。</strong> <strong class=\"km-churn-message-label\">访客：</strong>请通过其他联系方式联系网站所有者。<strong class=\"km-churn-message-label\">网站管理员：</strong>如果您需要帮助恢复聊天，请联系 Kommunicate 支持团队。",
+  "account.churned.notice": "此网站的聊天功能已被禁用。访客：请通过其他联系方式联系网站所有者。网站管理员：如果您需要帮助恢复聊天，请联系 Kommunicate 支持团队。",
   "group.metadata.CREATE_GROUP_MESSAGE": ":adminName 创建了群组 :groupName",
   "group.metadata.REMOVE_MEMBER_MESSAGE": ":adminName 移除了 :userName",
   "group.metadata.ADD_MEMBER_MESSAGE": ":adminName 添加了 :userName",

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -390,15 +390,10 @@
                         </div>
                         <div class="km-churn-content">
                             <p id="km-churn-notice" class="km-churn-message">
-                                <strong class="km-churn-message-highlight">
-                                    Chat has been disabled for this website.
-                                </strong>
-                                <strong class="km-churn-message-label">Visitors:</strong>
-                                Please contact the website owner using another contact method.
-                                <strong class="km-churn-message-label">
-                                    Website administrators:
-                                </strong>
-                                If you need help restoring chat, contact Kommunicate Support.
+                                Chat has been disabled for this website. Visitors: Please contact
+                                the website owner using another contact method. Website
+                                administrators: If you need help restoring chat, contact Kommunicate
+                                Support.
                             </p>
                         </div>
                     </div>

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -390,11 +390,15 @@
                         </div>
                         <div class="km-churn-content">
                             <p id="km-churn-notice" class="km-churn-message">
-                                Messaging via
-                                <span id="deactivate-link">Kommunicate chatbot</span>
-                                is disabled for this account. To enable, please contact the admin of
-                                the website. If you are the admin, get in touch at
-                                <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>
+                                <strong class="km-churn-message-highlight">
+                                    Chat has been disabled for this website.
+                                </strong>
+                                <strong class="km-churn-message-label">Visitors:</strong>
+                                Please contact the website owner using another contact method.
+                                <strong class="km-churn-message-label">
+                                    Website administrators:
+                                </strong>
+                                If you need help restoring chat, contact Kommunicate Support.
                             </p>
                         </div>
                     </div>

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -391,14 +391,7 @@
                         <div class="km-churn-content">
                             <p id="km-churn-notice" class="km-churn-message">
                                 Messaging via
-                                <a
-                                    id="deactivate-link"
-                                    href="https://www.kommunicate.io/poweredby"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    Kommunicate chatbot
-                                </a>
+                                <span id="deactivate-link">Kommunicate chatbot</span>
                                 is disabled for this account. To enable, please contact the admin of
                                 the website. If you are the admin, get in touch at
                                 <a href="mailto:support@kommunicate.io">support@kommunicate.io</a>

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -389,12 +389,7 @@
                             <span id="km-churn-banner-text">Account inactive</span>
                         </div>
                         <div class="km-churn-content">
-                            <p id="km-churn-notice" class="km-churn-message">
-                                Chat has been disabled for this website. Visitors: Please contact
-                                the website owner using another contact method. Website
-                                administrators: If you need help restoring chat, contact Kommunicate
-                                Support.
-                            </p>
+                            <p id="km-churn-notice" class="km-churn-message"></p>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Remove the external “Kommunicate chatbot” hyperlink from the inactive account banner

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 
<img width="603" height="818" alt="image" src="https://github.com/user-attachments/assets/34ce3287-849d-40f3-9896-0908b869d5d9" />

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Reworked the inactive account/churn notice to remove clickable outbound links and replace them with a highlighted, HTML-formatted message that separately guides **Visitors** and **Website administrators**.
  * Updated the churn notice label content across English and all supported locales with the new wording.
  * Simplified the churn modal behavior so it no longer generates or injects a deactivation navigation link.
  * Added styling for highlighted churn message text and label emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->