### PR TITLE
Fix widget foreground color mapping

### DIFF
--- a/webplugin/js/app/kommunicate.custom.theme.js
+++ b/webplugin/js/app/kommunicate.custom.theme.js
@@ -36,6 +36,8 @@ function KmCustomTheme() {
         primaryColor: '--km-accent',
         primaryColorRgb: '--km-accent-rgb',
         chatHeaderBackground: '--km-widget-header-background',
+        primaryForeground: '--km-on-primary',
+        primaryForegroundColor: '--km-on-primary',
         onPrimary: '--km-on-primary',
         onPrimaryLink: '--km-on-primary-link',
         primaryVariant: '--km-primary-variant',
@@ -63,6 +65,19 @@ function KmCustomTheme() {
 
     function hasThemeValue(value) {
         return value != null && String(value).trim().length > 0;
+    }
+
+    function mergeThemeOverrides(overrides, source, aliasOnly) {
+        if (!kommunicateCommons.isObject(source)) {
+            return;
+        }
+        Object.keys(source).forEach(function (key) {
+            var resolvedKey = THEME_VARIABLE_ALIASES[key] || key;
+            if (aliasOnly && resolvedKey === key && key.indexOf('--km-') !== 0) {
+                return;
+            }
+            overrides[resolvedKey] = source[key];
+        });
     }
 
     _this.init = function (optns) {
@@ -217,14 +232,19 @@ function KmCustomTheme() {
             WIDGET_SETTINGS.themeVars,
         ];
         var overrides = {};
+        mergeThemeOverrides(overrides, WIDGET_SETTINGS, true);
         overrideSources.forEach(function (source) {
-            if (kommunicateCommons.isObject(source)) {
-                Object.keys(source).forEach(function (key) {
-                    var resolvedKey = THEME_VARIABLE_ALIASES[key] || key;
-                    overrides[resolvedKey] = source[key];
-                });
-            }
+            mergeThemeOverrides(overrides, source, false);
         });
+        var resolvedForeground =
+            overrides['--km-on-primary'] || overrides['--km-custom-widget-contrast-color'];
+        if (hasThemeValue(resolvedForeground)) {
+            overrides['--km-on-primary'] = overrides['--km-on-primary'] || resolvedForeground;
+            overrides['--km-on-primary-link'] =
+                overrides['--km-on-primary-link'] || overrides['--km-on-primary'];
+            overrides['--km-custom-widget-contrast-color'] =
+                overrides['--km-custom-widget-contrast-color'] || overrides['--km-on-primary'];
+        }
         if (isClassicLayout() && !hasThemeValue(overrides['--km-on-primary'])) {
             console.log('overriding --km-on-primary for classic layout');
             overrides['--km-on-primary'] = '#ffffff';


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
-Fix widget header foreground color handling so explicitly configured primary foreground colors are correctly applied in the web widget, while preserving the old fallback behavior for existing customers who do not provide a foreground override.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [X] I have tested it locally and all functionalities are working fine.
- [X] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-The root cause was a theme mapping mismatch. The dashboard/customizer was saving the primary foreground color correctly, but the widget theme code was only resolving a limited set of keys from nested theme objects. Because of that, the explicit foreground color was not propagated to the header variables, and the widget fell back to the older contrast-based logic, which produced black text/icons on the red header.

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing primary foreground colors through theme settings.
  - Theme customization now keeps primary, link, and contrast colors synchronized when a foreground color is specified.
  - Widget-level theme overrides are applied consistently alongside configured theme settings.

- **Bug Fixes**
  - Improved validation and handling of theme customization values to prevent invalid overrides from affecting the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->