### PR TITLE
[TDH-3904] Support localized trigger buttons

### DIFF
--- a/webplugin/js/app/kommunicate-ui.js
+++ b/webplugin/js/app/kommunicate-ui.js
@@ -1553,16 +1553,59 @@ KommunicateUI = {
         }
     },
     loadQuickReplies: function (quickReplies) {
+        var getNormalizedLocale = function (locale) {
+            return locale && locale.toLowerCase().replace(/_/g, '-');
+        };
+        var getLocaleValue = function (value) {
+            if (!kommunicateCommons.isObject(value)) {
+                return value;
+            }
+            var getValueForLocale = function (locale) {
+                for (var key in value) {
+                    if (
+                        value.hasOwnProperty(key) &&
+                        getNormalizedLocale(key) === locale &&
+                        value[key]
+                    ) {
+                        return value[key];
+                    }
+                }
+            };
+            var locale =
+                getNormalizedLocale(kommunicate._globals.userLocale) ||
+                getNormalizedLocale(
+                    (navigator.languages && navigator.languages[0]) ||
+                        navigator.language ||
+                        navigator.userLanguage
+                );
+            var languageCode = locale && locale.split('-')[0];
+            return (
+                getValueForLocale(locale) ||
+                getValueForLocale(languageCode) ||
+                getValueForLocale('en') ||
+                value[Object.keys(value)[0]] ||
+                ''
+            );
+        };
         var intentList = document.getElementById('mck-intent-options');
         if (quickReplies.length > 0 && intentList && intentList.childElementCount < 1) {
             kommunicateCommons.show('#mck-quick-replies-box');
             for (var i = 0; i < quickReplies.length; i++) {
+                var quickReply = quickReplies[i];
+                var isQuickReplyObject = kommunicateCommons.isObject(quickReply);
+                var title = isQuickReplyObject
+                    ? getLocaleValue(quickReply.title || quickReply.name || quickReply.message)
+                    : quickReply;
+                var message = isQuickReplyObject
+                    ? getLocaleValue(quickReply.message || quickReply.title || quickReply.name)
+                    : quickReply;
                 var li = document.createElement('li');
-                li.innerText = quickReplies[i];
+                li.innerText = title;
+                li.dataset.reply = message;
                 intentList.appendChild(li);
                 li.onclick = function (e) {
                     e.preventDefault();
-                    document.getElementById('mck-text-box').innerText = this.innerText;
+                    document.getElementById('mck-text-box').innerText = this.dataset.reply;
                     document.getElementById('mck-msg-sbmt').click();
                 };
             }


### PR DESCRIPTION
## Jira
- [TDH-3904](https://kommunicate.atlassian.net/browse/TDH-3904)

## Summary
- Extend startup trigger buttons (`kommunicateSettings.quickReplies`) so object entries can provide localized `title`, `name`, or `message` values.
- Resolve locale-map values from `userLocale`, then browser locale, then `en`, with fallback to the first configured locale value.
- Keep existing string trigger buttons and click submission behavior unchanged for backward compatibility.

## Example
```js
quickReplies: [
  {
    title: {
      en: "Speak with an Agent",
      hi: "एजेंट से बात करें"
    },
    message: "Speak with an Agent"
  },
  {
    title: {
      en: "Book a Demo",
      hi: "डेमो बुक करें"
    },
    message: "Book a Demo"
  }
]
```

## Root Cause
Trigger buttons are configured through `quickReplies`, but the startup renderer treated every item as a plain string. Random customer training phrases cannot be localized through static SDK labels, so trigger buttons need to accept localized values directly in their configuration.

## Validation
- `node --check webplugin/js/app/kommunicate-ui.js`
- `git diff --check`
- Static diff check: PR contains only `webplugin/js/app/kommunicate-ui.js`

[TDH-3904]: https://kommunicate.atlassian.net/browse/TDH-3904