### PR TITLE
TDH-3449-Welcome message ordering issue

### DIFF
--- a/webplugin/js/app/mck-sidebox-1.0.js
+++ b/webplugin/js/app/mck-sidebox-1.0.js
@@ -8281,9 +8281,27 @@ const firstVisibleMsg = {
                     if (tokenizedStreamElementToReplace) {
                         $messageTemplate.insertBefore(tokenizedStreamElementToReplace);
                     } else {
-                        append
+                        const shouldOrderLiveWelcomeMessage =
+                            append && !msgThroughListAPI && msg.metadata?.WELCOME_EVENT;
+                        const $nextMessage = shouldOrderLiveWelcomeMessage
+                            ? $applozic('#mck-message-cell .mck-message-inner [name="message"]')
+                                  .filter(function () {
+                                      return (
+                                          Number($applozic(this).attr('data-msgtime')) >
+                                          Number(msg.createdAtTime)
+                                      );
+                                  })
+                                  .first()
+                            : null;
+
+                        const didInsertWelcomeMessageOutOfOrder =
+                            $nextMessage && $nextMessage.length;
+                        didInsertWelcomeMessageOutOfOrder
+                            ? $messageTemplate.insertBefore($nextMessage)
+                            : append
                             ? $messageTemplate.appendTo('#mck-message-cell .mck-message-inner')
                             : $messageTemplate.prependTo('#mck-message-cell .mck-message-inner');
+                        didInsertWelcomeMessageOutOfOrder && _this.messageClubbing(true, true);
                     }
                 }
                 if (!isUserMsg && !msgThroughListAPI) {
@@ -10621,7 +10639,7 @@ const firstVisibleMsg = {
                 }
             };
 
-            _this.messageClubbing = function (processAllMessages) {
+            _this.messageClubbing = function (processAllMessages, resetExistingClubbing) {
                 var allMessages = $applozic(
                     '#mck-message-cell .mck-message-inner div[name="message"]'
                 );
@@ -10640,6 +10658,8 @@ const firstVisibleMsg = {
                         allMessages[_len - 1].classList.add('km-clubbing-last');
                     }
                 } else {
+                    resetExistingClubbing &&
+                        allMessages.removeClass('km-clubbing-first km-clubbing-last');
                     $applozic.each(allMessages, function (key, value) {
                         var timeOffset =
                             allMessages[key].nextSibling &&


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Fix an issue where multi-part welcome messages sometimes appear out of order in the chat widget.
- Root cause: live socket messages can arrive out of order, while the widget always rendered them in arrival order.
- Change: welcome-event messages are now placed in the UI according to their createdAtTime, so the final welcome-message order remains correct.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [ ] I have tested it locally and all functionalities are working fine.
- [ ] I have compared it with mocks and all design elements are the same.
- [ ] I have tested it in IE Browser.

### How was the code tested?
<!-- Be as specific as possible. -->
-

### What new thing you came across while writing this code? 
-

### In case you fixed a bug then please describe the root cause of it? 
-

### Screenshot
- 

NOTE: Make sure you're comparing your branch with the correct base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live welcome messages now appear in the correct chronological position, even when received out of order.
  * Message grouping is automatically refreshed when a welcome message is inserted between existing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->