### PR TITLE
TDH-4073 render follow-up message styles

### DIFF
--- a/webplugin/css/app/style.css
+++ b/webplugin/css/app/style.css
@@ -4198,19 +4198,66 @@ div#mck-rated:before {
 
 .km-header-cta {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: none;
   color: white;
-  height: 15px;
+  height: 32px;
   background-color: transparent;
-  width: auto;
+  width: 32px;
+  min-width: 32px;
+  padding: 0;
+  border-radius: 10px;
   font-size: 16px !important;
   cursor: pointer;
-  line-height: 15px !important;
-  white-space: nowrap;
+  line-height: 0 !important;
+  flex-shrink: 0;
+}
+.km-header-cta svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+}
+.km-header-cta#km-talk-to-human svg {
+  transform: translateY(3px);
 }
 .km-header-cta .restart-conversation-icon {
   margin-top: -4px;
+}
+.km-header-cta:hover .tooltip-text, .km-header-cta:focus-visible .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+.km-header-cta .tooltip-text {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  visibility: hidden;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(15, 23, 42, 0.96);
+  color: #ffffff;
+  border-radius: 8px;
+  text-align: center;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  padding: 6px 10px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.km-header-cta .tooltip-text::before {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent rgba(15, 23, 42, 0.96) transparent;
 }
 
 /* -----------------Support for hiding list and buttons post call to action------------- */

--- a/webplugin/js/app/km-bottom-tabs.js
+++ b/webplugin/js/app/km-bottom-tabs.js
@@ -21,13 +21,20 @@
         }
 
         function getBottomFaqRedirectConfig() {
-            var appOptions =
-                appOptionSession.getPropertyDataFromSession('appOptions') || applozic._globals;
-            var appSettings = appOptions.appSettings || {};
-            var url = appSettings.bottomFaqRedirectUrl || appOptions.bottomFaqRedirectUrl;
+            var sessionOptions = appOptionSession.getPropertyDataFromSession('appOptions') || {};
+            var globalOptions = (w.applozic && w.applozic._globals) || {};
+            var sessionSettings = sessionOptions.appSettings || {};
+            var globalSettings = globalOptions.appSettings || {};
+            var url =
+                sessionSettings.bottomFaqRedirectUrl ||
+                sessionOptions.bottomFaqRedirectUrl ||
+                globalSettings.bottomFaqRedirectUrl ||
+                globalOptions.bottomFaqRedirectUrl;
             var target =
-                appSettings.bottomFaqRedirectTarget ||
-                appOptions.bottomFaqRedirectTarget ||
+                sessionSettings.bottomFaqRedirectTarget ||
+                sessionOptions.bottomFaqRedirectTarget ||
+                globalSettings.bottomFaqRedirectTarget ||
+                globalOptions.bottomFaqRedirectTarget ||
                 '_blank';
 
             url = typeof url === 'string' ? url.trim() : '';
@@ -47,10 +54,6 @@
                     return;
                 }
                 if (target === '_self') {
-                    if (w.parent && w.parent !== w) {
-                        w.parent.location.href = url;
-                        return;
-                    }
                     w.location.href = url;
                     return;
                 }

--- a/webplugin/js/app/km-bottom-tabs.js
+++ b/webplugin/js/app/km-bottom-tabs.js
@@ -19,6 +19,45 @@
         function getKommunicateUI() {
             return params.KommunicateUI || w.KommunicateUI;
         }
+
+        function getBottomFaqRedirectConfig() {
+            var appOptions =
+                appOptionSession.getPropertyDataFromSession('appOptions') || applozic._globals;
+            var appSettings = appOptions.appSettings || {};
+            var url = appSettings.bottomFaqRedirectUrl || appOptions.bottomFaqRedirectUrl;
+            var target =
+                appSettings.bottomFaqRedirectTarget ||
+                appOptions.bottomFaqRedirectTarget ||
+                '_blank';
+
+            url = typeof url === 'string' ? url.trim() : '';
+            target = typeof target === 'string' && target.trim() ? target.trim() : '_blank';
+
+            return { url: url, target: target };
+        }
+
+        function openBottomFaqRedirect(url, target) {
+            try {
+                if (target === '_top') {
+                    w.top.location.href = url;
+                    return;
+                }
+                if (target === '_parent') {
+                    w.parent.location.href = url;
+                    return;
+                }
+                if (target === '_self') {
+                    if (w.parent && w.parent !== w) {
+                        w.parent.location.href = url;
+                        return;
+                    }
+                    w.location.href = url;
+                    return;
+                }
+            } catch (e) {}
+
+            w.open(url, target, 'noopener,noreferrer');
+        }
         function getTopBarManager() {
             return params.topBarManager;
         }
