### PR TITLE
fix(TDH-4110): refresh active assignee status

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -3719,6 +3719,7 @@ const firstVisibleMsg = {
 
         function MckMessageService() {
             var _this = this;
+            var assigneeAvailabilityRefreshTimer;
             var $mck_search = $applozic('#mck-search');
             var $mck_msg_to = $applozic('#mck-msg-to');
             var $mck_msg_new = $applozic('#mck-msg-new');
@@ -6597,6 +6598,38 @@ const firstVisibleMsg = {
                     data.roleType !== KommunicateConstants.APPLOZIC_USER_ROLE_TYPE.BOT
                 );
                 _this.processOnlineStatusChange(tabId, data, updateConversationHeaderParams);
+            };
+            _this.refreshAssigneeAvailability = function (tabId) {
+                clearTimeout(assigneeAvailabilityRefreshTimer);
+                assigneeAvailabilityRefreshTimer = setTimeout(function () {
+                    var assigneeId = CURRENT_GROUP_DATA.conversationAssignee;
+                    if (
+                        !assigneeId ||
+                        CURRENT_GROUP_DATA.tabId != tabId ||
+                        CURRENT_GROUP_DATA.isConversationAssigneeBot
+                    ) {
+                        return;
+                    }
+
+                    mckContactService.getUsersDetail([assigneeId], {
+                        cached: false,
+                        callback: function (result) {
+                            if (
+                                CURRENT_GROUP_DATA.tabId != tabId ||
+                                CURRENT_GROUP_DATA.conversationAssignee != assigneeId ||
+                                !result ||
+                                !result.data ||
+                                !result.data.response
+                            ) {
+                                return;
+                            }
+                            var assigneeDetail = result.data.response.find(function (userDetail) {
+                                return userDetail.userId == assigneeId;
+                            });
+                            assigneeDetail && _this.updateAssigneeDetails(assigneeDetail, tabId);
+                        },
+                    });
+                }, 250);
             };
             _this.processOnlineStatusChange = function (
                 tabId,
@@ -12753,6 +12786,15 @@ const firstVisibleMsg = {
                             }
                         } else if (messageType === 'APPLOZIC_02') {
                             Kommunicate.KmEventHandler.onMessageSent(message);
+                        }
+                        if (
+                            (messageType === 'APPLOZIC_01' ||
+                                messageType === 'MESSAGE_RECEIVED' ||
+                                messageType === 'APPLOZIC_02') &&
+                            message.groupId &&
+                            message.groupId == CURRENT_GROUP_DATA.tabId
+                        ) {
+                            mckMessageService.refreshAssigneeAvailability(message.groupId);
                         }
                         if (typeof contact === 'undefined') {
                             var params = {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?

## Summary

Refreshes the active conversation assignee’s availability status after messages are sent or received.

## Problem

The widget cached the agent details returned by `/rest/ws/user/v2/detail`.

When a Super Admin changed the assigned agent’s status, the widget continued showing the previous status for an existing conversation. The correct status appeared only after refreshing the page or starting a new chat.

## Changes

- Re-fetches the active human assignee’s details after sent and received message events.
- Bypasses the cached user details for this refresh.
- Updates the conversation header with the latest Online/Offline status.
- Debounces duplicate message events to avoid unnecessary requests.
- Prevents stale responses from updating a different conversation.
- Skips availability refreshes for bot assignees.
-

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assignee availability details now refresh automatically when relevant conversation updates are received.
  * Updates are delayed briefly to prevent unnecessary refreshes and avoid showing outdated assignee information.
  * Refreshes apply only to the active conversation and current assignee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->