### PR TITLE
km-input-voice-metadata-issue

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5751,6 +5751,7 @@ const firstVisibleMsg = {
                     resolvedMetadata.KM_INPUT_TYPE ||
                     typeof mckVoice === 'undefined' ||
                     !mckVoice ||
+                    typeof mckVoice.isVoiceModeActive !== 'function' ||
                     !mckVoice.isVoiceModeActive() ||
                     !messagePxy.message ||
                     messagePxy.fileMeta

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5745,6 +5745,22 @@ const firstVisibleMsg = {
                 );
             };
 
+            _this.updateMessageMetadataForVoiceInput = function (messagePxy, metadata) {
+                var resolvedMetadata = metadata || {};
+                if (
+                    resolvedMetadata.KM_INPUT_TYPE ||
+                    typeof mckVoice === 'undefined' ||
+                    !mckVoice ||
+                    !mckVoice.isVoiceModeActive() ||
+                    !messagePxy.message ||
+                    messagePxy.fileMeta
+                ) {
+                    return resolvedMetadata;
+                }
+                resolvedMetadata.KM_INPUT_TYPE = 'VOICE';
+                return resolvedMetadata;
+            };
+
             _this.submitMessage = function (messagePxy, optns) {
                 var randomId = messagePxy.key;
                 var metadata = messagePxy.metadata ? messagePxy.metadata : {};
@@ -5766,6 +5782,7 @@ const firstVisibleMsg = {
                     "#mck-message-cell .mck-message-inner div[name='message']." + randomId
                 );
 
+                metadata = _this.updateMessageMetadataForVoiceInput(messagePxy, metadata);
                 $applozic.extend(metadata, {
                     KM_CHAT_CONTEXT: JSON.stringify(_this.getChatContext(messagePxy)),
                 });

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5747,17 +5747,12 @@ const firstVisibleMsg = {
 
             _this.updateMessageMetadataForVoiceInput = function (messagePxy, metadata) {
                 var resolvedMetadata = metadata || {};
-                if (
-                    resolvedMetadata.KM_INPUT_TYPE ||
-                    typeof mckVoice === 'undefined' ||
-                    !mckVoice ||
-                    !mckVoice.isVoiceModeActive() ||
-                    !messagePxy.message ||
-                    messagePxy.fileMeta
-                ) {
+                if (resolvedMetadata.KM_INPUT_TYPE || !messagePxy.message || messagePxy.fileMeta) {
                     return resolvedMetadata;
                 }
-                resolvedMetadata.KM_INPUT_TYPE = 'VOICE';
+                if (typeof mckVoice !== 'undefined' && mckVoice && mckVoice.isVoiceModeActive()) {
+                    resolvedMetadata.KM_INPUT_TYPE = 'VOICE';
+                }
                 return resolvedMetadata;
             };
 

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -5751,7 +5751,6 @@ const firstVisibleMsg = {
                     resolvedMetadata.KM_INPUT_TYPE ||
                     typeof mckVoice === 'undefined' ||
                     !mckVoice ||
-                    typeof mckVoice.isVoiceModeActive !== 'function' ||
                     !mckVoice.isVoiceModeActive() ||
                     !messagePxy.message ||
                     messagePxy.fileMeta

--- a/webplugin/js/app/voice/mck-voice.js
+++ b/webplugin/js/app/voice/mck-voice.js
@@ -4156,11 +4156,6 @@ class MckVoice {
             message: trimmedMessage,
             groupId: CURRENT_GROUP_DATA.tabId,
         };
-        if (this.isVoiceModeActive()) {
-            messagePayload.metadata = {
-                KM_INPUT_TYPE: 'VOICE',
-            };
-        }
         kommunicate.sendMessage(messagePayload);
         return true;
     }


### PR DESCRIPTION
### What do you want to achieve?
- Fix voice-mode message metadata so CTA/button-triggered sends also include `KM_INPUT_TYPE: "VOICE"` when voice chat is active.

### PR Checklist
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
- 

### What new thing you came across while writing this code?
-

### In case you fixed a bug then please describe the root cause of it?
- 

### Screenshot
- N/A for this change. The expected verification is in the request payload: button/CTA sends in active voice mode should now include both `KM_CHAT_CONTEXT` and `KM_INPUT_TYPE: "VOICE"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of voice input so outgoing chat messages correctly reflect voice mode when active.
  * Ensures messages are not unintentionally tagged: if a message has no text or includes attachments, existing metadata is preserved and no voice tagging is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->