@@ -404,6 +443,16 @@
             if (resolvedTabType === COLLAPSE_TAB_TYPE) {
                 handleCollapseAction();
                 return;
+            }
+            if (resolvedTabType === 'faqs' && options.userTriggered && !options.skipFaqTrigger) {
+                var bottomFaqRedirectConfig = getBottomFaqRedirectConfig();
+                if (bottomFaqRedirectConfig.url) {
+                    openBottomFaqRedirect(
+                        bottomFaqRedirectConfig.url,
+                        bottomFaqRedirectConfig.target
+                    );
+                    return;
+                }
             }
             setBottomTabState(resolvedTabType);
             showBottomTabs();

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -229,7 +229,7 @@ Kommunicate.markup = {
             `;
     },
     getGenericSuggestedReplyButton: function () {
-        return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-hidePostCTA="{{hidePostCTA}}">{{name}}</button>`;
+        return `<button aria-label="{{name}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{action.updateLanguage}}" data-hidePostCTA="{{hidePostCTA}}" style="{{buttonStyle}}">{{name}}</button>`;
     },
     getPassangerDetail: function (options) {
         if (!options.sessionId) {
@@ -628,13 +628,7 @@ Kommunicate.markup.getFormMarkup = function (options) {
         return formMarkup;
     }
 };
-Kommunicate.markup.quickRepliesContainerTemplate = function (options, template) {
-    var payload = JSON.parse(options.payload);
-    var buttonClass;
-    var hidePostCTA = kommunicate._globals.hidePostCTA;
-    var followUpMessageStyle = options.KM_FOLLOWUP_MESSAGE_STYLE;
-    var buttonStyle = '';
-
+var parseFollowUpMessageStyle = function (followUpMessageStyle) {
     if (typeof followUpMessageStyle === 'string') {
         try {
             followUpMessageStyle = JSON.parse(followUpMessageStyle);
@@ -643,26 +637,105 @@ Kommunicate.markup.quickRepliesContainerTemplate = function (options, template) 
         }
     }
 
-    if (followUpMessageStyle) {
-        buttonStyle = ['color', 'fontStyle', 'fontWeight', 'font-style', 'font-weight']
-            .reduce(function (styles, key) {
-                var value = followUpMessageStyle[key];
-                if (!value) {
-                    return styles;
-                }
+    return kommunicateCommons.isObject(followUpMessageStyle) ? followUpMessageStyle : null;
+};
 
-                var cssKey =
-                    key.indexOf('-') !== -1
-                        ? key
-                        : key.replace(/[A-Z]/g, function (match) {
-                              return '-' + match.toLowerCase();
-                          });
-
-                styles.push(cssKey + ':' + value);
-                return styles;
-            }, [])
-            .join(';');
+var sanitizeFollowUpColorValue = function (value) {
+    if (typeof value !== 'string') {
+        return '';
     }
+
+    value = value.trim();
+
+    return /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([0-9%,.\s/]+\)|[a-zA-Z]+)$/.test(value) ? value : '';
+};
+
+var sanitizeFollowUpFontStyleValue = function (value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    value = value.trim().toLowerCase();
+
+    return ['normal', 'italic', 'oblique'].indexOf(value) !== -1 ? value : '';
+};
+
+var sanitizeFollowUpFontWeightValue = function (value) {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+        return '';
+    }
+
+    value = String(value).trim().toLowerCase();
+
+    return /^(normal|bold|bolder|lighter|[1-9]00)$/.test(value) ? value : '';
+};
+
+var getFollowUpStyleValue = function (followUpMessageStyle, keys, sanitizer) {
+    for (var i = 0; i < keys.length; i++) {
+        var sanitizedValue = sanitizer(followUpMessageStyle[keys[i]]);
+        if (sanitizedValue) {
+            return sanitizedValue;
+        }
+    }
+
+    return '';
+};
+
+var getFollowUpButtonStyle = function (followUpMessageStyle) {
+    followUpMessageStyle = parseFollowUpMessageStyle(followUpMessageStyle);
+    var colorValue;
+
+    if (!followUpMessageStyle) {
+        return '';
+    }
+
+    colorValue = getFollowUpStyleValue(followUpMessageStyle, ['color'], sanitizeFollowUpColorValue);
+
+    return [
+        {
+            cssKey: 'color',
+            value: colorValue,
+        },
+        {
+            cssKey: 'font-style',
+            value: getFollowUpStyleValue(
+                followUpMessageStyle,
+                ['fontStyle', 'font-style'],
+                sanitizeFollowUpFontStyleValue
+            ),
+        },
+        {
+            cssKey: 'font-weight',
+            value: getFollowUpStyleValue(
+                followUpMessageStyle,
+                ['fontWeight', 'font-weight'],
+                sanitizeFollowUpFontWeightValue
+            ),
+        },
+        {
+            cssKey: 'border-color',
+            value:
+                getFollowUpStyleValue(
+                    followUpMessageStyle,
+                    ['borderColor', 'border-color'],
+                    sanitizeFollowUpColorValue
+                ) || colorValue,
+        },
+    ]
+        .reduce(function (styles, styleOption) {
+            if (styleOption.value) {
+                styles.push(styleOption.cssKey + ':' + styleOption.value);
+            }
+
+            return styles;
+        }, [])
+        .join(';');
+};
+Kommunicate.markup.quickRepliesContainerTemplate = function (options, template) {
+    var payload = JSON.parse(options.payload);
+    var buttonClass;
+    var hidePostCTA = kommunicate._globals.hidePostCTA;
+    var buttonStyle = getFollowUpButtonStyle(options.KM_FOLLOWUP_MESSAGE_STYLE);
 
     switch (template) {
         case KommunicateConstants.ACTIONABLE_MESSAGE_TEMPLATE.QUICK_REPLY:
@@ -1040,6 +1113,7 @@ Kommunicate.markup.getLinkTarget = function (buttonInfo) {
 Kommunicate.markup.getGenericButtonMarkup = function (metadata) {
     var buttonPayloadList = metadata.payload ? JSON.parse(metadata.payload) : [];
     var buttonContainerHtml = '<div class="km-cta-multi-button-container">';
+    var buttonStyle = getFollowUpButtonStyle(metadata.KM_FOLLOWUP_MESSAGE_STYLE);
     var buttonClass =
         ' km-custom-widget-border-color ' +
         (buttonPayloadList.length == 1
@@ -1076,6 +1150,7 @@ Kommunicate.markup.getGenericButtonMarkup = function (metadata) {
                 }));
         } else if (singlePayload.type == 'quickReply' || singlePayload.type == 'suggestedReply') {
             singlePayload.buttonClass = 'km-quick-rpy-btn ' + buttonClass;
+            singlePayload.buttonStyle = buttonStyle;
             singlePayload.message = singlePayload.action.message || singlePayload.name;
             singlePayload.type == 'quickReply' &&
                 (singlePayload.hidePostCTA = kommunicate._globals.hidePostCTA);

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -641,30 +641,18 @@ var parseFollowUpMessageStyle = function (followUpMessageStyle) {
 };
 
 var sanitizeFollowUpColorValue = function (value) {
-    if (typeof value !== 'string') {
-        return '';
-    }
-
-    value = value.trim();
+    value = String(value).trim();
 
     return /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([0-9%,.\s/]+\)|[a-zA-Z]+)$/.test(value) ? value : '';
 };
 
 var sanitizeFollowUpFontStyleValue = function (value) {
-    if (typeof value !== 'string') {
-        return '';
-    }
-
-    value = value.trim().toLowerCase();
+    value = String(value).trim().toLowerCase();
 
     return ['normal', 'italic', 'oblique'].indexOf(value) !== -1 ? value : '';
 };
 
 var sanitizeFollowUpFontWeightValue = function (value) {
-    if (typeof value !== 'string' && typeof value !== 'number') {
-        return '';
-    }
-
     value = String(value).trim().toLowerCase();
 
     return /^(normal|bold|bolder|lighter|[1-9]00)$/.test(value) ? value : '';

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -224,7 +224,7 @@ Kommunicate.markup = {
     getQuickRepliesTemplate: function () {
         return `
             {{#payload}}
-                 <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-hidePostCTA="{{hidePostCTA}}">{{title}}</button>
+                 <button aria-label="{{title}}" title='{{message}}' class="km-quick-replies km-custom-widget-text-color {{buttonClass}} " data-metadata = "{{replyMetadata}}" data-languageCode = "{{updateLanguage}}" data-hidePostCTA="{{hidePostCTA}}" style="{{buttonStyle}}">{{title}}</button>
             {{/payload}}
             `;
     },
@@ -632,6 +632,38 @@ Kommunicate.markup.quickRepliesContainerTemplate = function (options, template) 
     var payload = JSON.parse(options.payload);
     var buttonClass;
     var hidePostCTA = kommunicate._globals.hidePostCTA;
+    var followUpMessageStyle = options.KM_FOLLOWUP_MESSAGE_STYLE;
+    var buttonStyle = '';
+
+    if (typeof followUpMessageStyle === 'string') {
+        try {
+            followUpMessageStyle = JSON.parse(followUpMessageStyle);
+        } catch (e) {
+            followUpMessageStyle = null;
+        }
+    }
+
+    if (followUpMessageStyle) {
+        buttonStyle = ['color', 'fontStyle', 'fontWeight', 'font-style', 'font-weight']
+            .reduce(function (styles, key) {
+                var value = followUpMessageStyle[key];
+                if (!value) {
+                    return styles;
+                }
+
+                var cssKey =
+                    key.indexOf('-') !== -1
+                        ? key
+                        : key.replace(/[A-Z]/g, function (match) {
+                              return '-' + match.toLowerCase();
+                          });
+
+                styles.push(cssKey + ':' + value);
+                return styles;
+            }, [])
+            .join(';');
+    }
+
     switch (template) {
         case KommunicateConstants.ACTIONABLE_MESSAGE_TEMPLATE.QUICK_REPLY:
             buttonClass = 'km-quick-rpy-btn km-custom-widget-border-color ';
@@ -654,6 +686,7 @@ Kommunicate.markup.quickRepliesContainerTemplate = function (options, template) 
                 ? JSON.stringify(payload[i].replyMetadata)
                 : payload[i].replyMetadata;
         payload[i].buttonClass = buttonClass;
+        payload[i].buttonStyle = buttonStyle;
         payload[i].hidePostCTA = hidePostCTA;
     }
     return Mustache.to_html(Kommunicate.markup.getQuickRepliesTemplate(), {

--- a/webplugin/js/app/km-richtext-markup-1.0.js
+++ b/webplugin/js/app/km-richtext-markup-1.0.js
@@ -641,6 +641,9 @@ var parseFollowUpMessageStyle = function (followUpMessageStyle) {
 };
 
 var sanitizeFollowUpColorValue = function (value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
     value = String(value).trim();
 
     return /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([0-9%,.\s/]+\)|[a-zA-Z]+)$/.test(value) ? value : '';

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6904,6 +6904,32 @@ const firstVisibleMsg = {
                 return msg.message.replace(/<[^>]*>/g, '').trim();
             };
 
+            function getFollowUpMessageStyleExpr(metadata) {
+                var followUpMessageStyle = metadata && metadata.KM_FOLLOWUP_MESSAGE_STYLE;
+                if (!followUpMessageStyle) {
+                    return '';
+                }
+
+                return ['color', 'fontStyle', 'fontWeight', 'font-style', 'font-weight']
+                    .reduce(function (styles, key) {
+                        var value = followUpMessageStyle[key];
+                        if (!value) {
+                            return styles;
+                        }
+
+                        var cssKey =
+                            key.indexOf('-') !== -1
+                                ? key
+                                : key.replace(/[A-Z]/g, function (match) {
+                                      return '-' + match.toLowerCase();
+                                  });
+
+                        styles.push(cssKey + ':' + value);
+                        return styles;
+                    }, [])
+                    .join(';');
+            }
+
             var FILE_PREVIEW_URL = '/rest/ws/aws/file/';
             var CLOUD_HOST_URL = 'www.googleapis.com';
             var markup =
@@ -6924,7 +6950,7 @@ const firstVisibleMsg = {
                 '<div class="mck-msgreply-border ${textreplyVisExpr}">${msgReply}</div>' +
                 '<div class="mck-msgreply-border ${msgpreviewvisExpr}">{{html msgPreview}}</div>' +
                 '</div>' +
-                '<div class="mck-msg-text mck-msg-content notranslate" tabindex="-1">' +
+                '<div class="mck-msg-text mck-msg-content notranslate" tabindex="-1" style="${followUpMessageStyleExpr}">' +
                 '<div class="mck-msg-feedback-sticker ${showFeedbackSticker}">{{html feedbackStickerExpr}}</div>' +
                 '</div>' +
                 '</div>' +
@@ -8250,6 +8276,7 @@ const firstVisibleMsg = {
                         downloadMediaUrlExpr: alFileService.getFileAttachment(msg),
                         msgClassExpr: messageClass,
                         msgBoxColor: msgBoxColorStyle,
+                        followUpMessageStyleExpr: getFollowUpMessageStyleExpr(msg.metadata),
                         progressMeterClassExpr: progressMeterClass,
                         attachmentBoxExpr: attachmentBox,
                         msgExpr: frwdMsgExpr,

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -7218,9 +7218,12 @@ const firstVisibleMsg = {
                     : MCK_LABELS['header.primary.CTA'][currentCTAKey];
 
                 buttonPrimary.innerHTML =
-                    '<span class="tooltip-text n-vis"></span>' +
+                    '<span class="tooltip-text">' +
+                    toolTipText +
+                    '</span>' +
                     (nestedKey ? currentCTA.icon[nestedKey] : currentCTA.icon);
 
+                buttonPrimary.setAttribute('aria-label', toolTipText);
                 buttonPrimary.setAttribute('title', toolTipText);
                 buttonPrimary.id = currentCTA.id;
             };

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6919,11 +6919,7 @@ const firstVisibleMsg = {
             }
 
             function sanitizeFollowUpColorValue(value) {
-                if (typeof value !== 'string') {
-                    return '';
-                }
-
-                value = value.trim();
+                value = String(value).trim();
 
                 return /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([0-9%,.\s/]+\)|[a-zA-Z]+)$/.test(value)
                     ? value
@@ -6931,20 +6927,12 @@ const firstVisibleMsg = {
             }
 
             function sanitizeFollowUpFontStyleValue(value) {
-                if (typeof value !== 'string') {
-                    return '';
-                }
-
-                value = value.trim().toLowerCase();
+                value = String(value).trim().toLowerCase();
 
                 return ['normal', 'italic', 'oblique'].indexOf(value) !== -1 ? value : '';
             }
 
             function sanitizeFollowUpFontWeightValue(value) {
-                if (typeof value !== 'string' && typeof value !== 'number') {
-                    return '';
-                }
-
                 value = String(value).trim().toLowerCase();
 
                 return /^(normal|bold|bolder|lighter|[1-9]00)$/.test(value) ? value : '';
@@ -7004,6 +6992,25 @@ const firstVisibleMsg = {
                     .join(';');
             }
 
+            function getFollowUpMessageBubbleStyleExpr(metadata) {
+                var followUpMessageStyle = parseFollowUpMessageStyle(
+                    metadata && metadata.KM_FOLLOWUP_MESSAGE_STYLE
+                );
+                var backgroundColor;
+
+                if (!followUpMessageStyle) {
+                    return '';
+                }
+
+                backgroundColor = getFollowUpStyleValue(
+                    followUpMessageStyle,
+                    ['backgroundColor', 'background-color'],
+                    sanitizeFollowUpColorValue
+                );
+
+                return backgroundColor ? 'background-color:' + backgroundColor : '';
+            }
+
             var FILE_PREVIEW_URL = '/rest/ws/aws/file/';
             var CLOUD_HOST_URL = 'www.googleapis.com';
             var markup =
@@ -7015,7 +7022,7 @@ const firstVisibleMsg = {
                 '<div class="mck-msg-avator blk-lg-3">{{html msgImgExpr}}</div>' +
                 '<div class ="km-conversation-container-right ${kmAttchMsg}">' +
                 '<div class="km-msg-box-attachment ${attachmentBoxExpr} ">{{html attachmentTemplate}}<div class="km-msg-box-progressMeter ${progressMeterClassExpr} ">{{html progressMeter}}</div></div>' +
-                '<div class="mck-msg-box ${msgClassExpr} ${msgBoxColor}">' +
+                '<div class="mck-msg-box ${msgClassExpr} ${msgBoxColor}" style="${followUpMessageBubbleStyleExpr}">' +
                 '<div class="move-right mck-msg-text"></div>' +
                 '<div class="mck-msg-reply mck-vertical-line ${msgReplyToVisibleExpr}">' +
                 '<div class="mck-msgto">${msgReplyTo} </div>' +
@@ -8351,6 +8358,9 @@ const firstVisibleMsg = {
                         msgClassExpr: messageClass,
                         msgBoxColor: msgBoxColorStyle,
                         followUpMessageStyleExpr: getFollowUpMessageStyleExpr(msg.metadata),
+                        followUpMessageBubbleStyleExpr: getFollowUpMessageBubbleStyleExpr(
+                            msg.metadata
+                        ),
                         progressMeterClassExpr: progressMeterClass,
                         attachmentBoxExpr: attachmentBox,
                         msgExpr: frwdMsgExpr,

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6919,6 +6919,9 @@ const firstVisibleMsg = {
             }
 
             function sanitizeFollowUpColorValue(value) {
+                if (value === undefined || value === null) {
+                    return '';
+                }
                 value = String(value).trim();
 
                 return /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([0-9%,.\s/]+\)|[a-zA-Z]+)$/.test(value)
@@ -7217,11 +7220,12 @@ const firstVisibleMsg = {
                     ? MCK_LABELS['header.primary.CTA'][currentCTAKey][nestedKey]
                     : MCK_LABELS['header.primary.CTA'][currentCTAKey];
 
-                buttonPrimary.innerHTML =
-                    '<span class="tooltip-text">' +
-                    toolTipText +
-                    '</span>' +
-                    (nestedKey ? currentCTA.icon[nestedKey] : currentCTA.icon);
+                buttonPrimary.innerHTML = nestedKey ? currentCTA.icon[nestedKey] : currentCTA.icon;
+
+                var tooltipTextNode = document.createElement('span');
+                tooltipTextNode.className = 'tooltip-text';
+                tooltipTextNode.textContent = toolTipText;
+                buttonPrimary.insertBefore(tooltipTextNode, buttonPrimary.firstChild);
 
                 buttonPrimary.setAttribute('aria-label', toolTipText);
                 buttonPrimary.setAttribute('title', toolTipText);

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6910,6 +6910,14 @@ const firstVisibleMsg = {
                     return '';
                 }
 
+                if (typeof followUpMessageStyle === 'string') {
+                    try {
+                        followUpMessageStyle = JSON.parse(followUpMessageStyle);
+                    } catch (e) {
+                        return '';
+                    }
+                }
+
                 return ['color', 'fontStyle', 'fontWeight', 'font-style', 'font-weight']
                     .reduce(function (styles, key) {
                         var value = followUpMessageStyle[key];

--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -6904,35 +6904,101 @@ const firstVisibleMsg = {
                 return msg.message.replace(/<[^>]*>/g, '').trim();
             };
 
-            function getFollowUpMessageStyleExpr(metadata) {
-                var followUpMessageStyle = metadata && metadata.KM_FOLLOWUP_MESSAGE_STYLE;
-                if (!followUpMessageStyle) {
-                    return '';
-                }
-
+            function parseFollowUpMessageStyle(followUpMessageStyle) {
                 if (typeof followUpMessageStyle === 'string') {
                     try {
                         followUpMessageStyle = JSON.parse(followUpMessageStyle);
                     } catch (e) {
-                        return '';
+                        return null;
                     }
                 }
 
-                return ['color', 'fontStyle', 'fontWeight', 'font-style', 'font-weight']
-                    .reduce(function (styles, key) {
-                        var value = followUpMessageStyle[key];
-                        if (!value) {
-                            return styles;
+                return kommunicateCommons.isObject(followUpMessageStyle)
+                    ? followUpMessageStyle
+                    : null;
+            }
+
+            function sanitizeFollowUpColorValue(value) {
+                if (typeof value !== 'string') {
+                    return '';
+                }
+
+                value = value.trim();
+
+                return /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([0-9%,.\s/]+\)|[a-zA-Z]+)$/.test(value)
+                    ? value
+                    : '';
+            }
+
+            function sanitizeFollowUpFontStyleValue(value) {
+                if (typeof value !== 'string') {
+                    return '';
+                }
+
+                value = value.trim().toLowerCase();
+
+                return ['normal', 'italic', 'oblique'].indexOf(value) !== -1 ? value : '';
+            }
+
+            function sanitizeFollowUpFontWeightValue(value) {
+                if (typeof value !== 'string' && typeof value !== 'number') {
+                    return '';
+                }
+
+                value = String(value).trim().toLowerCase();
+
+                return /^(normal|bold|bolder|lighter|[1-9]00)$/.test(value) ? value : '';
+            }
+
+            function getFollowUpStyleValue(followUpMessageStyle, keys, sanitizer) {
+                for (var i = 0; i < keys.length; i++) {
+                    var sanitizedValue = sanitizer(followUpMessageStyle[keys[i]]);
+                    if (sanitizedValue) {
+                        return sanitizedValue;
+                    }
+                }
+
+                return '';
+            }
+
+            function getFollowUpMessageStyleExpr(metadata) {
+                var followUpMessageStyle = parseFollowUpMessageStyle(
+                    metadata && metadata.KM_FOLLOWUP_MESSAGE_STYLE
+                );
+                var styleConfig = [
+                    {
+                        keys: ['color'],
+                        cssKey: 'color',
+                        sanitizer: sanitizeFollowUpColorValue,
+                    },
+                    {
+                        keys: ['fontStyle', 'font-style'],
+                        cssKey: 'font-style',
+                        sanitizer: sanitizeFollowUpFontStyleValue,
+                    },
+                    {
+                        keys: ['fontWeight', 'font-weight'],
+                        cssKey: 'font-weight',
+                        sanitizer: sanitizeFollowUpFontWeightValue,
+                    },
+                ];
+
+                if (!followUpMessageStyle) {
+                    return '';
+                }
+
+                return styleConfig
+                    .reduce(function (styles, styleOption) {
+                        var value = getFollowUpStyleValue(
+                            followUpMessageStyle,
+                            styleOption.keys,
+                            styleOption.sanitizer
+                        );
+
+                        if (value) {
+                            styles.push(styleOption.cssKey + ':' + value);
                         }
 
-                        var cssKey =
-                            key.indexOf('-') !== -1
-                                ? key
-                                : key.replace(/[A-Z]/g, function (match) {
-                                      return '-' + match.toLowerCase();
-                                  });
-
-                        styles.push(cssKey + ':' + value);
                         return styles;
                     }, [])
                     .join(';');

--- a/webplugin/scss/components/_km-header.scss
+++ b/webplugin/scss/components/_km-header.scss
@@ -1,53 +1,72 @@
 .km-header-cta {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: none;
     color: white;
-    height: 15px;
+    height: 32px;
     background-color: transparent;
-    width: auto;
+    width: 32px;
+    min-width: 32px;
+    padding: 0;
+    border-radius: 10px;
     font-size: 16px !important;
-    // padding: 10px;
-    // border-radius: 6px;
     cursor: pointer;
-    line-height: 15px !important;
-    white-space: nowrap;
+    line-height: 0 !important;
+    flex-shrink: 0;
+
+    svg {
+        width: 20px;
+        height: 20px;
+        display: block;
+    }
+
+    &#km-talk-to-human svg {
+        transform: translateY(3px);
+    }
+
     .restart-conversation-icon {
         margin-top: -4px;
     }
-    // &:hover .tooltip-text {
-    //     visibility: visible;
-    //     opacity: 1;
-    // }
-    // & .tooltip-text {
-    //     font-size: 14px;
-    //     visibility: hidden;
-    //     position: absolute;
-    //     background-color: $text-primary-color;
-    //     color: $text-secondary-color;
-    //     border-radius: 2px;
-    //     text-align: center;
-    //     z-index: 1; /* Ensure the tooltip is on top of other elements */
-    //     opacity: 0;
-    //     transition: opacity 0.3s;
-    //     /* Center the tooltip using translate */
-    //     transform: translate(-50%, -50%);
-    //     top: 160%;
-    //     left: 50%;
-    //     padding: 8px 16px;
 
-    //     &::after {
-    //         content: '';
-    //         position: absolute;
-    //         bottom: 100%;
-    //         left: 50%;
-    //         margin-left: -5px;
-    //         border-width: 5px;
-    //         border-style: solid;
-    //         border-color: transparent transparent $text-primary-color
-    //             transparent;
-    //     }
-    // }
+    &:hover .tooltip-text,
+    &:focus-visible .tooltip-text {
+        visibility: visible;
+        opacity: 1;
+    }
+
+    .tooltip-text {
+        font-size: 12px;
+        font-weight: 500;
+        line-height: 1.2;
+        visibility: hidden;
+        position: absolute;
+        top: calc(100% + 8px);
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: rgba(15, 23, 42, 0.96);
+        color: #ffffff;
+        border-radius: 8px;
+        text-align: center;
+        z-index: 2;
+        opacity: 0;
+        transition: opacity 0.2s ease;
+        padding: 6px 10px;
+        white-space: nowrap;
+        pointer-events: none;
+
+        &::before {
+            content: '';
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            border-width: 5px;
+            border-style: solid;
+            border-color: transparent transparent rgba(15, 23, 42, 0.96) transparent;
+        }
+    }
 }
 // header close button
 // #km-chat-widget-close-button {

--- a/webplugin/template/mck-sidebox.html
+++ b/webplugin/template/mck-sidebox.html
@@ -112,7 +112,7 @@
                                 tabindex="0"
                                 role="button"
                             >
-                                <span class="tooltip-text n-vis"></span>
+                                <span class="tooltip-text"></span>
                             </button>
                         </div>
                         <div class="mck-dropdown n-vis" id="km-widget-options">


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Render follow-up message styles from bot metadata in the Web SDK for both the follow-up text and follow-up quick reply / suggested reply buttons.
- Address the existing CodeRabbit review feedback by validating and sanitizing inline style values before rendering them.
- Document the client-specific custom CSS approach for increasing the Talk to Human button height, font styling, and icon size without changing the default experience for everyone.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
- 

### What new thing you came across while writing this code? 
- The follow-up text and follow-up actionable buttons are rendered through different markup paths in the widget, so both flows need to stay aligned when adding any metadata-driven styling.

### In case you fixed a bug then please describe the root cause of it? 
- The initial implementation only handled part of the follow-up UI and was directly interpolating metadata values into inline styles. Because of that, button styling was incomplete and the review feedback around style sanitization remained valid.

### Screenshot
- <img width="289" height="173" alt="image" src="https://github.com/user-attachments/assets/7cc9d615-23cc-4d24-b59c-cac910bff42b" />

### Notes
- Client-specific Talk to Human sizing can be done with widget custom CSS. Example:

```css
#km-talk-to-human,
.km-option-talk-to-human,
.km-talk-to-human-div .talk-to-human-link {
  min-height: 44px !important;
  padding: 10px 14px !important;
  font-size: 14px !important;
  font-weight: 600 !important;
  line-height: 1.2 !important;
}

#km-talk-to-human svg,
.km-option-talk-to-human svg,
.km-talk-to-human-div .talk-to-human-link svg {
  width: 28px !important;
  height: 28px !important;
  min-width: 28px !important;
  min-height: 28px !important;
}
```

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom per-message follow-up styling from message metadata (text color/font style/font weight) and bubble background color.
  * Updated quick-reply and suggested-reply buttons to support metadata-driven inline styling.
  * Enhanced Bottom Tabs so FAQ navigation can redirect to an externally configured URL/target without switching the tab UI.
* **Bug Fixes**
  * Improved the header primary CTA tooltip behavior and accessibility by rendering the tooltip text and setting the CTA `aria-label` accordingly.
* **UI Improvements**
  * Refreshed header CTA button styling (fixed 32px layout) and tooltip presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->