### PR TITLE
Zopim error fix

### DIFF
--- a/webplugin/js/app/zendesk-chat-service.js
+++ b/webplugin/js/app/zendesk-chat-service.js
@@ -83,7 +83,6 @@ function ZendeskChatService() {
                 };
             }
             zChat.init(zendeskInitOptions);
-            _this.updateVisitorPath();
             zChat.on('connection_update', _this.handleZopimConnectedStatus);
             zChat.on('chat', _this.zopimEvents);
         }
@@ -93,6 +92,7 @@ function ZendeskChatService() {
         if (status === 'connected') {
             ZENDESK_SDK_CONNECTED = true;
             console.log('SDK Connected');
+            _this.updateVisitorPath();
             messagesInBuffer.length &&
                 messagesInBuffer.map((messageEvent) => {
                     console.log('handleUserMessage: ', messageEvent);


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Call updateVisitorPath() only after Zendesk Chat Web SDK reports connection_update === 'connected'.
Prevents sendVisitorPath: Web SDK is not initialized yet when visitor path was sent immediately after zChat.init().

This error is coming for customer. And we have only 1 customer of zendesk zopim.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch
